### PR TITLE
added securitycontext and workingdir

### DIFF
--- a/config/sharedresource/node_daemonset.yaml
+++ b/config/sharedresource/node_daemonset.yaml
@@ -33,6 +33,7 @@ spec:
             # non-privileged sidecar containers cannot access unix domain socket
             # created by privileged CSI driver container.
             privileged: true
+            readOnlyRootFilesystem: true
           env:
             - name: KUBE_NODE_NAME
               valueFrom:
@@ -55,6 +56,7 @@ spec:
           image: registry.redhat.io/openshift-builds/openshift-builds-shared-resource-rhel9@sha256:4360777eae5222b4828dec01591520c500e3c8db8fe7d28168b231e7ad724336
           # for development purposes; eventually switch to IfNotPresent
           imagePullPolicy: IfNotPresent
+          workingDir: /run/csi-data-dir 
           command:
             - /openshift-builds-shared-resource
           args:
@@ -74,6 +76,7 @@ spec:
                   fieldPath: spec.nodeName
           securityContext:
             privileged: true
+            readOnlyRootFilesystem: true
           ports:
             - containerPort: 9898
               name: healthz

--- a/config/sharedresource/webhook_deployment.yaml
+++ b/config/sharedresource/webhook_deployment.yaml
@@ -35,6 +35,8 @@ spec:
             value: ""
           - name: RESERVED_SHARED_SECRET_NAMES
             value: "openshift-etc-pki-entitlement: openshift-config-managed:etc-pki-entitlement"
+        securityContext:
+          readOnlyRootFilesystem: true
         volumeMounts:
         - name: trusted-ca-bundle
           mountPath: /etc/pki/tls/certs/


### PR DESCRIPTION
- Added `workingDir: /run/csi-data-dir` to the `hostpath` container within the `shared-resource-csi-driver-node` DaemonSet
 
- This change sets `/run/csi-data-dir`—a `hostPath` mounted from the host's writable `tmpfs` (RAM-backed ephemeral storage) specifically intended for the CSI driver's data operations—as the default starting directory for the driver's main process. 
 
- When the CSI driver needs to create staging directories for shared secrets, these operations are now correctly rooted within this designated writable `hostPath`. This change does not introduce any security vulnerabilities primarily because the container already runs as `privileged: true` and already had this specific `hostPath` mounted; the `workingDir` setting doesn't grant additional access to new host paths or escalate its existing privileges. 

- It's a functional fix that ensures the driver's necessary write operations occur in an appropriate, intended, and ephemeral location on the host, allowing it to function correctly while the container's base image remains protected by `readOnlyRootFilesystem: true`.