### PR TITLE
BUILD-1023: add required labels for enterprise contract

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,5 +42,6 @@ LABEL \
     summary="Red Hat OpenShift Builds Operator" \
     maintainer="openshift-builds@redhat.com" \
     description="Red Hat OpenShift Builds Operator" \
+    io.k8s.description="Red Hat OpenShift Builds Operator" \
     io.k8s.display-name="Red Hat OpenShift Builds Operator" \
     io.openshift.tags="builds,operator"


### PR DESCRIPTION
## Changes

- add missing label required for enterprise contract

Signed-off-by: Avinal Kumar <avinal@redhat.com>
