### PR TITLE
BUILD-993: Add Builds to Supported OCP Catalog Indexes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,10 @@ IMAGE_TAG_BASE ?= quay.io/redhat-user-workloads/rh-openshift-builds-tenant/opens
 BUNDLE_IMG ?= $(IMAGE_TAG_BASE)-bundle:v$(VERSION)
 
 # BUNDLE_GEN_FLAGS are the flags passed to the operator-sdk generate bundle command
-BUNDLE_GEN_FLAGS ?= -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)
+# Setting `--overwrite=false`, which unfortunately requires `bundle.Dockerfile` labels and
+# `annotations.yaml` data to be manually synced.
+# See https://github.com/operator-framework/operator-sdk/issues/6787
+BUNDLE_GEN_FLAGS ?= -q --overwrite=false --version $(VERSION) $(BUNDLE_METADATA_OPTS)
 
 # USE_IMAGE_DIGESTS defines if images are resolved via tags or digests
 # You can enable this value if you would like to use SHA Based Digests

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -15,6 +15,9 @@ LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v4
 LABEL operators.operatorframework.io.test.mediatype.v1=scorecard+v1
 LABEL operators.operatorframework.io.test.config.v1=tests/scorecard/
 
+# Labels for Red Hat Operators
+LABEL com.redhat.openshift.versions="v4.12-v4.17"
+
 # Copy files to locations specified by labels.
 COPY bundle/manifests /manifests/
 COPY bundle/metadata /metadata/

--- a/bundle/manifests/openshift-builds-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/openshift-builds-operator.clusterserviceversion.yaml
@@ -36,7 +36,7 @@ metadata:
     categories: Developer Tools, Integration & Delivery
     certified: "true"
     containerImage: quay.io/redhat-user-workloads/rh-openshift-builds-tenant/openshift-builds/openshift-builds-operator-rhel9
-    createdAt: "2024-07-18T06:21:29Z"
+    createdAt: "2024-07-23T14:24:57Z"
     description: Builds for Red Hat OpenShift is a framework for building container
       images on Kubernetes.
     features.operators.openshift.io/csi: "true"
@@ -765,7 +765,7 @@ spec:
                   value: quay.io/redhat-user-workloads/rh-openshift-builds-tenant/openshift-builds/openshift-builds-waiter@sha256:e04a0308814b77ce475112b3a2cc569488d005b673c95ba5c0f30ef06f7a59c3
                 - name: IMAGE_SHIPWRIGHT_SHP_BUILD_WEBHOOK
                   value: quay.io/redhat-user-workloads/rh-openshift-builds-tenant/openshift-builds/openshift-builds-webhook@sha256:3402ebfffa2e40df8547d715c352b1761dafabddb510f20c29bb6804d89ec51e
-                image: quay.io/redhat-user-workloads/rh-openshift-builds-tenant/openshift-builds/openshift-builds-operator@sha256:dba3f565217646704a66aa8de7c828fbf0e812ac60431b91706b6ba22137d558
+                image: quay.io/redhat-user-workloads/rh-openshift-builds-tenant/openshift-builds/openshift-builds-operator:4c95f2f44f98dc4bf4b2510904548f9e5b2192f5
                 imagePullPolicy: Always
                 livenessProbe:
                   httpGet:
@@ -847,14 +847,14 @@ spec:
   - cicd
   links:
   - name: Documentation
-    url: https://docs.openshift.com/builds/1.0/about/overview-openshift-builds.html
+    url: https://docs.openshift.com/builds/latest/about/overview-openshift-builds.html
   - name: Builds for Openshift
     url: https://github.com/redhat-openshift-builds/operator
   maintainers:
   - email: openshift-builds@redhat.com
     name: Red Hat OpenShift Builds Team
-  maturity: alpha
-  minKubeVersion: 1.24.0
+  maturity: stable
+  minKubeVersion: 1.25.0
   provider:
     name: Red Hat
     url: https://www.redhat.com

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -13,3 +13,6 @@ annotations:
   # Annotations for testing.
   operators.operatorframework.io.test.mediatype.v1: scorecard+v1
   operators.operatorframework.io.test.config.v1: tests/scorecard/
+
+  # Annotations for releasing Red Hat operators.
+  com.redhat.openshift.versions: "v4.12-v4.17"

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: operator
   newName: quay.io/redhat-user-workloads/rh-openshift-builds-tenant/openshift-builds/openshift-builds-operator
-  newTag: 2cfeec6d0fa3a41152c774f8a561e02597e6774d
+  newTag: 4c95f2f44f98dc4bf4b2510904548f9e5b2192f5

--- a/config/manifests/bases/openshift-builds-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/openshift-builds-operator.clusterserviceversion.yaml
@@ -26,7 +26,7 @@ metadata:
     operatorframework.io/arch.arm64: supported
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
-  name: openshift-builds-operator.v1.1.0
+  name: openshift-builds-operator.v0.0.0
   namespace: openshift-builds
 spec:
   apiservicedefinitions: {}
@@ -86,14 +86,14 @@ spec:
   - cicd
   links:
   - name: Documentation
-    url: https://docs.openshift.com/builds/1.0/about/overview-openshift-builds.html
+    url: https://docs.openshift.com/builds/latest/about/overview-openshift-builds.html
   - name: Builds for Openshift
     url: https://github.com/redhat-openshift-builds/operator
   maintainers:
   - email: openshift-builds@redhat.com
     name: Red Hat OpenShift Builds Team
-  maturity: alpha
-  minKubeVersion: 1.24.0
+  maturity: stable
+  minKubeVersion: 1.25.0
   provider:
     name: Red Hat
     url: https://www.redhat.com


### PR DESCRIPTION
This updates our bundle lables and annotations to specify the versions of OCP the operator can be deployed on (4.12-4.17). As part of this work, the operator CSV was updated to set the minimum k8s version to 1.25.0. A few minor fixes to CSV were also added.

Note that the labels on `bundle.Dockerfile` and the annotations in `bundle/manifests/metadata/annotations.yaml` need to be synced manually. This is due to a feature gap in operator-sdk's `generate bundle` command.