### PR TITLE
Add tests to Konflux CI

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,7 @@
+# References:
+# https://docs.snyk.io/scan-applications/snyk-code/using-snyk-code-from-the-cli/excluding-directories-and-files-from-the-snyk-code-cli-test
+# https://docs.snyk.io/snyk-cli/commands/ignore
+exclude:
+  global:
+    - vendor/**
+    - "**/*_test.go"

--- a/.tekton/operator-pull-request.yaml
+++ b/.tekton/operator-pull-request.yaml
@@ -7,6 +7,7 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/task: "[.tekton/operator-unit-test.yaml]"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
       == "main"
   creationTimestamp: null
@@ -105,10 +106,10 @@ spec:
       name: prefetch-input
       type: string
     - default: "false"
-      description: Java build
-      name: java
+      description: Skip unit testing
+      name: skip-unit-test
       type: string
-    - default: ""
+    - default: "1d"
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
@@ -129,9 +130,6 @@ spec:
     - description: ""
       name: CHAINS-GIT_COMMIT
       value: $(tasks.clone-repository.results.commit)
-    - description: ""
-      name: JAVA_COMMUNITY_DEPENDENCIES
-      value: $(tasks.build-container.results.JAVA_COMMUNITY_DEPENDENCIES)
     tasks:
     - name: init
       params:
@@ -200,6 +198,20 @@ spec:
       workspaces:
       - name: source
         workspace: workspace
+    - name: unit-test
+      runAfter:
+        - prefetch-dependencies
+      taskRef:
+        name: unit-test
+      when:
+        - input: $(params.skip-unit-test)
+          operator: in
+          values:
+            - "false"
+      workspaces:
+        - name: source
+          subPath: source
+          workspace: workspace
     - name: build-container
       params:
       - name: IMAGE
@@ -217,7 +229,7 @@ spec:
       - name: COMMIT_SHA
         value: $(tasks.clone-repository.results.commit)
       runAfter:
-      - prefetch-dependencies
+      - unit-test
       taskRef:
         params:
         - name: name

--- a/.tekton/operator-push.yaml
+++ b/.tekton/operator-push.yaml
@@ -6,6 +6,7 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/task: "[.tekton/operator-unit-test.yaml]"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
       == "main"
   creationTimestamp: null
@@ -102,14 +103,14 @@ spec:
       name: prefetch-input
       type: string
     - default: "false"
-      description: Java build
-      name: java
+      description: Skip unit testing
+      name: skip-unit-test
       type: string
     - default: ""
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
-    - default: "false"
+    - default: "true"
       description: Build a source image.
       name: build-source-image
       type: string
@@ -126,9 +127,6 @@ spec:
     - description: ""
       name: CHAINS-GIT_COMMIT
       value: $(tasks.clone-repository.results.commit)
-    - description: ""
-      name: JAVA_COMMUNITY_DEPENDENCIES
-      value: $(tasks.build-container.results.JAVA_COMMUNITY_DEPENDENCIES)
     tasks:
     - name: init
       params:
@@ -197,6 +195,20 @@ spec:
       workspaces:
       - name: source
         workspace: workspace
+    - name: unit-test
+      runAfter:
+        - prefetch-dependencies
+      taskRef:
+        name: unit-test
+      when:
+        - input: $(params.skip-unit-test)
+          operator: in
+          values:
+            - "false"
+      workspaces:
+        - name: source
+          subPath: source
+          workspace: workspace
     - name: build-container
       params:
       - name: IMAGE
@@ -214,7 +226,7 @@ spec:
       - name: COMMIT_SHA
         value: $(tasks.clone-repository.results.commit)
       runAfter:
-      - prefetch-dependencies
+      - unit-test
       taskRef:
         params:
         - name: name

