### PR TITLE
BUILD-1146: fix serverName for csi driver metrics service

### DIFF
--- a/config/sharedresource/servicemonitor.yaml
+++ b/config/sharedresource/servicemonitor.yaml
@@ -12,7 +12,7 @@ spec:
     scheme: https
     tlsConfig:
       caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
-      serverName: shared-resource-csi-driver-node-metrics.openshift-cluster-csi-drivers.svc
+      serverName: shared-resource-csi-driver-node-metrics.openshift-builds.svc
   - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
     interval: 30s
     path: /metrics
@@ -20,7 +20,7 @@ spec:
     scheme: https
     tlsConfig:
       caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
-      serverName: shared-resource-csi-driver-node-metrics.openshift-cluster-csi-drivers.svc
+      serverName: shared-resource-csi-driver-node-metrics.openshift-builds.svc
   - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
     interval: 30s
     path: /metrics
@@ -28,7 +28,7 @@ spec:
     scheme: https
     tlsConfig:
       caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
-      serverName: shared-resource-csi-driver-node-metrics.openshift-cluster-csi-drivers.svc
+      serverName: shared-resource-csi-driver-node-metrics.openshift-builds.svc
   jobLabel: component
   selector:
     matchLabels:


### PR DESCRIPTION
## Changes

- OpenShift Bulds Operator deployes CSI Driver in openshift-builds
  namespace but the metrics service still has the default server name
- this causes TargetDown alerts because the metrics service is no longer
  reachable
- this commit fixes the server name
- fixes BUILD-1146

