### PR TITLE
Update golang to 1.22 for unit test task

### DIFF
--- a/.tekton/openshift-builds-operator-unit-test.yaml
+++ b/.tekton/openshift-builds-operator-unit-test.yaml
@@ -42,7 +42,7 @@ spec:
       - use
       - $(params.SOURCE_ARTIFACT)=/var/workdir/source
   - name: run-test
-    image: registry.access.redhat.com/ubi9/go-toolset:1.21.11-7@sha256:d128c3d36878251f039606f144ef2608746c3203708b722295e6c571df1d8613
+    image: registry.access.redhat.com/ubi9/go-toolset@sha256:b23212b6a296e95cbed5dd415d4cd5567db9e8057aa08e291f1fddc087cea944
     env:
     - name: GOOS
       value: $(params.GOOS)


### PR DESCRIPTION
Changes:
- Update unit-test task to use go-toolset 1.22