### PR TITLE
BUILD-1191: Adding build flags to make operator FIPS compliant

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,9 @@ FROM registry.access.redhat.com/ubi9/go-toolset@sha256:b23212b6a296e95cbed5dd415
 
 COPY . .
 
-RUN CGO_ENABLED=0 GO111MODULE=on go build -a -mod vendor -o operator cmd/main.go
+ENV GOEXPERIMENT=strictfipsruntime
+
+RUN CGO_ENABLED=1 GO111MODULE=on go build -a -mod vendor -tags strictfipsruntime -o operator cmd/main.go
 
 FROM registry.access.redhat.com/ubi9/ubi-micro@sha256:a410623c2b8e9429f9606af821be0231fef2372bd0f5f853fbe9743a0ddf7b34
 


### PR DESCRIPTION
- Changed `CGO_ENABLED=1`
- Added `GOEXPERIMENT=strictfipsruntime` env variable
- Added` -tags strictfipsruntime` as part of go build invocation
