### PR TITLE
Install Test for OpenShift Builds

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -22,13 +22,38 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/shipwright-io/operator/api/v1alpha1"
 
 	appsv1 "k8s.io/api/apps/v1"
+	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	operatorv1alpha1 "github.com/redhat-openshift-builds/operator/api/v1alpha1"
 )
+
+func waitForCRDExists(ctx context.Context, crdName string, timeout time.Duration) error {
+	crd := &extv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: crdName,
+		},
+	}
+	err := wait.PollUntilContextTimeout(ctx, 10*time.Second, timeout, true,
+		func(ctx context.Context) (done bool, err error) {
+			err = kubeClient.Get(ctx, client.ObjectKeyFromObject(crd), crd)
+			if errors.IsNotFound(err) {
+				done = false
+				return
+			}
+			// If error is not nil, then something went wrong.
+			// Otherwise the CRD exists and we carry on.
+			done = true
+			return
+		})
+	return err
+}
 
 func waitForDeploymentReady(ctx context.Context, namespace string, name string, timeout time.Duration) error {
 	deployment := &appsv1.Deployment{
@@ -54,7 +79,31 @@ func waitForDeploymentReady(ctx context.Context, namespace string, name string, 
 	return err
 }
 
-var _ = Describe("Builds for OpenShift operator", Label("e2e"), func() {
+func waitForDaemonSetReady(ctx context.Context, namespace string, name string, timeout time.Duration) error {
+	daemonSet := &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+	err := wait.PollUntilContextTimeout(ctx, 10*time.Second, timeout, true,
+		func(ctx context.Context) (done bool, err error) {
+			err = kubeClient.Get(ctx, client.ObjectKeyFromObject(daemonSet), daemonSet)
+			if errors.IsNotFound(err) {
+				done = false
+				return
+			}
+			if err != nil {
+				done = true
+				return
+			}
+			done = (daemonSet.Status.NumberReady == daemonSet.Status.DesiredNumberScheduled)
+			return
+		})
+	return err
+}
+
+var _ = Describe("Builds for OpenShift operator", Label("e2e"), Label("operator"), func() {
 
 	When("the operator has been deployed", func() {
 
@@ -63,8 +112,47 @@ var _ = Describe("Builds for OpenShift operator", Label("e2e"), func() {
 			Expect(err).NotTo(HaveOccurred(), "checking if operator deployment is ready")
 		})
 
-		It("should create an OpenShiftBuild CRD with defaults enabled", func() {
-			Fail("not implemented yet")
-		})
+		It("should create an OpenShiftBuild CR with defaults enabled", Label("shipwright"), Label("shared-resources"),
+			func(ctx SpecContext) {
+				obInstance := &operatorv1alpha1.OpenShiftBuild{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "cluster",
+					},
+				}
+				err := kubeClient.Get(ctx, client.ObjectKeyFromObject(obInstance), obInstance)
+				Expect(err).NotTo(HaveOccurred(), "getting OpenShiftBuild instance")
+				Expect(obInstance.Spec.Shipwright.Build.State).To(Equal(operatorv1alpha1.Enabled))
+				Expect(obInstance.Spec.SharedResource.State).To(Equal(operatorv1alpha1.Enabled))
+			})
+
+		It("should create a ShipwrightBuild CR with correct defaults", Label("shipwright"), Label("builds"),
+			func(ctx SpecContext) {
+				shpInstances := &v1alpha1.ShipwrightBuildList{}
+				listOpts := &client.ListOptions{
+					Limit: 10,
+				}
+				err := kubeClient.List(ctx, shpInstances, listOpts)
+				Expect(err).NotTo(HaveOccurred(), "getting ShipwrightBuild instances")
+				instancesCount := len(shpInstances.Items)
+				Expect(instancesCount).To(Equal(1), "checking ShipwrightBuild instances")
+				if instancesCount == 0 {
+					return
+				}
+				shpInstance := shpInstances.Items[0]
+				Expect(len(shpInstance.OwnerReferences)).To(Equal(1), "checking owner reference count")
+				Expect(shpInstance.Spec.TargetNamespace).To(Equal("openshift-builds"), "checking target namespace")
+			})
+
+		It("should deploy the Shared Resource CSI Driver", Label("shared-resources"),
+			func(ctx SpecContext) {
+				err := waitForCRDExists(ctx, "sharedconfigmaps.sharedresource.openshift.io", 10*time.Minute)
+				Expect(err).NotTo(HaveOccurred(), "checking Shared Resource CRDs")
+				err = waitForCRDExists(ctx, "sharedsecrets.sharedresource.openshift.io", 10*time.Minute)
+				Expect(err).NotTo(HaveOccurred(), "checking Shared Resource CRDs")
+				err = waitForDaemonSetReady(ctx, "openshift-builds", "shared-resource-csi-driver-node", 10*time.Minute)
+				Expect(err).NotTo(HaveOccurred(), "checking Shared Resource CSI Driver DaemonSet")
+				err = waitForDeploymentReady(ctx, "openshift-builds", "shared-resource-csi-driver-webhook", 10*time.Minute)
+				Expect(err).NotTo(HaveOccurred(), "checking Shared Resource CSI Driver webhook")
+			})
 	})
 })

--- a/test/e2e/setup.go
+++ b/test/e2e/setup.go
@@ -20,10 +20,15 @@ import (
 	. "github.com/onsi/ginkgo/v2" //nolint:golint,revive
 	. "github.com/onsi/gomega"    //nolint:golint,revive
 
+	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	operatorv1alpha1 "github.com/redhat-openshift-builds/operator/api/v1alpha1"
 	"github.com/redhat-openshift-builds/operator/test/setup"
+	shpoperatorv1alpha1 "github.com/shipwright-io/operator/api/v1alpha1"
 )
 
 var (
@@ -32,11 +37,18 @@ var (
 )
 
 var _ = BeforeSuite(func(ctx SpecContext) {
+	scheme := runtime.NewScheme()
+	Expect(clientgoscheme.AddToScheme(scheme)).To(Succeed(), "setting up kubeClient")
+	Expect(extv1.AddToScheme(scheme)).To(Succeed(), "setting up kubeClient")
+	Expect(operatorv1alpha1.AddToScheme(scheme)).To(Succeed(), "setting up kubeClient")
+	Expect(shpoperatorv1alpha1.AddToScheme(scheme)).To(Succeed(), "setting up kubeClient")
 
 	ctrl.SetLogger(GinkgoLogr)
 	config, err := ctrl.GetConfig()
 	Expect(err).NotTo(HaveOccurred(), "getting KUBECONFIG")
-	kubeClient, err = client.New(config, client.Options{})
+	kubeClient, err = client.New(config, client.Options{
+		Scheme: scheme,
+	})
 	Expect(err).NotTo(HaveOccurred(), "setting up kubeClient")
 
 	By("installing operators", func() {


### PR DESCRIPTION
Initial install e2e test for OpenShift Builds. This test assumes operator has been subscribed with OLM. Once the operator deployment reports itself "Ready", the test then verifies the default settings for the OpenShiftBuild instance and the status of operands.

Ginkgo labels are used to distinguish which feature sets are being tested. In the future, these can be used to run subsets of the e2e test suite. The following labels are used as a starting point:

- e2e, operator: indicate this is an e2e test of the whole operator
- shipwright: tests of Shipwright features
- builds: tests of build features (will likely be paired with shipwright label)
- shared-resources: tests of the Shared Resource CSI Driver