### PR TITLE
fix: copying bundle directory in dockerfile

### DIFF
--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -28,7 +28,7 @@ LABEL com.redhat.openshift.versions="v4.12-v4.17" \
     vendor="Red Hat, Inc." \
     version="v1.1.0"
 
-COPY bundle/ /bundle/
+COPY bundle/ /
 COPY LICENSE /licenses/
 
 USER 65532:65532


### PR DESCRIPTION
Fixes copying bundle directory

Signed-off-by: Avinal Kumar <avinal@redhat.com>

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED
