### PR TITLE
BUILD-920: change default installation namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,18 @@
-# operator
+# OpenShift Builds Operator
+
 OpenShift Builds operator provides the API to manage Shipwright Build and Shared Resource CSI Driver.
 
 ## Description
+
 OpenShift Builds operator deploys and manages the following components
+
 - Shipwright Components (pending implementation)
 - Shared Resource CSI Driver (pending implementation)
 
 ## Getting Started
 
 ### Prerequisites
+
 - go version v1.20.0+
 - docker version 17.03+.
 - kubectl version v1.11.3+.
@@ -22,21 +26,22 @@ Use the IMAGE_TAG_BASE variable to change the operator image's target repostiory
 This should be a proper image name and not end with trailing slashes or special characters.
 
 ```sh
-$ make docker-build docker-push IMAGE_TAG_BASE=quay.io/myusername/rh-openshift-builds/operator
+make docker-build docker-push IMAGE_TAG_BASE=quay.io/myusername/rh-openshift-builds/operator
 ```
 
 **NOTE:** You must have permission to push to the container registry referenced in `IMAGE_TAG_BASE`.
 Your cluster must also have permission to pull images from the referenced container registry.
 
-#### Step 2: Deploy CRDs and Operator**Install the CRDs into the cluster:**
+#### Step 2: Deploy CRDs and Operator **Install the CRDs into the cluster:**
 
 For this step, you must have the equivalent of "cluster admin" privileges on the cluster.
 
 First, deploy custom resource definitions (CRDs) for the operator by running:
 
 ```sh
-$ make install
+make install
 ```
+
 Next, deploy the operator using the same `IMAGE_TAG_BASE` variable as above.
 
 ```sh
@@ -44,6 +49,7 @@ make deploy IMAGE_TAG_BASE=quay.io/myusername/rh-openshift-builds/operator
 ```
 
 ### To Uninstall
+
 **Delete the instances (CRs) from the cluster:**
 
 ```sh
@@ -67,33 +73,42 @@ make undeploy
 Red Hat operators are designed to be managed by Operator Lifecycle Manager (OLM) and deployed
 through the `OperatorHub` section of the OpenShift web console. To deploy with OpenShift and OLM:
 
+> [!TIP]
+> You can combine all or multiple `make` commands in one single command if you don't have anything to modify in between the steps.
+>
+> ```sh
+> make docker-build docker-push bundle bundle-build bundle-push catalog-fbc-build catalog-push catalog-deploy IMAGE_TAG_BASE=quay.io/musername/rh-openshift-builds/operator
+> ```
+
 1. Build your operator and push it to a container registry (step 1 above).
 2. Build the operator bundle and push it to a container registry, by running the following `make
    commands:
 
    ```sh
-   $ make bundle IMAGE_TAG_BASE=quay.io/myusername/rh-openshift-builds/operator
-   $ make bundle-build bundle-push IMAGE_TAG_BASE=quay.io/myusername/rh-openshift-builds/operator
+   make bundle IMAGE_TAG_BASE=quay.io/myusername/rh-openshift-builds/operator
+   make bundle-build bundle-push IMAGE_TAG_BASE=quay.io/myusername/rh-openshift-builds/operator
    ```
 
 3. Build and push the operator catalog
 
    ```sh
-   $ make catalog-fbc-build IMAGE_TAG_BASE=quay.io/myusername/rh-openshift-builds/operator
-   $ make catalog-push IMAGE_TAG_BASE=quay.io/myusername/rh-openshift-builds/operator
+   make catalog-fbc-build IMAGE_TAG_BASE=quay.io/myusername/rh-openshift-builds/operator
+   make catalog-push IMAGE_TAG_BASE=quay.io/myusername/rh-openshift-builds/operator
    ```
 
 4. Deploy the catalog as a `CatalogSource`
 
    ```sh
-   $ make catalog-deploy IMAGE_TAG_BASE=quay.io/myusername/rh-openshift-builds/operator
+   make catalog-deploy IMAGE_TAG_BASE=quay.io/myusername/rh-openshift-builds/operator
    ```
 
 5. In the OpenShift web console, navigate to "OperatorHub" in the Administrator view. You should be
    able to filter for operators in the "Test Candidate Operators" catalog and install the Builds for OpenShift operator from there.
 
