### PR TITLE
Update pipeline ref for bundle 

### DIFF
--- a/.tekton/openshift-builds-operator-bundle-pull-request.yaml
+++ b/.tekton/openshift-builds-operator-bundle-pull-request.yaml
@@ -52,7 +52,7 @@ spec:
       - name: revision
         value: main
       - name: pathInRepo
-        value: /pipelines/konflux-build-multi-platform.yaml
+        value: /pipelines/konflux-build-bundle.yaml
   taskRunTemplate: {}
   workspaces:
   - name: git-auth

--- a/.tekton/openshift-builds-operator-bundle-push.yaml
+++ b/.tekton/openshift-builds-operator-bundle-push.yaml
@@ -51,7 +51,7 @@ spec:
       - name: revision
         value: main
       - name: pathInRepo
-        value: /pipelines/konflux-build-multi-platform.yaml
+        value: /pipelines/konflux-build-bundle.yaml
   taskRunTemplate: {}
   workspaces:
   - name: git-auth

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/ubi-micro@sha256:d115f8aad9c4ae7ee21ae75bbcb3dc2c5dbf9b57bf6dad6dcb5aac5c02003bde
+FROM scratch
 
 LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
 LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/


### PR DESCRIPTION
## Changes

- updates pipeline ref based on this PR - https://github.com/redhat-openshift-builds/release/pull/19. 
It adds New pipelines with ecosystem-cert-preflight-checks removed since an operator bundle doesn't need it. This solves Conforma check for skipped check.