### PR TITLE
BUILD-1135: Defines volumes & volumeMounts in buildStrategy

### DIFF
--- a/config/shipwright/build/strategy/buildah.yaml
+++ b/config/shipwright/build/strategy/buildah.yaml
@@ -168,6 +168,9 @@ spec:
         - $(params.registries-insecure[*])
         - --registries-search
         - $(params.registries-search[*])
+      volumeMounts:
+      - mountPath: /etc/pki/entitlement
+        name: etc-pki-entitlement
       resources:
         limits:
           cpu: "1"
@@ -199,6 +202,10 @@ spec:
       type: string
       default: "vfs"
       # For details see the "--storage-driver" section of https://github.com/containers/buildah/blob/main/docs/buildah.1.md#options
+  volumes:
+  - name: etc-pki-entitlement
+    emptydir: {}
+    overridable: true
   securityContext:
     runAsUser: 0
     runAsGroup: 0

--- a/config/shipwright/build/strategy/source_to_image.yaml
+++ b/config/shipwright/build/strategy/source_to_image.yaml
@@ -7,6 +7,9 @@ spec:
   volumes:
     - name: s2i
       emptyDir: {}
+    - name: etc-pki-entitlement
+      emptyDir: {}
+      overridable: true
   buildSteps:
     - name: s2i-generate
       image: registry.redhat.io/source-to-image/source-to-image-rhel8:v1.3.9
@@ -22,6 +25,8 @@ spec:
       volumeMounts:
         - name: s2i
           mountPath: /s2i
+        - mountPath: /etc/pki/entitlement
+          name: etc-pki-entitlement
     - name: buildah
       image: registry.redhat.io/ubi8/buildah:8.8
       workingDir: /s2i
@@ -134,6 +139,8 @@ spec:
       volumeMounts:
         - name: s2i
           mountPath: /s2i
+        - mountPath: /etc/pki/entitlement
+          name: etc-pki-entitlement
   parameters:
     - name: registries-block
       description: The registries that need to block pull access.


### PR DESCRIPTION
This commit adds volume & volumeMount section to enabling sharing rhel-entitlement secret with buildah buildStrategy. 