### PR TITLE
BUILD-1301: Remove FIPS Compliance Support

### DIFF
--- a/bundle/manifests/openshift-builds-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/openshift-builds-operator.clusterserviceversion.yaml
@@ -43,7 +43,7 @@ metadata:
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "true"
     features.operators.openshift.io/disconnected: "true"
-    features.operators.openshift.io/fips-compliant: "true"
+    features.operators.openshift.io/fips-compliant: "false"
     features.operators.openshift.io/proxy-aware: "true"
     features.operators.openshift.io/tls-profiles: "false"
     features.operators.openshift.io/token-auth-aws: "false"

--- a/config/manifests/bases/openshift-builds-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/openshift-builds-operator.clusterserviceversion.yaml
@@ -13,7 +13,7 @@ metadata:
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "true"
     features.operators.openshift.io/disconnected: "true"
-    features.operators.openshift.io/fips-compliant: "true"
+    features.operators.openshift.io/fips-compliant: "false"
     features.operators.openshift.io/proxy-aware: "true"
     features.operators.openshift.io/tls-profiles: "false"
     features.operators.openshift.io/token-auth-aws: "false"


### PR DESCRIPTION
OpenShift Pipelines recently notified teams that they will not support FIPS until v1.19. Builds for OpenShift this cannot make a FIPS support claim until all of its dependencies also support FIPS.

This reverts commit 5c8b697748bbf03f2d5f12f3e96c0a4f8e2cb284.