### PR TITLE
Fix golangci-lint errors

### DIFF
--- a/internal/controller/openshiftbuild_controller.go
+++ b/internal/controller/openshiftbuild_controller.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+
 	"k8s.io/apimachinery/pkg/api/errors"
 
 	"k8s.io/apimachinery/pkg/runtime"


### PR DESCRIPTION
Fix `golangci-lint` errors which is failing `make test`.