### PR TITLE
migrate unit-test to use Konflux's Trusted-artifact pattern

### DIFF
--- a/.tekton/openshift-builds-operator-pull-request.yaml
+++ b/.tekton/openshift-builds-operator-pull-request.yaml
@@ -7,6 +7,7 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/task: "[.tekton/openshift-builds-operator-unit-test.yaml]"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "pull_request" &&
       target_branch == "main" &&
@@ -127,6 +128,10 @@ spec:
         set of values is determined by the configuration of the multi-platform-controller.
       name: build-platforms
       type: array
+    - default: "false"
+      description: Skip unit testing
+      name: skip-unit-test
+      type: string
     results:
     - description: ""
       name: IMAGE_URL
@@ -213,6 +218,19 @@ spec:
         workspace: git-auth
       - name: netrc
         workspace: netrc
+    - name: unit-test
+      params:
+      - name : SOURCE_ARTIFACT
+        value : $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      runAfter:
+      - prefetch-dependencies
+      taskRef:
+        name: unit-test
+      when:
+      - input: $(params.skip-unit-test)
+        operator: in
+        values:
+          - "false"
     - matrix:
         params:
         - name: PLATFORM
@@ -246,7 +264,7 @@ spec:
       - name: IMAGE_APPEND_PLATFORM
         value: "true"
       runAfter:
-      - prefetch-dependencies
+      - unit-test
       taskRef:
         params:
         - name: name

--- a/.tekton/openshift-builds-operator-push.yaml
+++ b/.tekton/openshift-builds-operator-push.yaml
@@ -6,6 +6,7 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/task: "[.tekton/openshift-builds-operator-unit-test.yaml]"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push" &&
       target_branch == "main" &&
@@ -214,6 +215,19 @@ spec:
         workspace: git-auth
       - name: netrc
         workspace: netrc
+    - name: unit-test
+      params:
+      - name : SOURCE_ARTIFACT
+        value : $(tasks.clone-repository.results.SOURCE_ARTIFACT)
+      runAfter:
+      - prefetch-dependencies
+      taskRef:
+        name: unit-test
+      when:
+      - input: $(params.skip-unit-test)
+        operator: in
+        values:
+          - "false"
     - matrix:
         params:
         - name: PLATFORM
@@ -247,7 +261,7 @@ spec:
       - name: IMAGE_APPEND_PLATFORM
         value: "true"
       runAfter:
-      - prefetch-dependencies
+      - unit-test
       taskRef:
         params:
         - name: name

--- a/.tekton/openshift-builds-operator-unit-test.yaml
+++ b/.tekton/openshift-builds-operator-unit-test.yaml
@@ -23,7 +23,24 @@ spec:
   - default: ""
     description: Go mod caching directory path
     name: GOMODCACHE
+  - description: The Trusted Artifact URI pointing to the artifact with the application source code.
+    name: SOURCE_ARTIFACT
+    type: string
+  stepTemplate:
+    volumeMounts:
+      - mountPath: /var/workdir
+        name: workdir
+        readOnly: false
+    # run as root to be able to do write operations in the run-test task
+    securityContext:
+      runAsUser: 0
   steps:
+  # step to fetch the Trusted Artifact and make it available to the next steps.
+  - name: use-trusted-artifact
+    image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:8391272c4e5011120e9e7fee2c1f339e9405366110bf239dadcbc21e953ce099
+    args:
+      - use
+      - $(params.SOURCE_ARTIFACT)=/var/workdir/source
   - name: run-test
     image: registry.access.redhat.com/ubi9/go-toolset:1.21.11-7@sha256:d128c3d36878251f039606f144ef2608746c3203708b722295e6c571df1d8613
     env:
@@ -39,13 +56,13 @@ spec:
       value: $(params.GOCACHE)
     - name: GOMODCACHE
       value: $(params.GOMODCACHE)
-    resources: {}
     script: |
       #!/usr/bin/env bash
       set -eux
-      git config --global --add safe.directory $(workspaces.source.path)
+      git config --global --add safe.directory "$(pwd)"
       make test
-    workingDir: $(workspaces.source.path)
-  workspaces:
-  - name: source
-    description: Mount the source code directory
+    workingDir: /var/workdir/source
+  volumes:
+    # volume to store a copy of the source code accessible only to this Task.
+    - name: workdir
+      emptyDir: {}


### PR DESCRIPTION
Konflux's Trusted Artifact pattern - https://konflux-ci.dev/docs/advanced-how-tos/using-trusted-artifacts/#migrate-to-trusted-artifacts