### PR TITLE
[BUILD-1184] Replaces image tags to sha-digests for supporte BuildStrategy

### DIFF
--- a/config/shipwright/build/strategy/buildah.yaml
+++ b/config/shipwright/build/strategy/buildah.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   buildSteps:
     - name: build-and-push
-      image: registry.redhat.io/ubi8/buildah:8.8
+      image: registry.redhat.io/ubi8/buildah@sha256:1c89cc3cab0ac0fc7387c1fe5e63443468219aab6fd531c8dad6d22fd999819e
       workingDir: $(params.shp-source-root)
       securityContext:
         capabilities:

--- a/config/shipwright/build/strategy/source_to_image.yaml
+++ b/config/shipwright/build/strategy/source_to_image.yaml
@@ -12,7 +12,7 @@ spec:
       overridable: true
   buildSteps:
     - name: s2i-generate
-      image: registry.redhat.io/source-to-image/source-to-image-rhel8:v1.3.9
+      image: registry.redhat.io/source-to-image/source-to-image-rhel8@sha256:d041c1bbe503d152d0759598f79802e257816d674b342670ef61c6f9e6d401c5
       workingDir: $(params.shp-source-root)
       command: 
         - /usr/local/bin/s2i
@@ -28,7 +28,7 @@ spec:
         - mountPath: /etc/pki/entitlement
           name: etc-pki-entitlement
     - name: buildah
-      image: registry.redhat.io/ubi8/buildah:8.8
+      image: registry.redhat.io/ubi8/buildah@sha256:1c89cc3cab0ac0fc7387c1fe5e63443468219aab6fd531c8dad6d22fd999819e
       workingDir: /s2i
       securityContext:
         capabilities:


### PR DESCRIPTION
As mirroring images with tags isn't supported yet, using sha-digests in the build strategies would make it easier to mirror these images while using builds in Airgapped clusters.