--- a/.tekton/operator-unit-test.yaml
+++ b/.tekton/operator-unit-test.yaml
@@ -1,0 +1,51 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: unit-test
+spec:
+  description: Runs unit test for OpenShift Builds Operator.
+  params:
+    - default: -race -cover -v
+      description: Flags to use for the test command
+      name: GO_TEST_FLAGS
+    - default: linux
+      description: Operating system to use for testing
+      name: GOOS
+    - default: amd64
+      description: System architecture to use for testing
+      name: GOARCH
+    - default: auto
+      description: Go module support
+      name: GO111MODULE
+    - default: ""
+      description: Go caching directory path
+      name: GOCACHE
+    - default: ""
+      description: Go mod caching directory path
+      name: GOMODCACHE
+  steps:
+    - name: run-test
+      image: docker.io/library/golang:1.22
+      env:
+        - name: GOOS
+          value: $(params.GOOS)
+        - name: GOARCH
+          value: $(params.GOARCH)
+        - name: GO_TEST_FLAGS
+          value: $(params.GO_TEST_FLAGS)
+        - name: GO111MODULE
+          value: $(params.GO111MODULE)
+        - name: GOCACHE
+          value: $(params.GOCACHE)
+        - name: GOMODCACHE
+          value: $(params.GOMODCACHE)
+      resources: {}
+      script: |
+        #!/usr/bin/env bash
+        set -eux
+        git config --global --add safe.directory $(workspaces.source.path)
+        make test
+      workingDir: $(workspaces.source.path)
+  workspaces:
+    - name: source
+      description: Mount the source code directory

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,9 +23,9 @@ COPY internal/controller/ internal/controller/
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager cmd/main.go
 
-# Use distroless as minimal base image to package the manager binary
-# Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/static:nonroot
+# Use Red Hat Universal Base Image to package the manager binary
+# Refer to https://catalog.redhat.com/software/containers/ubi9/ubi-micro/615bdf943f6014fa45ae1b58
+FROM registry.access.redhat.com/ubi9/ubi-micro@sha256:8e33df2832f039b4b1adc53efd783f9404449994b46ae321ee4a0bf4499d5c42
 WORKDIR /
 COPY --from=builder /workspace/manager .
 USER 65532:65532

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ endif
 # Be aware that the target commands are only tested with Docker which is
 # scaffolded by default. However, you might want to replace it to use other
 # tools. (i.e. podman)
-CONTAINER_TOOL ?= docker
+CONTAINER_TOOL ?= podman
 
 # Setting SHELL to bash allows bash commands to be executed by recipes.
 # Options are set to exit when a recipe line exits non-zero or a piped command fails.
@@ -121,7 +121,7 @@ test-e2e:
 	go test ./test/e2e/ -v -ginkgo.v
 	
 GOLANGCI_LINT = $(shell pwd)/bin/golangci-lint
-GOLANGCI_LINT_VERSION ?= v1.54.2
+GOLANGCI_LINT_VERSION ?= v1.57.2
 golangci-lint:
 	@[ -f $(GOLANGCI_LINT) ] || { \
 	set -e ;\

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,2 +1,8 @@
 resources:
 - manager.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+images:
+- name: controller
+  newName: quay.io/redhat-openshift-builds/operator
+  newTag: v0.0.1

--- a/internal/controller/openshiftbuild_controller.go
+++ b/internal/controller/openshiftbuild_controller.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+
 	"k8s.io/apimachinery/pkg/api/errors"
 
 	"k8s.io/apimachinery/pkg/runtime"

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -59,24 +59,25 @@ var _ = Describe("controller", Ordered, func() {
 			var controllerPodName string
 			var err error
 
-			// projectimage stores the name of the image used in the example
-			var projectimage = "example.com/operator:v0.0.1"
+			// projectImage stores the name of the image used in the example
+			var projectImage = "quay.io/redhat-openshift-builds/operator:v0.0.1"
 
 			By("building the manager(Operator) image")
-			cmd := exec.Command("make", "docker-build", fmt.Sprintf("IMG=%s", projectimage))
+			cmd := exec.Command("make", "docker-build", fmt.Sprintf("IMG=%s", projectImage))
 			_, err = utils.Run(cmd)
 			ExpectWithOffset(1, err).NotTo(HaveOccurred())
 
 			By("loading the the manager(Operator) image on Kind")
-			err = utils.LoadImageToKindClusterWithName(projectimage)
+			err = utils.LoadImageToKindClusterWithName(projectImage)
 			ExpectWithOffset(1, err).NotTo(HaveOccurred())
 
 			By("installing CRDs")
 			cmd = exec.Command("make", "install")
 			_, err = utils.Run(cmd)
+			ExpectWithOffset(1, err).NotTo(HaveOccurred())
 
 			By("deploying the controller-manager")
-			cmd = exec.Command("make", "deploy", fmt.Sprintf("IMG=%s", projectimage))
+			cmd = exec.Command("make", "deploy", fmt.Sprintf("IMG=%s", projectImage))
 			_, err = utils.Run(cmd)
 			ExpectWithOffset(1, err).NotTo(HaveOccurred())
 


### PR DESCRIPTION
This PR adds/enables the following in Konflux CI:
- Add unit test task to pipeline
- Enable source image build
- Snyk ignore file

This PR also updates golangci-lint version and fixes lint issues.