### PR TITLE
Boostrap OperatorHub e2e Test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,8 +131,8 @@ vet: ## Run go vet against code.
 test: manifests generate fmt vet envtest ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test $$(go list ./... | grep -v /e2e) -coverprofile cover.out
 
-# Utilize Kind or modify the e2e tests to load the image locally, enabling compatibility with other vendors.
-.PHONY: test-e2e  # Run the e2e tests against a Kind k8s instance that is spun up.
+# e2e tests must run against an OpenShift Cluster.
+.PHONY: test-e2e  # Run the e2e tests against an OpenShift cluster
 test-e2e:
 	go test ./test/e2e/ -v -ginkgo.v
 	

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	k8s.io/client-go v1.5.2
 	k8s.io/utils v0.0.0-20240502163921-fe8a2dddb1d0
 	sigs.k8s.io/controller-runtime v0.17.4
+	sigs.k8s.io/yaml v1.4.0
 )
 
 require (
@@ -97,7 +98,6 @@ require (
 	knative.dev/pkg v0.0.0-20240404013351-5d4af76051e4 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
-	sigs.k8s.io/yaml v1.4.0 // indirect
 )
 
 replace k8s.io/client-go => k8s.io/client-go v0.29.7

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -17,106 +17,54 @@ limitations under the License.
 package e2e
 
 import (
-	"fmt"
-	"os/exec"
+	"context"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/redhat-openshift-builds/operator/test/utils"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-const namespace = "operator-system"
-
-var _ = Describe("controller", Label("e2e"), Ordered, func() {
-	BeforeAll(func() {
-		By("installing prometheus operator")
-		Expect(utils.InstallPrometheusOperator()).To(Succeed())
-
-		By("installing the cert-manager")
-		Expect(utils.InstallCertManager()).To(Succeed())
-
-		By("creating manager namespace")
-		cmd := exec.Command("kubectl", "create", "ns", namespace)
-		_, _ = utils.Run(cmd)
-	})
-
-	AfterAll(func() {
-		By("uninstalling the Prometheus manager bundle")
-		utils.UninstallPrometheusOperator()
-
-		By("uninstalling the cert-manager bundle")
-		utils.UninstallCertManager()
-
-		By("removing manager namespace")
-		cmd := exec.Command("kubectl", "delete", "ns", namespace)
-		_, _ = utils.Run(cmd)
-	})
-
-	Context("Operator", func() {
-		It("should run successfully", func() {
-			var controllerPodName string
-			var err error
-
-			// projectImage stores the name of the image used in the example
-			var projectImage = "quay.io/redhat-openshift-builds/operator:v0.0.1"
-
-			By("building the manager(Operator) image")
-			cmd := exec.Command("make", "docker-build", fmt.Sprintf("IMG=%s", projectImage))
-			_, err = utils.Run(cmd)
-			ExpectWithOffset(1, err).NotTo(HaveOccurred())
-
-			By("loading the the manager(Operator) image on Kind")
-			err = utils.LoadImageToKindClusterWithName(projectImage)
-			ExpectWithOffset(1, err).NotTo(HaveOccurred())
-
-			By("installing CRDs")
-			cmd = exec.Command("make", "install")
-			_, err = utils.Run(cmd)
-			ExpectWithOffset(1, err).NotTo(HaveOccurred())
-
-			By("deploying the controller-manager")
-			cmd = exec.Command("make", "deploy", fmt.Sprintf("IMG=%s", projectImage))
-			_, err = utils.Run(cmd)
-			ExpectWithOffset(1, err).NotTo(HaveOccurred())
-
-			By("validating that the controller-manager pod is running as expected")
-			verifyControllerUp := func() error {
-				// Get pod name
-
-				cmd = exec.Command("kubectl", "get",
-					"pods", "-l", "control-plane=controller-manager",
-					"-o", "go-template={{ range .items }}"+
-						"{{ if not .metadata.deletionTimestamp }}"+
-						"{{ .metadata.name }}"+
-						"{{ \"\\n\" }}{{ end }}{{ end }}",
-					"-n", namespace,
-				)
-
-				podOutput, err := utils.Run(cmd)
-				ExpectWithOffset(2, err).NotTo(HaveOccurred())
-				podNames := utils.GetNonEmptyLines(string(podOutput))
-				if len(podNames) != 1 {
-					return fmt.Errorf("expect 1 controller pods running, but got %d", len(podNames))
-				}
-				controllerPodName = podNames[0]
-				ExpectWithOffset(2, controllerPodName).Should(ContainSubstring("controller-manager"))
-
-				// Validate pod status
-				cmd = exec.Command("kubectl", "get",
-					"pods", controllerPodName, "-o", "jsonpath={.status.phase}",
-					"-n", namespace,
-				)
-				status, err := utils.Run(cmd)
-				ExpectWithOffset(2, err).NotTo(HaveOccurred())
-				if string(status) != "Running" {
-					return fmt.Errorf("controller pod in %s status", status)
-				}
-				return nil
+func waitForDeploymentReady(ctx context.Context, namespace string, name string, timeout time.Duration) error {
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+	err := wait.PollUntilContextTimeout(ctx, 10*time.Second, timeout, true,
+		func(ctx context.Context) (done bool, err error) {
+			err = kubeClient.Get(ctx, client.ObjectKeyFromObject(deployment), deployment)
+			if errors.IsNotFound(err) {
+				done = false
+				return
 			}
-			EventuallyWithOffset(1, verifyControllerUp, time.Minute, time.Second).Should(Succeed())
+			if err != nil {
+				done = true
+				return
+			}
+			done = (deployment.Status.ReadyReplicas > 0)
+			return
+		})
+	return err
+}
 
+var _ = Describe("Builds for OpenShift operator", Label("e2e"), func() {
+
+	When("the operator has been deployed", func() {
+
+		BeforeEach(func(ctx SpecContext) {
+			err := waitForDeploymentReady(ctx, "openshift-builds", "openshift-builds-operator", 10*time.Minute)
+			Expect(err).NotTo(HaveOccurred(), "checking if operator deployment is ready")
+		})
+
+		It("should create an OpenShiftBuild CRD with defaults enabled", func() {
+			Fail("not implemented yet")
 		})
 	})
 })

--- a/test/e2e/setup.go
+++ b/test/e2e/setup.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2024 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	. "github.com/onsi/ginkgo/v2" //nolint:golint,revive
+	. "github.com/onsi/gomega"    //nolint:golint,revive
+
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/redhat-openshift-builds/operator/test/setup"
+)
+
+var (
+	kubeClient client.Client
+	mgr        *setup.OperatorManager
+)
+
+var _ = BeforeSuite(func(ctx SpecContext) {
+
+	ctrl.SetLogger(GinkgoLogr)
+	config, err := ctrl.GetConfig()
+	Expect(err).NotTo(HaveOccurred(), "getting KUBECONFIG")
+	kubeClient, err = client.New(config, client.Options{})
+	Expect(err).NotTo(HaveOccurred(), "setting up kubeClient")
+
+	By("installing operators", func() {
+		mgr = setup.NewOperatorManager(kubeClient)
+		err = mgr.InstallBuildsForOpenShift(ctx)
+		Expect(err).NotTo(HaveOccurred(), "ensure Builds for OpenShift installed")
+	})
+
+})

--- a/test/setup/manifests/subscription-openshift-builds.yaml
+++ b/test/setup/manifests/subscription-openshift-builds.yaml
@@ -1,0 +1,13 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  labels:
+    operators.coreos.com/openshift-builds-operator.openshift-builds: ""
+  name: openshift-builds-operator
+  namespace: openshift-builds
+spec:
+  channel: latest
+  installPlanApproval: Automatic
+  name: openshift-builds-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace

--- a/test/setup/operators.go
+++ b/test/setup/operators.go
@@ -1,0 +1,166 @@
+/*
+Copyright 2024 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package setup
+
+import (
+	"context"
+	"embed"
+	"fmt"
+	"time"
+
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	crlog "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/yaml"
+)
+
+//go:embed manifests/*
+var manifests embed.FS
+
+type OperatorManager struct {
+	kubeClient client.Client
+}
+
+func NewOperatorManager(kubeClient client.Client) *OperatorManager {
+	return &OperatorManager{
+		kubeClient: kubeClient,
+	}
+}
+
+func (m *OperatorManager) createFromManifest(ctx context.Context, file string, obj *unstructured.Unstructured) error {
+	manifest, err := manifests.ReadFile(file)
+	if err != nil {
+		return err
+	}
+	err = yaml.Unmarshal(manifest, obj)
+	if err != nil {
+		return err
+	}
+	return m.kubeClient.Create(ctx, obj)
+}
+
+// InstallBuildsForOpenShift ensures that Builds for OpenShift and its operands have been installed
+// and deployed on the cluster.
+func (m *OperatorManager) InstallBuildsForOpenShift(ctx context.Context) error {
+	subscription := m.buildsSubscriptionStub()
+	opLog := crlog.FromContext(ctx).WithValues("namespace", subscription.GetNamespace(), "group", "operators.coreos.com")
+	subLog := opLog.WithValues("kind", "Subscription", "name", subscription.GetName())
+	err := m.kubeClient.Get(ctx, client.ObjectKeyFromObject(subscription), subscription)
+	if kerrors.IsNotFound(err) {
+		if err := m.createBuildsSubscription(ctx, subscription); err != nil {
+			return fmt.Errorf("failed to create Builds for OpenShift subscription: %v", err)
+		}
+		subLog.Info("created object")
+	}
+	subLog.Info("found object")
+	installedCSV, err := m.waitForInstalledCSV(ctx, subscription, 10*time.Minute)
+	if err != nil {
+		return fmt.Errorf("could not determine Builds for OpenShift installedCSV: %v", err)
+	}
+	csvLog := opLog.WithValues("kind", "ClusterServiceVersion", "name", installedCSV)
+	csvLog.Info("determined installedCSV")
+	phase, err := m.waitForCSVSucceeded(ctx, installedCSV, 10*time.Minute)
+	csvLog.WithValues("phase", phase).Info("CSV phase determined")
+	if err != nil {
+		return fmt.Errorf("CSV %s install did not succeed, reached phase %s: %v", installedCSV, phase, err)
+	}
+	return nil
+}
+
+// waitForInstalledCSV polls the provided Subscription object until `status.installedCSV` returns a
+// value.
+func (m *OperatorManager) waitForInstalledCSV(ctx context.Context, subscription *unstructured.Unstructured,
+	timeout time.Duration) (string, error) {
+	var installedCSV string
+	// Poll up to the provided timeout
+	waitErr := wait.PollUntilContextTimeout(ctx, 10*time.Second, timeout, true,
+		func(ctx context.Context) (done bool, err error) {
+			err = m.kubeClient.Get(ctx, client.ObjectKeyFromObject(subscription), subscription)
+			if kerrors.IsNotFound(err) {
+				// Keep polling if the subscription object is not found.
+				done = false
+				return
+			}
+			if err != nil {
+				done = true
+				return
+			}
+			// done is `true` if the value is found for .status.installedCSV
+			installedCSV, done, err = unstructured.NestedString(subscription.Object, "status", "installedCSV")
+			// Continue polling if installedCSV is the empty string
+			if len(installedCSV) == 0 {
+				done = false
+			}
+			return
+		})
+	return installedCSV, waitErr
+}
+
+// waitForCSVSucceeded polls the named CSV's object until `status.phase`
+func (m *OperatorManager) waitForCSVSucceeded(ctx context.Context, installedCSV string, timeout time.Duration) (string,
+	error) {
+	csv := &unstructured.Unstructured{}
+	csv.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "operators.coreos.com",
+		Version: "v1alpha1",
+		Kind:    "ClusterServiceVersion",
+	})
+	csv.SetNamespace("openshift-builds")
+	csv.SetName(installedCSV)
+
+	var phase string
+	waitErr := wait.PollUntilContextTimeout(ctx, 10*time.Second, timeout, true,
+		func(ctx context.Context) (done bool, err error) {
+			err = m.kubeClient.Get(ctx, client.ObjectKeyFromObject(csv), csv)
+			if kerrors.IsNotFound(err) {
+				// Keep polling if the subscription object is not found.
+				done = false
+				return
+			}
+			if err != nil {
+				done = true
+				return
+			}
+			// done is `true` if the value is found for .status.phase
+			phase, done, err = unstructured.NestedString(csv.Object, "status", "phase")
+			// Continue polling the phase is not "Succeeded" (includes empty value)
+			if phase != "Succeeded" {
+				done = false
+			}
+			return
+		})
+	return phase, waitErr
+}
+
+func (m *OperatorManager) buildsSubscriptionStub() *unstructured.Unstructured {
+	subscription := &unstructured.Unstructured{}
+	subscription.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "operators.coreos.com",
+		Version: "v1alpha1",
+		Kind:    "Subscription",
+	})
+	subscription.SetNamespace("openshift-builds")
+	subscription.SetName("openshift-builds-operator")
+	return subscription
+}
+
+func (m *OperatorManager) createBuildsSubscription(ctx context.Context, subscription *unstructured.Unstructured) error {
+	return m.createFromManifest(ctx, "manifests/subscription-openshift-builds.yaml", subscription)
+}


### PR DESCRIPTION
Updating the e2e test scaffolding from operator-sdk to deploy Builds for OpenShift using OperatorHub. The updated e2e uses the "standard" install method from the Red Hat operators catalog, whose YAML manifest is embedded into the `setup.go` test framework code. Kubernetes objects are deployed using the default controller-runtime client and `unstructured.Unstructured` objects with TypeMeta set.

The `BeforeSuite` phase checks if Builds for OpenShift has been installed via OLM, and if not creates the required `Subscription`. It then waits for the generated OLM `ClusterServiceVersion` object to exist and reach the `Succeeded` phase. Subsequent tests should implement their own `BeforeEach` logic to ensure the specific system under test is ready (usually an operand). An example is provided, where the operator deployment is checked for readiness before verification of the `OpenShiftBuild` CRD is run.

Teardown logic for the operator is not provided due to the nested dependencies of the Builds for OpenShift operator. This can be addressed in a future test enhancement.