### PR TITLE
fix: Boostrap OpenShiftBuild Object

### DIFF
--- a/internal/common/constants.go
+++ b/internal/common/constants.go
@@ -11,7 +11,7 @@ const (
 const (
 	OpenShiftBuildFinalizerName = "operator.openshift.io/openshiftbuilds"
 	OpenShiftBuildCRDName       = "openshiftbuilds.operator.openshift.io"
-	OpenShiftBuildResourceName  = "openshiftbuild"
+	OpenShiftBuildResourceName  = "cluster"
 	OpenShiftBuildNamespaceName = "openshift-builds"
 )
 

--- a/internal/controller/openshiftbuild_controller_test.go
+++ b/internal/controller/openshiftbuild_controller_test.go
@@ -25,6 +25,7 @@ import (
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -32,9 +33,24 @@ import (
 	operatorv1alpha1 "github.com/redhat-openshift-builds/operator/api/v1alpha1"
 )
 
+const finalizerName = common.OpenShiftBuildFinalizerName
+
 var _ = Describe("OpenShiftBuild Controller", func() {
-	Context("When reconciling a resource", func() {
-		ctx := context.Background()
+
+	var (
+		reconciler *OpenShiftBuildReconciler
+		ctx        context.Context
+	)
+
+	BeforeEach(func() {
+		reconciler = &OpenShiftBuildReconciler{
+			Client: k8sClient,
+			Scheme: k8sClient.Scheme(),
+		}
+		ctx = context.Background()
+	})
+
+	When("reconciling an OpenShiftBuild resource", func() {
 
 		namespacedName := types.NamespacedName{
 			Name: common.OpenShiftBuildResourceName,
@@ -68,17 +84,16 @@ var _ = Describe("OpenShiftBuild Controller", func() {
 			// TODO(user): Cleanup logic after each test, like removing the resource instance.
 			resource := &operatorv1alpha1.OpenShiftBuild{}
 			err := k8sClient.Get(ctx, namespacedName, resource)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred(), "get OpenShiftBuild resource")
 
-			By("Cleanup the specific resource instance OpenShiftBuild")
-			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+			controllerutil.RemoveFinalizer(resource, finalizerName)
+			Expect(k8sClient.Update(ctx, resource)).To(Succeed(), "remove finalizer from OpenShiftBuild resource")
+
+			err = k8sClient.Delete(ctx, resource)
+			Expect(err).NotTo(HaveOccurred(), "delete OpenShiftBuild resource")
 		})
 		It("should successfully reconcile the resource", func() {
 			By("Reconciling the created resource")
-			reconciler := &OpenShiftBuildReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
-			}
 
 			_, err := reconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: namespacedName,
@@ -88,4 +103,63 @@ var _ = Describe("OpenShiftBuild Controller", func() {
 			// Example: If you expect a certain status condition after reconciliation, verify it here.
 		})
 	})
+
+	When("bootstrapping the OpenShiftBuild resource", func() {
+
+		AfterEach(func() {
+			// Cleanup the created OpenShiftBuild resource
+			obj := &operatorv1alpha1.OpenShiftBuild{}
+			err := k8sClient.Get(ctx, types.NamespacedName{Name: common.OpenShiftBuildResourceName}, obj)
+			Expect(err).NotTo(HaveOccurred(), "get created OpenShiftBuild resource")
+
+			controllerutil.RemoveFinalizer(obj, finalizerName)
+			err = k8sClient.Update(ctx, obj)
+			Expect(err).NotTo(HaveOccurred(), "remove finalizer from OpenShiftBuild resource")
+
+			err = k8sClient.Delete(ctx, obj)
+			Expect(err).NotTo(HaveOccurred(), "delete OpenShiftBuild resource")
+		})
+
+		It("should create the OpenShiftBuild resource if not present", func() {
+			err := reconciler.BootstrapOpenShiftBuild(ctx, k8sClient)
+			Expect(err).NotTo(HaveOccurred(), "boostrap OpenShiftBuild resource")
+
+			resultObj := &operatorv1alpha1.OpenShiftBuild{}
+			err = k8sClient.Get(ctx, types.NamespacedName{Name: common.OpenShiftBuildResourceName}, resultObj)
+			Expect(err).NotTo(HaveOccurred(), "get created OpenShiftBuild object")
+			validateDefaults(resultObj)
+		})
+
+		It("should set required fields with default values", func() {
+			// Create empty spec object
+			buildObj := &operatorv1alpha1.OpenShiftBuild{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: common.OpenShiftBuildResourceName,
+				},
+				Spec: operatorv1alpha1.OpenShiftBuildSpec{},
+			}
+			err := k8sClient.Create(ctx, buildObj)
+			Expect(err).NotTo(HaveOccurred(), "create empty OpenShiftBuild resource")
+
+			err = reconciler.BootstrapOpenShiftBuild(ctx, k8sClient)
+			Expect(err).NotTo(HaveOccurred(), "boostrap OpenShiftBuild resource")
+
+			// Re-fetch object to get updated values
+			resultObj := &operatorv1alpha1.OpenShiftBuild{}
+			err = k8sClient.Get(ctx, types.NamespacedName{Name: common.OpenShiftBuildResourceName}, resultObj)
+			Expect(err).NotTo(HaveOccurred(), "get updated OpenShiftBuild object")
+			validateDefaults(resultObj)
+		})
+
+	})
 })
+
+func validateDefaults(obj *operatorv1alpha1.OpenShiftBuild) {
+	Expect(obj.Spec.Shipwright).NotTo(BeNil())
+	Expect(obj.Spec.Shipwright.Build).NotTo(BeNil())
+	Expect(obj.Spec.Shipwright.Build.State).To(Equal(operatorv1alpha1.Enabled))
+	Expect(controllerutil.ContainsFinalizer(obj, common.OpenShiftBuildFinalizerName)).To(BeTrue(), "checking for finalizer %q", common.OpenShiftBuildFinalizerName)
+
+	Expect(obj.Spec.SharedResource).NotTo(BeNil())
+	Expect(obj.Spec.SharedResource.State).To(Equal(operatorv1alpha1.Enabled))
+}


### PR DESCRIPTION
- Move bootstrap logic outside of `SetupWithManager`, run before controllers start instead.
- Change singleton OpenShiftBuild name to `cluster`.
- Update tests to remove OpenShiftBuild finalizers prior to deletion.