### PR TITLE
[BUILD-997] Adds Console Sample for a build that pushes to external registry

### DIFF
--- a/bundle/manifests/openshift-builds-sample-buildah-build.yaml
+++ b/bundle/manifests/openshift-builds-sample-buildah-build.yaml
@@ -18,8 +18,8 @@ spec:
       source:
         type: Git
         git:
-          url: https://github.com/shipwright-io/sample-go
-        contextDir: docker-build
+          url: https://github.com/redhat-openshift-builds/samples/
+        contextDir: buildah-build
       strategy:
         name: buildah
         kind: ClusterBuildStrategy
@@ -27,4 +27,6 @@ spec:
       - name: dockerfile
         value: Dockerfile
       output:
+        # The "namespace" in the image needs to be replaced with the namespace name where related build exists.
+        # If the following image value is passed as is, the pod will error out while pushing the image due to authentication failures.
         image: image-registry.openshift-image-registry.svc:5000/namespace/sample-go-app

--- a/bundle/manifests/openshift-builds-sample-buildah-external-registry.yaml
+++ b/bundle/manifests/openshift-builds-sample-buildah-external-registry.yaml
@@ -1,0 +1,34 @@
+apiVersion: console.openshift.io/v1
+kind: ConsoleYAMLSample
+metadata:
+  name: buildah-build-external-push
+spec:
+  description: A sample Build using buildah BuildStrategy that pushes the built image to an external registry
+  snippet: false
+  targetResource:
+    apiVersion: shipwright.io/v1beta1
+    kind: Build
+  title: Buildah Build External Push
+  yaml: |
+    apiVersion: shipwright.io/v1beta1
+    kind: Build
+    metadata:
+      name: buildah-golang-build-external-push
+    spec:
+      source:
+        type: Git
+        git:
+          url: https://github.com/shipwright-io/sample-go
+        contextDir: docker-build
+      strategy:
+        name: buildah
+        kind: ClusterBuildStrategy
+      paramValues:
+      - name: dockerfile
+        value: Dockerfile
+      output:
+        # For a successful image push, a pushSecret with relevant credentials must be available in the same namespace as builds.
+        # Detailed steps are available at: https://docs.openshift.com/builds/1.1/authenticating/understanding-authentication-at-runtime.html#ob-authentication-to-container-registries_understanding-authentication-at-runtime
+        pushSecret: secretName
+        # The "quayRepo" in the image needs to be replaced with a valid Quay.io organization or Quay username.
+        image: quay.io/quayRepo/sample-go-app

--- a/bundle/manifests/openshift-builds-sample-buildah-external-registry.yaml
+++ b/bundle/manifests/openshift-builds-sample-buildah-external-registry.yaml
@@ -18,8 +18,8 @@ spec:
       source:
         type: Git
         git:
-          url: https://github.com/shipwright-io/sample-go
-        contextDir: docker-build
+          url: https://github.com/redhat-openshift-builds/samples/
+        contextDir: buildah-build
       strategy:
         name: buildah
         kind: ClusterBuildStrategy
@@ -28,7 +28,7 @@ spec:
         value: Dockerfile
       output:
         # For a successful image push, a pushSecret with relevant credentials must be available in the same namespace as builds.
-        # Detailed steps are available at: https://docs.openshift.com/builds/1.1/authenticating/understanding-authentication-at-runtime.html#ob-authentication-to-container-registries_understanding-authentication-at-runtime
+        # Detailed steps are available at: https://docs.redhat.com/en/documentation/builds_for_red_hat_openshift/1.1/html-single/authentication/index?extIdCarryOver=true&sc_cid=701f2000001Css5AAC#ob-authentication-to-container-registries_understanding-authentication-at-runtime
         pushSecret: secretName
         # The "quayRepo" in the image needs to be replaced with a valid Quay.io organization or Quay username.
         image: quay.io/quayRepo/sample-go-app

--- a/bundle/manifests/openshift-builds-sample-s2i-java-build.yaml
+++ b/bundle/manifests/openshift-builds-sample-s2i-java-build.yaml
@@ -18,12 +18,15 @@ spec:
       source: 
         type: Git
         git:
-          url: https://github.com/monodot/simple-camel-spring-boot-app
+          url: https://github.com/redhat-openshift-builds/samples/
+        contextDir: s2i-build/java
       strategy: 
         name: source-to-image
         kind: ClusterBuildStrategy
       paramValues: 
       - name: builder-image
-        value: quay.io/myriad/fabric8-s2i-java:latest-java11
+        value: registry.access.redhat.com/ubi9/openjdk-11
       output:
+        # The "namespace" in the image needs to be replaced with the namespace name where related build exists.
+        # If the following image value is passed as is, the pod will error out while pushing the image due to authentication failures.
         image: image-registry.openshift-image-registry.svc:5000/namespace/s2i-java-example

--- a/bundle/manifests/openshift-builds-sample-s2i-nodejs-build.yaml
+++ b/bundle/manifests/openshift-builds-sample-s2i-nodejs-build.yaml
@@ -18,8 +18,8 @@ spec:
       source:
         type: Git
         git:
-          url: https://github.com/shipwright-io/sample-nodejs
-        contextDir: source-build/
+          url: https://github.com/redhat-openshift-builds/samples/
+        contextDir: s2i-build/nodejs
       strategy:
         name: source-to-image
         kind: ClusterBuildStrategy
@@ -27,4 +27,6 @@ spec:
       - name: builder-image
         value: quay.io/centos7/nodejs-12-centos7:master
       output:
+        # The "namespace" in the image needs to be replaced with the namespace name where related build exists.
+        # If the following image value is passed as is, the pod will error out while pushing the image due to authentication failures.
         image: image-registry.openshift-image-registry.svc:5000/namespace/s2i-nodejs-example


### PR DESCRIPTION
This is an extension to #100.
- Adds a sample example for build pushing to external registry.
- Adds informative comments for references in all the builds. (At present, those comments are ignored when the sample yaml loads while creation of the instance. Checking with console team if this could be corrected with the upcoming versions). 