### PR TITLE
Disable ppc64le and s390x architecture for pull request in builds-1.2

### DIFF
--- a/.tekton/openshift-builds-operator-bundle-pull-request.yaml
+++ b/.tekton/openshift-builds-operator-bundle-pull-request.yaml
@@ -38,6 +38,12 @@ spec:
     value: "true"
   - name: hermetic
     value: "true"
+  - name: build-platforms
+    value:
+      - linux/x86_64
+      - linux/arm64
+  - name: prefetch-input
+    value: '{"packages": [{"type": "gomod"}]}'
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.
@@ -117,9 +123,6 @@ spec:
       type: string
     - default:
       - linux/x86_64
-      - linux/arm64
-      - linux/ppc64le
-      - linux/s390x
       description: List of platforms to build the container images on. The available
         set of values is determined by the configuration of the multi-platform-controller.
       name: build-platforms

--- a/.tekton/openshift-builds-operator-bundle-push.yaml
+++ b/.tekton/openshift-builds-operator-bundle-push.yaml
@@ -35,6 +35,14 @@ spec:
     value: "true"
   - name: hermetic
     value: "true"
+  - name: build-platforms
+    value:
+      - linux/x86_64
+      - linux/arm64
+      - linux/ppc64le
+      - linux/s390x
+  - name: prefetch-input
+    value: '{"packages": [{"type": "gomod"}]}'
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.
@@ -114,9 +122,6 @@ spec:
       type: string
     - default:
       - linux/x86_64
-      - linux/arm64
-      - linux/ppc64le
-      - linux/s390x
       description: List of platforms to build the container images on. The available
         set of values is determined by the configuration of the multi-platform-controller.
       name: build-platforms

--- a/.tekton/openshift-builds-operator-pull-request.yaml
+++ b/.tekton/openshift-builds-operator-pull-request.yaml
@@ -40,8 +40,12 @@ spec:
     value: "true"
   - name: hermetic
     value: "true"
+  - name: build-platforms
+    value:
+      - linux/x86_64
+      - linux/arm64
   - name: prefetch-input
-    value: '{"packages": [{"type": "gomod"}], "flags": ["gomod-vendor-check"]}'
+    value: '{"packages": [{"type": "gomod"}]}'
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.
@@ -121,9 +125,6 @@ spec:
       type: string
     - default:
       - linux/x86_64
-      - linux/arm64
-      - linux/ppc64le
-      - linux/s390x
       description: List of platforms to build the container images on. The available
         set of values is determined by the configuration of the multi-platform-controller.
       name: build-platforms

--- a/.tekton/openshift-builds-operator-push.yaml
+++ b/.tekton/openshift-builds-operator-push.yaml
@@ -38,7 +38,7 @@ spec:
   - name: hermetic
     value: "true"
   - name: prefetch-input
-    value: '{"packages": [{"type": "gomod"}], "flags": ["gomod-vendor-check"]}'
+    value: '{"packages": [{"type": "gomod"}]}'
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.


### PR DESCRIPTION
Changes:
- Update tekton pipelines to disable ppc64le and s390x architecture for pull request in builds-1.2