### PR TITLE
Fix YAML syntax in buildah strategy

### DIFF
--- a/config/shipwright/build/strategy/buildah.yaml
+++ b/config/shipwright/build/strategy/buildah.yaml
@@ -168,7 +168,7 @@ spec:
         - $(params.registries-insecure[*])
         - --registries-search
         - $(params.registries-search[*])
-        volumeMounts:
+      volumeMounts:
         - mountPath: /etc/pki/entitlement
           name: etc-pki-entitlement
       resources:


### PR DESCRIPTION
Changes:
- Fix indentation issue in buildah strategy

(cherry picked from commit 12515cf215486e6e84bd734ac21cb74712229bd6)