### PR TITLE
Fix RBAC for CRD permissions

### DIFF
--- a/bundle/manifests/openshift-builds-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/openshift-builds-operator.clusterserviceversion.yaml
@@ -90,715 +90,723 @@ spec:
     spec:
       clusterPermissions:
         - rules:
-            - apiGroups:
-                - shipwright.io
-              resources:
-                - clusterbuildstrategies
-              verbs:
-                - get
-                - list
-                - watch
-            - apiGroups:
-                - shipwright.io
-              resources:
-                - buildstrategies
-              verbs:
-                - get
-                - list
-                - watch
-                - create
-                - update
-                - patch
-                - delete
-            - apiGroups:
-                - shipwright.io
-              resources:
-                - builds
-              verbs:
-                - get
-                - list
-                - watch
-                - create
-                - update
-                - patch
-                - delete
-            - apiGroups:
-                - shipwright.io
-              resources:
-                - buildruns
-              verbs:
-                - get
-                - list
-                - watch
-                - create
-                - update
-                - patch
-                - delete
-            - apiGroups:
-                - shipwright.io
-              resources:
-                - buildruns
-              verbs:
-                - get
-                - list
-                - watch
-                - update
-                - delete
-            - apiGroups:
-                - shipwright.io
-              resources:
-                - buildruns/finalizers
-              verbs:
-                - update
-            - apiGroups:
-                - shipwright.io
-              resources:
-                - buildruns/status
-              verbs:
-                - update
-            - apiGroups:
-                - shipwright.io
-              resources:
-                - builds
-              verbs:
-                - get
-                - list
-                - watch
-            - apiGroups:
-                - shipwright.io
-              resources:
-                - builds/finalizers
-              verbs:
-                - update
-            - apiGroups:
-                - shipwright.io
-              resources:
-                - builds/status
-              verbs:
-                - update
-            - apiGroups:
-                - shipwright.io
-              resources:
-                - buildstrategies
-              verbs:
-                - get
-                - list
-                - watch
-            - apiGroups:
-                - shipwright.io
-              resources:
-                - clusterbuildstrategies
-              verbs:
-                - get
-                - list
-                - watch
-            - apiGroups:
-                - tekton.dev
-              resources:
-                - taskruns
-              verbs:
-                - get
-                - list
-                - watch
-                - create
-                - delete
-                - patch
-            - apiGroups:
-                - ""
-              resources:
-                - pods
-              verbs:
-                - get
-                - list
-                - watch
-            - apiGroups:
-                - ""
-              resources:
-                - secrets
-              verbs:
-                - get
-                - list
-                - watch
-            - apiGroups:
-                - ""
-              resources:
-                - configmaps
-              verbs:
-                - list
-            - apiGroups:
-                - ""
-              resources:
-                - serviceaccounts
-              verbs:
-                - get
-                - list
-                - watch
-                - create
-                - update
-                - delete
-            - apiGroups:
-                - ""
-              resources:
-                - configmaps
-              verbs:
-                - get
-                - create
-                - update
-            - apiGroups:
-                - coordination.k8s.io
-              resources:
-                - leases
-              verbs:
-                - create
-                - get
-                - update
-            - apiGroups:
-                - ""
-              resources:
-                - events
-              verbs:
-                - create
-            - apiGroups:
-                - ""
-              resources:
-                - pods
-                - events
-                - configmaps
-                - secrets
-                - limitranges
-                - namespaces
-                - services
-              verbs:
-                - '*'
-            - apiGroups:
-                - admissionregistration.k8s.io
-                - admissionregistration.k8s.io/v1beta1
-              resources:
-                - validatingwebhookconfigurations
-              verbs:
-                - '*'
-            - apiGroups:
-                - ""
-              resources:
-                - endpoints
-              verbs:
-                - get
-                - list
-                - watch
-            - apiGroups:
-                - ""
-              resources:
-                - events
-                - services
-              verbs:
-                - create
-                - delete
-                - get
-                - list
-                - patch
-                - update
-                - watch
-            - apiGroups:
-                - admissionregistration.k8s.io
-              resources:
-                - validatingwebhookconfigurations
-              verbs:
-                - create
-                - delete
-                - get
-                - list
-                - patch
-                - update
-                - watch
-            - apiGroups:
-                - admissionregistration.k8s.io/v1beta1
-              resources:
-                - validatingwebhookconfigurations
-              verbs:
-                - create
-                - delete
-                - get
-                - list
-                - patch
-                - update
-                - watch
-            - apiGroups:
-                - apiextensions.k8s.io
-              resources:
-                - customresourcedefinitions
-              verbs:
-                - create
-                - get
-                - list
-                - watch
-            - apiGroups:
-                - apiextensions.k8s.io
-              resourceNames:
-                - buildruns.shipwright.io
-                - builds.shipwright.io
-                - buildstrategies.shipwright.io
-                - clusterbuildstrategies.shipwright.io
-              resources:
-                - customresourcedefinitions
-              verbs:
-                - delete
-                - patch
-                - update
-            - apiGroups:
-                - apiextensions.k8s.io
-              resourceNames:
-                - sharedconfigmaps.sharedresource.openshift.io
-                - sharedsecrets.sharedresource.openshift.io
-              resources:
-                - customresourcedefinitions
-              verbs:
-                - create
-                - delete
-                - get
-                - list
-                - patch
-                - update
-                - watch
-            - apiGroups:
-                - apps
-              resources:
-                - daemonsets
-              verbs:
-                - create
-                - delete
-                - get
-                - list
-                - update
-                - watch
-            - apiGroups:
-                - apps
-              resources:
-                - deployments
-              verbs:
-                - create
-                - delete
-                - get
-                - list
-                - update
-                - watch
-            - apiGroups:
-                - apps
-              resourceNames:
-                - shipwright-build-controller
-              resources:
-                - deployments
-              verbs:
-                - delete
-                - patch
-                - update
-            - apiGroups:
-                - apps
-              resourceNames:
-                - shipwright-build-webhook
-              resources:
-                - deployments
-              verbs:
-                - delete
-                - patch
-                - update
-            - apiGroups:
-                - apps
-              resourceNames:
-                - shipwright-build-controller
-              resources:
-                - deployments/finalizers
-              verbs:
-                - update
-            - apiGroups:
-                - apps
-              resourceNames:
-                - shipwright-build-webhook
-              resources:
-                - deployments/finalizers
-              verbs:
-                - update
-            - apiGroups:
-                - cert-manager.io
-              resources:
-                - certificates
-              verbs:
-                - create
-                - get
-                - list
-                - watch
-            - apiGroups:
-                - cert-manager.io
-              resourceNames:
-                - shipwright-build-webhook-cert
-              resources:
-                - certificates
-              verbs:
-                - delete
-                - patch
-                - update
-            - apiGroups:
-                - cert-manager.io
-              resources:
-                - issuers
-              verbs:
-                - create
-                - get
-                - list
-                - watch
-            - apiGroups:
-                - cert-manager.io
-              resourceNames:
-                - selfsigned-issuer
-              resources:
-                - issuers
-              verbs:
-                - delete
-                - patch
-                - update
-            - apiGroups:
-                - ""
-              resources:
-                - configmaps
-                - events
-                - limitranges
-                - namespaces
-                - pods
-                - secrets
-                - services
-              verbs:
-                - create
-                - delete
-                - get
-                - list
-                - patch
-                - update
-                - watch
-            - apiGroups:
-                - ""
-              resources:
-                - namespaces
-              verbs:
-                - create
-                - delete
-                - get
-                - list
-                - patch
-                - update
-                - watch
-            - apiGroups:
-                - ""
-              resources:
-                - serviceaccounts
-              verbs:
-                - create
-                - get
-                - list
-                - watch
-            - apiGroups:
-                - ""
-              resourceNames:
-                - shipwright-build-controller
-              resources:
-                - serviceaccounts
-              verbs:
-                - delete
-                - patch
-                - update
-            - apiGroups:
-                - ""
-              resourceNames:
-                - shipwright-build-webhook
-              resources:
-                - serviceaccounts
-              verbs:
-                - delete
-                - patch
-                - update
-            - apiGroups:
-                - monitoring.coreos.com
-              resources:
-                - servicemonitors
-              verbs:
-                - create
-                - delete
-                - get
-                - list
-                - update
-                - watch
-            - apiGroups:
-                - operator.openshift.io
-              resources:
-                - openshiftbuilds
-              verbs:
-                - create
-                - delete
-                - get
-                - list
-                - patch
-                - update
-                - watch
-            - apiGroups:
-                - operator.openshift.io
-              resources:
-                - openshiftbuilds/finalizers
-              verbs:
-                - update
-            - apiGroups:
-                - operator.openshift.io
-              resources:
-                - openshiftbuilds/status
-              verbs:
-                - get
-                - patch
-                - update
-            - apiGroups:
-                - operator.shipwright.io
-              resources:
-                - shipwrightbuilds
-              verbs:
-                - create
-                - delete
-                - get
-                - list
-                - patch
-                - update
-                - watch
-            - apiGroups:
-                - operator.shipwright.io
-              resources:
-                - shipwrightbuilds/finalizers
-              verbs:
-                - update
-            - apiGroups:
-                - operator.shipwright.io
-              resources:
-                - shipwrightbuilds/status
-              verbs:
-                - get
-                - patch
-                - update
-            - apiGroups:
-                - operator.tekton.dev
-              resources:
-                - tektonconfigs
-              verbs:
-                - create
-                - get
-                - list
-            - apiGroups:
-                - policy
-              resources:
-                - poddisruptionbudgets
-              verbs:
-                - create
-                - delete
-                - get
-                - list
-                - update
-                - watch
-            - apiGroups:
-                - rbac.authorization.k8s.io
-              resources:
-                - clusterrolebindings
-              verbs:
-                - create
-                - get
-                - list
-                - watch
-            - apiGroups:
-                - rbac.authorization.k8s.io
-              resourceNames:
-                - shipwright-build-controller
-              resources:
-                - clusterrolebindings
-              verbs:
-                - delete
-                - patch
-                - update
-            - apiGroups:
-                - rbac.authorization.k8s.io
-              resourceNames:
-                - shipwright-build-webhook
-              resources:
-                - clusterrolebindings
-              verbs:
-                - delete
-                - patch
-                - update
-            - apiGroups:
-                - rbac.authorization.k8s.io
-              resources:
-                - clusterrolebindings
-                - clusterroles
-                - rolebindings
-                - roles
-              verbs:
-                - create
-                - delete
-                - get
-                - list
-                - update
-                - watch
-            - apiGroups:
-                - rbac.authorization.k8s.io
-              resources:
-                - clusterroles
-              verbs:
-                - create
-                - get
-                - list
-                - watch
-            - apiGroups:
-                - rbac.authorization.k8s.io
-              resourceNames:
-                - shipwright-build-aggregate-edit
-              resources:
-                - clusterroles
-              verbs:
-                - delete
-                - patch
-                - update
-            - apiGroups:
-                - rbac.authorization.k8s.io
-              resourceNames:
-                - shipwright-build-aggregate-view
-              resources:
-                - clusterroles
-              verbs:
-                - delete
-                - patch
-                - update
-            - apiGroups:
-                - rbac.authorization.k8s.io
-              resourceNames:
-                - shipwright-build-controller
-              resources:
-                - clusterroles
-              verbs:
-                - delete
-                - patch
-                - update
-            - apiGroups:
-                - rbac.authorization.k8s.io
-              resourceNames:
-                - shipwright-build-webhook
-              resources:
-                - clusterroles
-              verbs:
-                - delete
-                - patch
-                - update
-            - apiGroups:
-                - rbac.authorization.k8s.io
-              resources:
-                - rolebindings
-              verbs:
-                - create
-                - get
-                - list
-                - watch
-            - apiGroups:
-                - rbac.authorization.k8s.io
-              resourceNames:
-                - shipwright-build-controller
-              resources:
-                - rolebindings
-              verbs:
-                - delete
-                - patch
-                - update
-            - apiGroups:
-                - rbac.authorization.k8s.io
-              resourceNames:
-                - shipwright-build-webhook
-              resources:
-                - rolebindings
-              verbs:
-                - delete
-                - patch
-                - update
-            - apiGroups:
-                - rbac.authorization.k8s.io
-              resources:
-                - roles
-              verbs:
-                - create
-                - get
-                - list
-                - watch
-            - apiGroups:
-                - rbac.authorization.k8s.io
-              resourceNames:
-                - shipwright-build-controller
-              resources:
-                - roles
-              verbs:
-                - delete
-                - patch
-                - update
-            - apiGroups:
-                - rbac.authorization.k8s.io
-              resourceNames:
-                - shipwright-build-webhook
-              resources:
-                - roles
-              verbs:
-                - delete
-                - patch
-                - update
-            - apiGroups:
-                - security.openshift.io
-              resourceNames:
-                - privileged
-              resources:
-                - securitycontextconstraints
-              verbs:
-                - use
-            - apiGroups:
-                - sharedresource.openshift.io
-              resources:
-                - sharedconfigmaps
-                - sharedsecrets
-              verbs:
-                - get
-                - list
-                - watch
-            - apiGroups:
-                - shipwright.io
-              resources:
-                - clusterbuildstrategies
-              verbs:
-                - create
-                - delete
-                - get
-                - list
-                - patch
-                - update
-                - watch
-            - apiGroups:
-                - storage.k8s.io
-              resources:
-                - csidrivers
-              verbs:
-                - create
-                - delete
-                - get
-                - list
-                - patch
-                - update
-                - watch
-            - apiGroups:
-                - authentication.k8s.io
-              resources:
-                - tokenreviews
-              verbs:
-                - create
-            - apiGroups:
-                - authorization.k8s.io
-              resources:
-                - subjectaccessreviews
-              verbs:
-                - create
+          - apiGroups:
+              - shipwright.io
+            resources:
+              - clusterbuildstrategies
+            verbs:
+              - get
+              - list
+              - watch
+          - apiGroups:
+              - shipwright.io
+            resources:
+              - buildstrategies
+            verbs:
+              - get
+              - list
+              - watch
+              - create
+              - update
+              - patch
+              - delete
+          - apiGroups:
+              - shipwright.io
+            resources:
+              - builds
+            verbs:
+              - get
+              - list
+              - watch
+              - create
+              - update
+              - patch
+              - delete
+          - apiGroups:
+              - shipwright.io
+            resources:
+              - buildruns
+            verbs:
+              - get
+              - list
+              - watch
+              - create
+              - update
+              - patch
+              - delete
+          - apiGroups:
+              - shipwright.io
+            resources:
+              - buildruns
+            verbs:
+              - get
+              - list
+              - watch
+              - update
+              - delete
+          - apiGroups:
+              - shipwright.io
+            resources:
+              - buildruns/finalizers
+            verbs:
+              - update
+          - apiGroups:
+              - shipwright.io
+            resources:
+              - buildruns/status
+            verbs:
+              - update
+          - apiGroups:
+              - shipwright.io
+            resources:
+              - builds
+            verbs:
+              - get
+              - list
+              - watch
+          - apiGroups:
+              - shipwright.io
+            resources:
+              - builds/finalizers
+            verbs:
+              - update
+          - apiGroups:
+              - shipwright.io
+            resources:
+              - builds/status
+            verbs:
+              - update
+          - apiGroups:
+              - shipwright.io
+            resources:
+              - buildstrategies
+            verbs:
+              - get
+              - list
+              - watch
+          - apiGroups:
+              - shipwright.io
+            resources:
+              - clusterbuildstrategies
+            verbs:
+              - get
+              - list
+              - watch
+          - apiGroups:
+              - tekton.dev
+            resources:
+              - taskruns
+            verbs:
+              - get
+              - list
+              - watch
+              - create
+              - delete
+              - patch
+          - apiGroups:
+              - ""
+            resources:
+              - pods
+            verbs:
+              - get
+              - list
+              - watch
+          - apiGroups:
+              - ""
+            resources:
+              - secrets
+            verbs:
+              - get
+              - list
+              - watch
+          - apiGroups:
+              - ""
+            resources:
+              - configmaps
+            verbs:
+              - list
+          - apiGroups:
+              - ""
+            resources:
+              - serviceaccounts
+            verbs:
+              - get
+              - list
+              - watch
+              - create
+              - update
+              - delete
+          - apiGroups:
+              - ""
+            resources:
+              - configmaps
+            verbs:
+              - get
+              - create
+              - update
+          - apiGroups:
+              - coordination.k8s.io
+            resources:
+              - leases
+            verbs:
+              - create
+              - get
+              - update
+          - apiGroups:
+              - ""
+            resources:
+              - events
+            verbs:
+              - create
+          - apiGroups:
+              - ""
+            resources:
+              - pods
+              - events
+              - configmaps
+              - secrets
+              - limitranges
+              - namespaces
+              - services
+            verbs:
+              - '*'
+          - apiGroups:
+              - admissionregistration.k8s.io
+              - admissionregistration.k8s.io/v1beta1
+            resources:
+              - validatingwebhookconfigurations
+            verbs:
+              - '*'
+          - apiGroups:
+              - ""
+            resources:
+              - endpoints
+            verbs:
+              - get
+              - list
+              - watch
+          - apiGroups:
+              - ""
+            resources:
+              - events
+              - services
+            verbs:
+              - create
+              - delete
+              - get
+              - list
+              - patch
+              - update
+              - watch
+          - apiGroups:
+              - admissionregistration.k8s.io
+            resources:
+              - validatingwebhookconfigurations
+            verbs:
+              - create
+              - delete
+              - get
+              - list
+              - patch
+              - update
+              - watch
+          - apiGroups:
+              - admissionregistration.k8s.io/v1beta1
+            resources:
+              - validatingwebhookconfigurations
+            verbs:
+              - create
+              - delete
+              - get
+              - list
+              - patch
+              - update
+              - watch
+          - apiGroups:
+              - apiextensions.k8s.io
+            resources:
+              - customresourcedefinitions
+              - customresourcedefinitions/status
+            verbs:
+              - get
+              - patch
+          - apiGroups:
+              - apiextensions.k8s.io
+            resources:
+              - customresourcedefinitions
+            verbs:
+              - create
+              - get
+              - list
+              - watch
+          - apiGroups:
+              - apiextensions.k8s.io
+            resourceNames:
+              - buildruns.shipwright.io
+              - builds.shipwright.io
+              - buildstrategies.shipwright.io
+              - clusterbuildstrategies.shipwright.io
+            resources:
+              - customresourcedefinitions
+            verbs:
+              - delete
+              - patch
+              - update
+          - apiGroups:
+              - apiextensions.k8s.io
+            resourceNames:
+              - sharedconfigmaps.sharedresource.openshift.io
+              - sharedsecrets.sharedresource.openshift.io
+            resources:
+              - customresourcedefinitions
+            verbs:
+              - create
+              - delete
+              - get
+              - list
+              - patch
+              - update
+              - watch
+          - apiGroups:
+              - apps
+            resources:
+              - daemonsets
+            verbs:
+              - create
+              - delete
+              - get
+              - list
+              - update
+              - watch
+          - apiGroups:
+              - apps
+            resources:
+              - deployments
+            verbs:
+              - create
+              - delete
+              - get
+              - list
+              - update
+              - watch
+          - apiGroups:
+              - apps
+            resourceNames:
+              - shipwright-build-controller
+            resources:
+              - deployments
+            verbs:
+              - delete
+              - patch
+              - update
+          - apiGroups:
+              - apps
+            resourceNames:
+              - shipwright-build-webhook
+            resources:
+              - deployments
+            verbs:
+              - delete
+              - patch
+              - update
+          - apiGroups:
+              - apps
+            resourceNames:
+              - shipwright-build-controller
+            resources:
+              - deployments/finalizers
+            verbs:
+              - update
+          - apiGroups:
+              - apps
+            resourceNames:
+              - shipwright-build-webhook
+            resources:
+              - deployments/finalizers
+            verbs:
+              - update
+          - apiGroups:
+              - cert-manager.io
+            resources:
+              - certificates
+            verbs:
+              - create
+              - get
+              - list
+              - watch
+          - apiGroups:
+              - cert-manager.io
+            resourceNames:
+              - shipwright-build-webhook-cert
+            resources:
+              - certificates
+            verbs:
+              - delete
+              - patch
+              - update
+          - apiGroups:
+              - cert-manager.io
+            resources:
+              - issuers
+            verbs:
+              - create
+              - get
+              - list
+              - watch
+          - apiGroups:
+              - cert-manager.io
+            resourceNames:
+              - selfsigned-issuer
+            resources:
+              - issuers
+            verbs:
+              - delete
+              - patch
+              - update
+          - apiGroups:
+              - ""
+            resources:
+              - configmaps
+              - events
+              - limitranges
+              - namespaces
+              - pods
+              - secrets
+              - services
+            verbs:
+              - create
+              - delete
+              - get
+              - list
+              - patch
+              - update
+              - watch
+          - apiGroups:
+              - ""
+            resources:
+              - namespaces
+            verbs:
+              - create
+              - delete
+              - get
+              - list
+              - patch
+              - update
+              - watch
+          - apiGroups:
+              - ""
+            resources:
+              - serviceaccounts
+            verbs:
+              - create
+              - get
+              - list
+              - watch
+          - apiGroups:
+              - ""
+            resourceNames:
+              - shipwright-build-controller
+            resources:
+              - serviceaccounts
+            verbs:
+              - delete
+              - patch
+              - update
+          - apiGroups:
+              - ""
+            resourceNames:
+              - shipwright-build-webhook
+            resources:
+              - serviceaccounts
+            verbs:
+              - delete
+              - patch
+              - update
+          - apiGroups:
+              - monitoring.coreos.com
+            resources:
+              - servicemonitors
+            verbs:
+              - create
+              - delete
+              - get
+              - list
+              - update
+              - watch
+          - apiGroups:
+              - operator.openshift.io
+            resources:
+              - openshiftbuilds
+            verbs:
+              - create
+              - delete
+              - get
+              - list
+              - patch
+              - update
+              - watch
+          - apiGroups:
+              - operator.openshift.io
+            resources:
+              - openshiftbuilds/finalizers
+            verbs:
+              - update
+          - apiGroups:
+              - operator.openshift.io
+            resources:
+              - openshiftbuilds/status
+            verbs:
+              - get
+              - patch
+              - update
+          - apiGroups:
+              - operator.shipwright.io
+            resources:
+              - shipwrightbuilds
+            verbs:
+              - create
+              - delete
+              - get
+              - list
+              - patch
+              - update
+              - watch
+          - apiGroups:
+              - operator.shipwright.io
+            resources:
+              - shipwrightbuilds/finalizers
+            verbs:
+              - update
+          - apiGroups:
+              - operator.shipwright.io
+            resources:
+              - shipwrightbuilds/status
+            verbs:
+              - get
+              - patch
+              - update
+          - apiGroups:
+              - operator.tekton.dev
+            resources:
+              - tektonconfigs
+            verbs:
+              - create
+              - get
+              - list
+          - apiGroups:
+              - policy
+            resources:
+              - poddisruptionbudgets
+            verbs:
+              - create
+              - delete
+              - get
+              - list
+              - update
+              - watch
+          - apiGroups:
+              - rbac.authorization.k8s.io
+            resources:
+              - clusterrolebindings
+            verbs:
+              - create
+              - get
+              - list
+              - watch
+          - apiGroups:
+              - rbac.authorization.k8s.io
+            resourceNames:
+              - shipwright-build-controller
+            resources:
+              - clusterrolebindings
+            verbs:
+              - delete
+              - patch
+              - update
+          - apiGroups:
+              - rbac.authorization.k8s.io
+            resourceNames:
+              - shipwright-build-webhook
+            resources:
+              - clusterrolebindings
+            verbs:
+              - delete
+              - patch
+              - update
+          - apiGroups:
+              - rbac.authorization.k8s.io
+            resources:
+              - clusterrolebindings
+              - clusterroles
+              - rolebindings
+              - roles
+            verbs:
+              - create
+              - delete
+              - get
+              - list
+              - update
+              - watch
+          - apiGroups:
+              - rbac.authorization.k8s.io
+            resources:
+              - clusterroles
+            verbs:
+              - create
+              - get
+              - list
+              - watch
+          - apiGroups:
+              - rbac.authorization.k8s.io
+            resourceNames:
+              - shipwright-build-aggregate-edit
+            resources:
+              - clusterroles
+            verbs:
+              - delete
+              - patch
+              - update
+          - apiGroups:
+              - rbac.authorization.k8s.io
+            resourceNames:
+              - shipwright-build-aggregate-view
+            resources:
+              - clusterroles
+            verbs:
+              - delete
+              - patch
+              - update
+          - apiGroups:
+              - rbac.authorization.k8s.io
+            resourceNames:
+              - shipwright-build-controller
+            resources:
+              - clusterroles
+            verbs:
+              - delete
+              - patch
+              - update
+          - apiGroups:
+              - rbac.authorization.k8s.io
+            resourceNames:
+              - shipwright-build-webhook
+            resources:
+              - clusterroles
+            verbs:
+              - delete
+              - patch
+              - update
+          - apiGroups:
+              - rbac.authorization.k8s.io
+            resources:
+              - rolebindings
+            verbs:
+              - create
+              - get
+              - list
+              - watch
+          - apiGroups:
+              - rbac.authorization.k8s.io
+            resourceNames:
+              - shipwright-build-controller
+            resources:
+              - rolebindings
+            verbs:
+              - delete
+              - patch
+              - update
+          - apiGroups:
+              - rbac.authorization.k8s.io
+            resourceNames:
+              - shipwright-build-webhook
+            resources:
+              - rolebindings
+            verbs:
+              - delete
+              - patch
+              - update
+          - apiGroups:
+              - rbac.authorization.k8s.io
+            resources:
+              - roles
+            verbs:
+              - create
+              - get
+              - list
+              - watch
+          - apiGroups:
+              - rbac.authorization.k8s.io
+            resourceNames:
+              - shipwright-build-controller
+            resources:
+              - roles
+            verbs:
+              - delete
+              - patch
+              - update
+          - apiGroups:
+              - rbac.authorization.k8s.io
+            resourceNames:
+              - shipwright-build-webhook
+            resources:
+              - roles
+            verbs:
+              - delete
+              - patch
+              - update
+          - apiGroups:
+              - security.openshift.io
+            resourceNames:
+              - privileged
+            resources:
+              - securitycontextconstraints
+            verbs:
+              - use
+          - apiGroups:
+              - sharedresource.openshift.io
+            resources:
+              - sharedconfigmaps
+              - sharedsecrets
+            verbs:
+              - get
+              - list
+              - watch
+          - apiGroups:
+              - shipwright.io
+            resources:
+              - clusterbuildstrategies
+            verbs:
+              - create
+              - delete
+              - get
+              - list
+              - patch
+              - update
+              - watch
+          - apiGroups:
+              - storage.k8s.io
+            resources:
+              - csidrivers
+            verbs:
+              - create
+              - delete
+              - get
+              - list
+              - patch
+              - update
+              - watch
+          - apiGroups:
+              - authentication.k8s.io
+            resources:
+              - tokenreviews
+            verbs:
+              - create
+          - apiGroups:
+              - authorization.k8s.io
+            resources:
+              - subjectaccessreviews
+            verbs:
+              - create
           serviceAccountName: openshift-builds-operator
       deployments:
         - label:

--- a/config/rbac/shipwright_build_controller_role.yaml
+++ b/config/rbac/shipwright_build_controller_role.yaml
@@ -50,3 +50,6 @@ rules:
   - apiGroups: ['']
     resources: ['serviceaccounts']
     verbs: ['get', 'list', 'watch', 'create', 'update', 'delete']
+  - apiGroups: ['apiextensions.k8s.io']
+    resources: ['customresourcedefinitions', 'customresourcedefinitions/status']
+    verbs: ['get', 'patch']


### PR DESCRIPTION
Changes:
- RBAC permissions fixed since the operator was not able to create the required resources. This has changed in the new release for Shipwright v0.14.