+6. By default the Openshift Builds Operator and its operands will get installed in the `openshift-builds` namespace.
 
 ## Contributing
+
 TBD
 
 **NOTE:** Run `make help` for more information on all potential `make` targets

--- a/bundle/manifests/openshift-builds-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/openshift-builds-operator.clusterserviceversion.yaml
@@ -47,6 +47,7 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "false"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
+    operatorframework.io/suggested-namespace: openshift-builds
     operators.openshift.io/valid-subscription: '["OpenShift Container Platform", "OpenShift
       Platform Plus"]'
     operators.operatorframework.io/builder: operator-sdk-v1.35.0

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -28,6 +28,7 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
 	operatorv1alpha1 "github.com/redhat-openshift-builds/operator/api/v1alpha1"
+	"github.com/redhat-openshift-builds/operator/internal/common"
 	"github.com/redhat-openshift-builds/operator/internal/controller"
 	shipwrightbuild "github.com/redhat-openshift-builds/operator/internal/shipwright/build"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -109,11 +110,14 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Fetch the namespace and store for later use
+	namespace := common.FetchCurrentNamespaceName()
+
 	// Run OpenshiftBuild controller
 	buildReconciler := &controller.OpenShiftBuildReconciler{
 		Client:     mgr.GetClient(),
 		Scheme:     mgr.GetScheme(),
-		Shipwright: shipwrightbuild.New(mgr.GetClient()),
+		Shipwright: shipwrightbuild.New(mgr.GetClient(), namespace),
 	}
 
 	if err := buildReconciler.SetupWithManager(mgr); err != nil {

--- a/config/manifests/bases/openshift-builds-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/openshift-builds-operator.clusterserviceversion.yaml
@@ -17,6 +17,7 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "false"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
+    operatorframework.io/suggested-namespace: openshift-builds
     operators.openshift.io/valid-subscription: '["OpenShift Container Platform", "OpenShift
       Platform Plus"]'
     repository: https://github.com/shipwright-io/operator

--- a/internal/common/constants.go
+++ b/internal/common/constants.go
@@ -8,7 +8,7 @@ const (
 	OpenShiftBuildFinalizerName = "operator.openshift.io/openshiftbuilds"
 	OpenShiftBuildCRDName       = "openshiftbuilds.operator.openshift.io"
 	OpenShiftBuildResourceName  = "cluster"
-	OpenShiftBuildNamespaceName = "openshift-builds"
+	OpenShiftBuilNamespaceName  = "openshift-builds"
 )
 
 const (
@@ -20,4 +20,5 @@ const (
 var (
 	ShipwrightBuildManifestPath         = filepath.Join("config", "shipwright", "build", "release")
 	ShipwrightBuildStrategyManifestPath = filepath.Join("config", "shipwright", "build", "strategy")
+	CurrentNamespaceName                string
 )

--- a/internal/common/predicate.go
+++ b/internal/common/predicate.go
@@ -1,6 +1,8 @@
 package common
 
 import (
+	"os"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -11,4 +13,17 @@ func IsControlledBy(object client.Object, owner *metav1.OwnerReference) bool {
 	return controller != nil && *controller.Controller &&
 		controller.APIVersion == owner.APIVersion &&
 		controller.Kind == owner.Kind
+}
+
+// FetchCurrentNamespaceName returns namespace name by using information stored as file
+// Returns default Openshift Builds namespace on error
+// Refer: https://kubernetes.io/docs/tasks/run-application/access-api-from-pod/#without-using-a-proxy
+func FetchCurrentNamespaceName() string {
+	namespace, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
+	if err != nil {
+		CurrentNamespaceName = OpenShiftBuilNamespaceName
+	} else {
+		CurrentNamespaceName = string(namespace)
+	}
+	return CurrentNamespaceName
 }

--- a/internal/controller/openshiftbuild_controller_test.go
+++ b/internal/controller/openshiftbuild_controller_test.go
@@ -42,14 +42,16 @@ var _ = Describe("OpenShiftBuild Controller", Label("controller", "openshiftbuil
 	var (
 		reconciler *OpenShiftBuildReconciler
 		ctx        context.Context
+		namespace  string
 	)
 
 	BeforeEach(func() {
+		namespace = common.OpenShiftBuilNamespaceName
 		reconciler = &OpenShiftBuildReconciler{
 			APIReader:  k8sClient,
 			Client:     k8sClient,
 			Scheme:     k8sClient.Scheme(),
-			Shipwright: shipwrightbuild.New(k8sClient),
+			Shipwright: shipwrightbuild.New(k8sClient, namespace),
 		}
 		ctx = context.Background()
 	})

--- a/internal/shipwright/build/build.go
+++ b/internal/shipwright/build/build.go
@@ -15,13 +15,15 @@ import (
 
 // ShipwrightBuild type defines methods to Get, Create, Delete v1alpha1.ShipwrightBuild resource
 type ShipwrightBuild struct {
-	Client client.Client
+	Client    client.Client
+	Namespace string
 }
 
 // New creates new instance of ShipwrightBuild type
-func New(client client.Client) *ShipwrightBuild {
+func New(client client.Client, namespace string) *ShipwrightBuild {
 	return &ShipwrightBuild{
-		Client: client,
+		Client:    client,
+		Namespace: namespace,
 	}
 }
 
@@ -68,7 +70,7 @@ func (sb *ShipwrightBuild) CreateOrUpdate(ctx context.Context, owner client.Obje
 
 	return ctrl.CreateOrUpdate(ctx, sb.Client, object, func() error {
 		object.Spec = shipwrightv1alpha1.ShipwrightBuildSpec{
-			TargetNamespace: common.OpenShiftBuildNamespaceName,
+			TargetNamespace: sb.Namespace,
 		}
 		controllerutil.AddFinalizer(object, common.OpenShiftBuildFinalizerName)
 		if err := ctrl.SetControllerReference(owner, object, sb.Client.Scheme()); err != nil {

--- a/internal/shipwright/build/build_test.go
+++ b/internal/shipwright/build/build_test.go
@@ -25,11 +25,13 @@ var _ = Describe("Build", Label("shipwright", "build"), func() {
 		shipwrightBuild *build.ShipwrightBuild
 		list            *shipwrightv1alpha1.ShipwrightBuildList
 		object          *shipwrightv1alpha1.ShipwrightBuild
+		namespace       string
 	)
 
 	BeforeEach(OncePerOrdered, func() {
 		ctx = context.Background()
-		shipwrightBuild = build.New(fake.NewClientBuilder().WithScheme(scheme).Build())
+		namespace = common.OpenShiftBuilNamespaceName
+		shipwrightBuild = build.New(fake.NewClientBuilder().WithScheme(scheme).Build(), namespace)
 	})
 
 	JustBeforeEach(OncePerOrdered, func() {
@@ -78,8 +80,8 @@ var _ = Describe("Build", Label("shipwright", "build"), func() {
 			It("should have the controller reference", func() {
 				Expect(metav1.IsControlledBy(object, owner)).To(BeTrue())
 			})
-			It("should have target namespace set to openshift build", func() {
-				Expect(object.Spec.TargetNamespace).To(Equal(common.OpenShiftBuildNamespaceName))
+			It("should have target namespace set to openshift builds", func() {
+				Expect(object.Spec.TargetNamespace).To(Equal(namespace))
 			})
 		})
 		When("there is an existing resource with same spec", Ordered, func() {
@@ -110,7 +112,7 @@ var _ = Describe("Build", Label("shipwright", "build"), func() {
 				Expect(result).To(Equal(controllerutil.OperationResultUpdated))
 			})
 			It("should update the specs to match expected", func() {
-				Expect(object.Spec.TargetNamespace).To(Equal(common.OpenShiftBuildNamespaceName))
+				Expect(object.Spec.TargetNamespace).To(Equal(namespace))
 			})
 		})
 	})


### PR DESCRIPTION
## Changes

- by default openshift-builds operator should install in its own namespace
  to enable independent upgrades from other operators
- user can still choose their own namespace while installing

Signed-off-by: Avinal Kumar <avinal@redhat.com>
