### PR TITLE
WIP: Update Go Tools to 1.22

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -252,7 +252,7 @@ $(CONTROLLER_GEN): $(LOCALBIN)
 .PHONY: envtest
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
 $(ENVTEST): $(LOCALBIN)
-	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.17
+	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.18
 
 .PHONY: operator-sdk
 OPERATOR_SDK ?= $(LOCALBIN)/operator-sdk

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/redhat-openshift-builds/operator
 
-go 1.21.0
+go 1.22.0
 
 require (
 	github.com/go-logr/logr v1.4.2


### PR DESCRIPTION
With latest update to go-toolset base image, we are now using golang 1.22 by default. As best practice, the following were also updated:

- Update go.mod to set go 1.22.0 as minimum version
- Use release-0.18 for the setup-envtest tool