### PR TITLE
Update security-context with readOnlyRootFilesystem: true to Mount root filesystem as read-only in Shared Resources containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,16 @@
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.23 AS builder
+FROM registry.redhat.io/ubi9/go-toolset AS builder
 
 COPY . .
 
 ENV GOEXPERIMENT=strictfipsruntime
 
-RUN CGO_ENABLED=1 GO111MODULE=on go build -a -mod vendor -tags strictfipsruntime -o operator cmd/main.go
+RUN CGO_ENABLED=1 GO111MODULE=on go build -a -mod vendor -tags strictfipsruntime -o /tmp/operator cmd/main.go
 
 FROM registry.redhat.io/ubi9/ubi-minimal@sha256:ac61c96b93894b9169221e87718733354dd3765dd4a62b275893c7ff0d876869
 
 WORKDIR /
 
-COPY --from=builder /operator .
+COPY --from=builder /tmp/operator .
 COPY config/shipwright/ config/shipwright/
 COPY config/sharedresource/ config/sharedresource/
 COPY LICENSE /licenses/

--- a/config/sharedresource/node_daemonset.yaml
+++ b/config/sharedresource/node_daemonset.yaml
@@ -33,6 +33,7 @@ spec:
             # non-privileged sidecar containers cannot access unix domain socket
             # created by privileged CSI driver container.
             privileged: true
+            readOnlyRootFilesystem: true
           env:
             - name: KUBE_NODE_NAME
               valueFrom:
@@ -74,6 +75,7 @@ spec:
                   fieldPath: spec.nodeName
           securityContext:
             privileged: true
+            readOnlyRootFilesystem: true
           ports:
             - containerPort: 9898
               name: healthz

--- a/config/sharedresource/webhook_deployment.yaml
+++ b/config/sharedresource/webhook_deployment.yaml
@@ -35,6 +35,8 @@ spec:
             value: ""
           - name: RESERVED_SHARED_SECRET_NAMES
             value: "openshift-etc-pki-entitlement: openshift-config-managed:etc-pki-entitlement"
+        securityContext:
+          readOnlyRootFilesystem: true
         volumeMounts:
         - name: trusted-ca-bundle
           mountPath: /etc/pki/tls/certs/


### PR DESCRIPTION
Added security-context with readOnlyRootFilesystem: true to node_daemonset.yaml and webhook_deployment.yaml for the shared-resource containers in openshift-builds namespace.

To test the changes, 

oc exec -it <shared-resource-pod-name> -n openshift-builds -c node-driver-registrar -- /bin/sh 

touch /test_sr-node_readonly.txt -> This will give error -> touch: cannot touch '/test_sr-node_readonly.txt': Read-only file system -> Proves the changes are in place

Similarly for other containers:

oc exec -it <shared-resource-pod-name> -n openshift-builds -c hostpath -- /bin/sh 

touch /test_sr-hostpath_readonly.txt -> This will give error -> touch: cannot touch '/test_sr-hostpath_readonly.txt': Read-only file system -> Proves the changes are in place

oc exec -it <shared-resource-csi-driver-webhook-name> -n openshift-builds -c shared-resource-csi-driver-webhook -- /bin/sh

touch /test_webhook_readonly.txt -> This will give error -> touch: cannot touch '/test_webhook_readonly.txt': Read-only file system -> Proves the changes are in place