### PR TITLE
BUILD-1194: fix buildah and s2i images for multiarch

### DIFF
--- a/config/shipwright/build/strategy/buildah.yaml
+++ b/config/shipwright/build/strategy/buildah.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   buildSteps:
     - name: build-and-push
-      image: registry.redhat.io/ubi8/buildah@sha256:1c89cc3cab0ac0fc7387c1fe5e63443468219aab6fd531c8dad6d22fd999819e
+      image: registry.redhat.io/ubi8/buildah@sha256:56c71ecd450f284325ba8434cbf5b3006078b11f0625c6258689699fa811c95d
       workingDir: $(params.shp-source-root)
       securityContext:
         capabilities:

--- a/config/shipwright/build/strategy/source_to_image.yaml
+++ b/config/shipwright/build/strategy/source_to_image.yaml
@@ -12,7 +12,7 @@ spec:
       overridable: true
   buildSteps:
     - name: s2i-generate
-      image: registry.redhat.io/source-to-image/source-to-image-rhel8@sha256:d041c1bbe503d152d0759598f79802e257816d674b342670ef61c6f9e6d401c5
+      image: registry.redhat.io/source-to-image/source-to-image-rhel8@sha256:016c93578908f1dbdc3052333a1d5a9ab0c03104070ac36a6ddf99350d7510f4
       workingDir: $(params.shp-source-root)
       command: 
         - /usr/local/bin/s2i
@@ -28,7 +28,7 @@ spec:
         - mountPath: /etc/pki/entitlement
           name: etc-pki-entitlement
     - name: buildah
-      image: registry.redhat.io/ubi8/buildah@sha256:1c89cc3cab0ac0fc7387c1fe5e63443468219aab6fd531c8dad6d22fd999819e
+      image: registry.redhat.io/ubi8/buildah@sha256:56c71ecd450f284325ba8434cbf5b3006078b11f0625c6258689699fa811c95d
       workingDir: /s2i
       securityContext:
         capabilities:


### PR DESCRIPTION
## Changes

- to ensure mirroring works we need to use SHA instead of tags
- fixes BUILD-1194
- Cherry pick of #212 

