### PR TITLE
Remove node selector from shared resource webhook deployment

### DIFF
--- a/config/sharedresource/webhook_deployment.yaml
+++ b/config/sharedresource/webhook_deployment.yaml
@@ -51,8 +51,6 @@ spec:
         terminationMessagePolicy: FallbackToLogsOnError
       priorityClassName: system-cluster-critical
       serviceAccountName: shared-resource-csi-driver-webhook
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       tolerations:
       - key: CriticalAddonsOnly
         operator: Exists


### PR DESCRIPTION
Changes:
- Remove "node-selector" from shared resource webhook deployment.