### PR TITLE
BUILD-997: Adds consoleYAMLSample manifests for builds sample in the operator bundle

### DIFF
--- a/bundle/manifests/openshift-builds-sample-buildah-build.yaml
+++ b/bundle/manifests/openshift-builds-sample-buildah-build.yaml
@@ -1,0 +1,30 @@
+apiVersion: console.openshift.io/v1
+kind: ConsoleYAMLSample
+metadata:
+  name: buildah-build
+spec:
+  description: A sample Build using buildah BuildStrategy
+  snippet: false
+  targetResource:
+    apiVersion: shipwright.io/v1beta1
+    kind: Build
+  title: Buildah Build
+  yaml: |
+    apiVersion: shipwright.io/v1beta1
+    kind: Build
+    metadata:
+      name: buildah-golang-build
+    spec:
+      source:
+        type: Git
+        git:
+          url: https://github.com/shipwright-io/sample-go
+        contextDir: docker-build
+      strategy:
+        name: buildah
+        kind: ClusterBuildStrategy
+      paramValues:
+      - name: dockerfile
+        value: Dockerfile
+      output:
+        image: image-registry.openshift-image-registry.svc:5000/namespace/sample-go-app

--- a/bundle/manifests/openshift-builds-sample-s2i-java-build.yaml
+++ b/bundle/manifests/openshift-builds-sample-s2i-java-build.yaml
@@ -1,0 +1,29 @@
+apiVersion: console.openshift.io/v1
+kind: ConsoleYAMLSample
+metadata:
+  name: source-to-image-java-build
+spec:
+  description: A sample Build using source-to-image BuildStrategy with java builder image
+  snippet: false
+  targetResource:
+    apiVersion: shipwright.io/v1beta1
+    kind: Build
+  title: Source-to-Image Java Build
+  yaml: |
+    apiVersion: shipwright.io/v1beta1
+    kind: Build
+    metadata:
+      name: s2i-java-build
+    spec:
+      source: 
+        type: Git
+        git:
+          url: https://github.com/monodot/simple-camel-spring-boot-app
+      strategy: 
+        name: source-to-image
+        kind: ClusterBuildStrategy
+      paramValues: 
+      - name: builder-image
+        value: quay.io/myriad/fabric8-s2i-java:latest-java11
+      output:
+        image: image-registry.openshift-image-registry.svc:5000/namespace/s2i-java-example

--- a/bundle/manifests/openshift-builds-sample-s2i-nodejs-build.yaml
+++ b/bundle/manifests/openshift-builds-sample-s2i-nodejs-build.yaml
@@ -1,0 +1,30 @@
+apiVersion: console.openshift.io/v1
+kind: ConsoleYAMLSample
+metadata:
+  name: source-to-image-nodejs-build
+spec:
+  description: A sample Build using source-to-image BuildStrategy with nodejs builder image
+  snippet: false
+  targetResource:
+    apiVersion: shipwright.io/v1beta1
+    kind: Build
+  title: Source-to-Image Nodejs Build
+  yaml: |
+    apiVersion: shipwright.io/v1beta1
+    kind: Build
+    metadata:
+      name: s2i-nodejs-build
+    spec:
+      source:
+        type: Git
+        git:
+          url: https://github.com/shipwright-io/sample-nodejs
+        contextDir: source-build/
+      strategy:
+        name: source-to-image
+        kind: ClusterBuildStrategy
+      paramValues:
+      - name: builder-image
+        value: quay.io/centos7/nodejs-12-centos7:master
+      output:
+        image: image-registry.openshift-image-registry.svc:5000/namespace/s2i-nodejs-example


### PR DESCRIPTION
This commit adds consoleYAMLSample manifests for following build scenarios:
- Build using `buildah` strategy for a go app.
- Build using `source-to-image` strategy with `nodejs` builder image.
- Build using `source-to-image` strategy with `java` builder image.