### PR TITLE
BUILD-1430: mount rootFilesystem as read-only

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -56,6 +56,7 @@ spec:
         # versions < 1.19 or on vendors versions which do NOT support this field by default (i.e. Openshift < 4.11 ).
         # seccompProfile:
         #   type: RuntimeDefault
+        readOnlyRootFilesystem: true
       containers:
       - command:
         - /operator


### PR DESCRIPTION
## Changes

- for security best practices, operator should mount any root filesystem as readonly

