### PR TITLE
Add shp cli download links as a new CR

### DIFF
--- a/bundle/manifests/openshift-builds-shp-cli-download_console.openshift.io_v1_consoleclidownload.yaml
+++ b/bundle/manifests/openshift-builds-shp-cli-download_console.openshift.io_v1_consoleclidownload.yaml
@@ -1,0 +1,15 @@
+apiVersion: console.openshift.io/v1
+kind: ConsoleCLIDownload
+metadata:
+  name: openshift-builds-shp-cli-download
+spec:
+  description: |
+    The Openshift Builds cli `shp` allows you to manage Openshift Builds resources.
+  displayName: shp - Openshift Builds Command Line Interface (CLI)
+  links:
+  - href: https://developers.redhat.com/content-gateway/file/pub/openshift-v4/clients/openshift-builds/1.3.0-258/shp-linux-amd64.tar.gz
+    text: Download shp for Linux x86_64
+  - href: https://developers.redhat.com/content-gateway/file/pub/openshift-v4/clients/openshift-builds/1.3.0-258/shp-darwin-amd64.tar.gz
+    text: Download shp for Mac x86_64
+  - href: https://developers.redhat.com/content-gateway/file/pub/openshift-v4/clients/openshift-builds/1.3.0-258/shp-windows-amd64.zip
+    text: Download shp for Windows x86_64

--- a/config/manifests/kustomization.yaml
+++ b/config/manifests/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
 - ../default
 - ../samples
 - ../scorecard
+- ../shipwright
 
 # [WEBHOOK] To enable webhooks, uncomment all the sections with [WEBHOOK] prefix.
 # Do NOT uncomment sections with prefix [CERTMANAGER], as OLM does not support cert-manager.

--- a/config/shipwright/cli/kustomization.yaml
+++ b/config/shipwright/cli/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+- shpclidownload.yaml

--- a/config/shipwright/cli/shpclidownload.yaml
+++ b/config/shipwright/cli/shpclidownload.yaml
@@ -1,0 +1,15 @@
+apiVersion: console.openshift.io/v1
+kind: ConsoleCLIDownload
+metadata:
+  name: openshift-builds-shp-cli-download
+spec:
+  description: |
+    The Openshift Builds cli `shp` allows you to manage Openshift Builds resources.
+  displayName: shp - Openshift Builds Command Line Interface (CLI)
+  links:
+  - href: 'https://developers.redhat.com/content-gateway/file/pub/openshift-v4/clients/openshift-builds/1.3.0-258/shp-linux-amd64.tar.gz'
+    text: Download shp for Linux x86_64
+  - href: 'https://developers.redhat.com/content-gateway/file/pub/openshift-v4/clients/openshift-builds/1.3.0-258/shp-darwin-amd64.tar.gz'
+    text: Download shp for Mac x86_64
+  - href: 'https://developers.redhat.com/content-gateway/file/pub/openshift-v4/clients/openshift-builds/1.3.0-258/shp-windows-amd64.zip'
+    text: Download shp for Windows x86_64

--- a/config/shipwright/kustomization.yaml
+++ b/config/shipwright/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+- cli


### PR DESCRIPTION
## Changes

- This PR adds a new custom resource - ConsoleCLIDownlaod 
- This custom resource will list download links for shp cli on the console
- fixes [Build-1363](https://issues.redhat.com/browse/BUILD-1363)

## How to test

Run this command `./bin/kustomize build config/manifests | ./bin/operator-sdk generate bundle --overwrite=false --version 1.2.0 --output-dir bundle-new`

This should add `openshift-builds-shp-cli-download_console.openshift.io_v1_consoleclidownload.yaml` file in the new folder