### PR TITLE
Fix bundle generation with relatedImages

### DIFF
--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -25,7 +25,8 @@ LABEL com.redhat.openshift.versions="v4.14-v4.18" \
     summary="Red Hat OpenShift Builds Operator Bundle" \
     url="https://catalog.redhat.com/software/containers/openshift-builds/openshift-builds-operator-bundle" \
     vendor="Red Hat, Inc." \
-    version="v1.3.0"
+    version="1.4.0" \
+    release="1.4.0"
 
 COPY bundle/ /
 COPY LICENSE /licenses/

--- a/bundle/manifests/openshift-builds-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/openshift-builds-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -4,7 +4,7 @@ metadata:
   creationTimestamp: null
   labels:
     app.kubernetes.io/part-of: openshift-builds
-    app.kubernetes.io/version: v1.2.0
+    app.kubernetes.io/version: 1.4.0
   name: openshift-builds-metrics-reader
 rules:
 - nonResourceURLs:

--- a/bundle/manifests/openshift-builds-operator-metrics_v1_service.yaml
+++ b/bundle/manifests/openshift-builds-operator-metrics_v1_service.yaml
@@ -4,7 +4,7 @@ metadata:
   creationTimestamp: null
   labels:
     app.kubernetes.io/part-of: openshift-builds
-    app.kubernetes.io/version: v1.2.0
+    app.kubernetes.io/version: 1.4.0
   name: openshift-builds-operator-metrics
 spec:
   ports:

--- a/bundle/manifests/openshift-builds-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/openshift-builds-operator.clusterserviceversion.yaml
@@ -36,7 +36,7 @@ metadata:
     categories: Developer Tools, Integration & Delivery
     certified: "true"
     containerImage: registry.redhat.io/openshift-builds/openshift-builds-operator-rhel9
-    createdAt: "2024-11-15T22:28:01Z"
+    createdAt: "2025-05-26T12:57:44Z"
     description: Builds for Red Hat OpenShift is a framework for building container images on Kubernetes.
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
@@ -51,7 +51,7 @@ metadata:
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-builds
     operators.openshift.io/valid-subscription: '["OpenShift Container Platform", "OpenShift Platform Plus"]'
-    operators.operatorframework.io/builder: operator-sdk-v1.35.0
+    operators.operatorframework.io/builder: operator-sdk-v1.39.2
     operators.operatorframework.io/internal-objects: '["openshiftbuilds.operator.openshift.io","shipwrightbuilds.operator.shipwright.io"]'
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
     repository: https://github.com/shipwright-io/operator
@@ -67,7 +67,9 @@ spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
-      - description: OpenShiftBuild describes the desired state of Builds for OpenShift, and the status of all deployed components.
+      - description: |-
+          OpenShiftBuild describes the desired state of Builds for OpenShift, and the status of
+          all deployed components.
         displayName: Open Shift Build
         kind: OpenShiftBuild
         name: openshiftbuilds.operator.openshift.io
@@ -91,729 +93,585 @@ spec:
     spec:
       clusterPermissions:
         - rules:
-          - apiGroups:
-              - shipwright.io
-            resources:
-              - clusterbuildstrategies
-            verbs:
-              - get
-              - list
-              - watch
-          - apiGroups:
-              - shipwright.io
-            resources:
-              - buildstrategies
-            verbs:
-              - get
-              - list
-              - watch
-              - create
-              - update
-              - patch
-              - delete
-          - apiGroups:
-              - shipwright.io
-            resources:
-              - builds
-            verbs:
-              - get
-              - list
-              - watch
-              - create
-              - update
-              - patch
-              - delete
-          - apiGroups:
-              - shipwright.io
-            resources:
-              - buildruns
-            verbs:
-              - get
-              - list
-              - watch
-              - create
-              - update
-              - patch
-              - delete
-          - apiGroups:
-              - shipwright.io
-            resources:
-              - buildruns
-            verbs:
-              - get
-              - list
-              - watch
-              - update
-              - delete
-          - apiGroups:
-              - shipwright.io
-            resources:
-              - buildruns/finalizers
-            verbs:
-              - update
-          - apiGroups:
-              - shipwright.io
-            resources:
-              - buildruns/status
-            verbs:
-              - update
-          - apiGroups:
-              - shipwright.io
-            resources:
-              - builds
-            verbs:
-              - get
-              - list
-              - watch
-          - apiGroups:
-              - shipwright.io
-            resources:
-              - builds/finalizers
-            verbs:
-              - update
-          - apiGroups:
-              - shipwright.io
-            resources:
-              - builds/status
-            verbs:
-              - update
-          - apiGroups:
-              - shipwright.io
-            resources:
-              - buildstrategies
-            verbs:
-              - get
-              - list
-              - watch
-          - apiGroups:
-              - shipwright.io
-            resources:
-              - clusterbuildstrategies
-            verbs:
-              - get
-              - list
-              - watch
-          - apiGroups:
-              - tekton.dev
-            resources:
-              - taskruns
-            verbs:
-              - get
-              - list
-              - watch
-              - create
-              - delete
-              - patch
-          - apiGroups:
-              - ""
-            resources:
-              - pods
-            verbs:
-              - get
-              - list
-              - watch
-          - apiGroups:
-              - ""
-            resources:
-              - secrets
-            verbs:
-              - get
-              - list
-              - watch
-          - apiGroups:
-              - ""
-            resources:
-              - configmaps
-            verbs:
-              - list
-          - apiGroups:
-              - ""
-            resources:
-              - serviceaccounts
-            verbs:
-              - get
-              - list
-              - watch
-              - create
-              - update
-              - delete
-          - apiGroups:
-              - ""
-            resources:
-              - configmaps
-            verbs:
-              - get
-              - create
-              - update
-          - apiGroups:
-              - coordination.k8s.io
-            resources:
-              - leases
-            verbs:
-              - create
-              - get
-              - update
-          - apiGroups:
-              - ""
-            resources:
-              - events
-            verbs:
-              - create
-          - apiGroups:
-              - ""
-            resources:
-              - pods
-              - events
-              - configmaps
-              - secrets
-              - limitranges
-              - namespaces
-              - services
-            verbs:
-              - '*'
-          - apiGroups:
-              - admissionregistration.k8s.io
-              - admissionregistration.k8s.io/v1beta1
-            resources:
-              - validatingwebhookconfigurations
-            verbs:
-              - '*'
-          - apiGroups:
-              - ""
-            resources:
-              - endpoints
-            verbs:
-              - get
-              - list
-              - watch
-          - apiGroups:
-              - ""
-            resources:
-              - events
-              - services
-            verbs:
-              - create
-              - delete
-              - get
-              - list
-              - patch
-              - update
-              - watch
-          - apiGroups:
-              - admissionregistration.k8s.io
-            resources:
-              - validatingwebhookconfigurations
-            verbs:
-              - create
-              - delete
-              - get
-              - list
-              - patch
-              - update
-              - watch
-          - apiGroups:
-              - admissionregistration.k8s.io/v1beta1
-            resources:
-              - validatingwebhookconfigurations
-            verbs:
-              - create
-              - delete
-              - get
-              - list
-              - patch
-              - update
-              - watch
-          - apiGroups:
-              - apiextensions.k8s.io
-            resources:
-              - customresourcedefinitions
-              - customresourcedefinitions/status
-            verbs:
-              - get
-              - patch
-          - apiGroups:
-              - apiextensions.k8s.io
-            resources:
-              - customresourcedefinitions
-            verbs:
-              - create
-              - get
-              - list
-              - watch
-          - apiGroups:
-              - apiextensions.k8s.io
-            resourceNames:
-              - buildruns.shipwright.io
-              - builds.shipwright.io
-              - buildstrategies.shipwright.io
-              - clusterbuildstrategies.shipwright.io
-            resources:
-              - customresourcedefinitions
-            verbs:
-              - delete
-              - patch
-              - update
-          - apiGroups:
-              - apiextensions.k8s.io
-            resourceNames:
-              - sharedconfigmaps.sharedresource.openshift.io
-              - sharedsecrets.sharedresource.openshift.io
-            resources:
-              - customresourcedefinitions
-            verbs:
-              - create
-              - delete
-              - get
-              - list
-              - patch
-              - update
-              - watch
-          - apiGroups:
-              - apps
-            resources:
-              - daemonsets
-            verbs:
-              - create
-              - delete
-              - get
-              - list
-              - update
-              - watch
-          - apiGroups:
-              - apps
-            resources:
-              - deployments
-            verbs:
-              - create
-              - delete
-              - get
-              - list
-              - update
-              - watch
-          - apiGroups:
-              - apps
-            resourceNames:
-              - shipwright-build-controller
-            resources:
-              - deployments
-            verbs:
-              - delete
-              - patch
-              - update
-          - apiGroups:
-              - apps
-            resourceNames:
-              - shipwright-build-webhook
-            resources:
-              - deployments
-            verbs:
-              - delete
-              - patch
-              - update
-          - apiGroups:
-              - apps
-            resourceNames:
-              - shipwright-build-controller
-            resources:
-              - deployments/finalizers
-            verbs:
-              - update
-          - apiGroups:
-              - apps
-            resourceNames:
-              - shipwright-build-webhook
-            resources:
-              - deployments/finalizers
-            verbs:
-              - update
-          - apiGroups:
-              - cert-manager.io
-            resources:
-              - certificates
-            verbs:
-              - create
-              - get
-              - list
-              - watch
-          - apiGroups:
-              - cert-manager.io
-            resourceNames:
-              - shipwright-build-webhook-cert
-            resources:
-              - certificates
-            verbs:
-              - delete
-              - patch
-              - update
-          - apiGroups:
-              - cert-manager.io
-            resources:
-              - issuers
-            verbs:
-              - create
-              - get
-              - list
-              - watch
-          - apiGroups:
-              - cert-manager.io
-            resourceNames:
-              - selfsigned-issuer
-            resources:
-              - issuers
-            verbs:
-              - delete
-              - patch
-              - update
-          - apiGroups:
-              - ""
-            resources:
-              - configmaps
-              - events
-              - limitranges
-              - namespaces
-              - pods
-              - secrets
-              - services
-            verbs:
-              - create
-              - delete
-              - get
-              - list
-              - patch
-              - update
-              - watch
-          - apiGroups:
-              - ""
-            resources:
-              - namespaces
-            verbs:
-              - create
-              - delete
-              - get
-              - list
-              - patch
-              - update
-              - watch
-          - apiGroups:
-              - ""
-            resources:
-              - serviceaccounts
-            verbs:
-              - create
-              - get
-              - list
-              - watch
-          - apiGroups:
-              - ""
-            resourceNames:
-              - shipwright-build-controller
-            resources:
-              - serviceaccounts
-            verbs:
-              - delete
-              - patch
-              - update
-          - apiGroups:
-              - ""
-            resourceNames:
-              - shipwright-build-webhook
-            resources:
-              - serviceaccounts
-            verbs:
-              - delete
-              - patch
-              - update
-          - apiGroups:
-              - monitoring.coreos.com
-            resources:
-              - servicemonitors
-            verbs:
-              - create
-              - delete
-              - get
-              - list
-              - update
-              - watch
-          - apiGroups:
-              - operator.openshift.io
-            resources:
-              - openshiftbuilds
-            verbs:
-              - create
-              - delete
-              - get
-              - list
-              - patch
-              - update
-              - watch
-          - apiGroups:
-              - operator.openshift.io
-            resources:
-              - openshiftbuilds/finalizers
-            verbs:
-              - update
-          - apiGroups:
-              - operator.openshift.io
-            resources:
-              - openshiftbuilds/status
-            verbs:
-              - get
-              - patch
-              - update
-          - apiGroups:
-              - operator.shipwright.io
-            resources:
-              - shipwrightbuilds
-            verbs:
-              - create
-              - delete
-              - get
-              - list
-              - patch
-              - update
-              - watch
-          - apiGroups:
-              - operator.shipwright.io
-            resources:
-              - shipwrightbuilds/finalizers
-            verbs:
-              - update
-          - apiGroups:
-              - operator.shipwright.io
-            resources:
-              - shipwrightbuilds/status
-            verbs:
-              - get
-              - patch
-              - update
-          - apiGroups:
-              - operator.tekton.dev
-            resources:
-              - tektonconfigs
-            verbs:
-              - create
-              - get
-              - list
-          - apiGroups:
-              - policy
-            resources:
-              - poddisruptionbudgets
-            verbs:
-              - create
-              - delete
-              - get
-              - list
-              - update
-              - watch
-          - apiGroups:
-              - rbac.authorization.k8s.io
-            resources:
-              - clusterrolebindings
-            verbs:
-              - create
-              - get
-              - list
-              - watch
-          - apiGroups:
-              - rbac.authorization.k8s.io
-            resourceNames:
-              - shipwright-build-controller
-            resources:
-              - clusterrolebindings
-            verbs:
-              - delete
-              - patch
-              - update
-          - apiGroups:
-              - rbac.authorization.k8s.io
-            resourceNames:
-              - shipwright-build-webhook
-            resources:
-              - clusterrolebindings
-            verbs:
-              - delete
-              - patch
-              - update
-          - apiGroups:
-              - rbac.authorization.k8s.io
-            resources:
-              - clusterrolebindings
-              - clusterroles
-              - rolebindings
-              - roles
-            verbs:
-              - create
-              - delete
-              - get
-              - list
-              - update
-              - watch
-          - apiGroups:
-              - rbac.authorization.k8s.io
-            resources:
-              - clusterroles
-            verbs:
-              - create
-              - get
-              - list
-              - watch
-          - apiGroups:
-              - rbac.authorization.k8s.io
-            resourceNames:
-              - shipwright-build-aggregate-edit
-            resources:
-              - clusterroles
-            verbs:
-              - delete
-              - patch
-              - update
-          - apiGroups:
-              - rbac.authorization.k8s.io
-            resourceNames:
-              - shipwright-build-aggregate-view
-            resources:
-              - clusterroles
-            verbs:
-              - delete
-              - patch
-              - update
-          - apiGroups:
-              - rbac.authorization.k8s.io
-            resourceNames:
-              - shipwright-build-controller
-            resources:
-              - clusterroles
-            verbs:
-              - delete
-              - patch
-              - update
-          - apiGroups:
-              - rbac.authorization.k8s.io
-            resourceNames:
-              - shipwright-build-webhook
-            resources:
-              - clusterroles
-            verbs:
-              - delete
-              - patch
-              - update
-          - apiGroups:
-              - rbac.authorization.k8s.io
-            resources:
-              - rolebindings
-            verbs:
-              - create
-              - get
-              - list
-              - watch
-          - apiGroups:
-              - rbac.authorization.k8s.io
-            resourceNames:
-              - shipwright-build-controller
-            resources:
-              - rolebindings
-            verbs:
-              - delete
-              - patch
-              - update
-          - apiGroups:
-              - rbac.authorization.k8s.io
-            resourceNames:
-              - shipwright-build-webhook
-            resources:
-              - rolebindings
-            verbs:
-              - delete
-              - patch
-              - update
-          - apiGroups:
-              - rbac.authorization.k8s.io
-            resources:
-              - roles
-            verbs:
-              - create
-              - get
-              - list
-              - watch
-          - apiGroups:
-              - rbac.authorization.k8s.io
-            resourceNames:
-              - shipwright-build-controller
-            resources:
-              - roles
-            verbs:
-              - delete
-              - patch
-              - update
-          - apiGroups:
-              - rbac.authorization.k8s.io
-            resourceNames:
-              - shipwright-build-webhook
-            resources:
-              - roles
-            verbs:
-              - delete
-              - patch
-              - update
-          - apiGroups:
-              - security.openshift.io
-            resourceNames:
-              - privileged
-            resources:
-              - securitycontextconstraints
-            verbs:
-              - use
-          - apiGroups:
-              - sharedresource.openshift.io
-            resources:
-              - sharedconfigmaps
-              - sharedsecrets
-            verbs:
-              - get
-              - list
-              - watch
-          - apiGroups:
-              - shipwright.io
-            resources:
-              - clusterbuildstrategies
-            verbs:
-              - create
-              - delete
-              - get
-              - list
-              - patch
-              - update
-              - watch
-          - apiGroups:
-              - storage.k8s.io
-            resources:
-              - csidrivers
-            verbs:
-              - create
-              - delete
-              - get
-              - list
-              - patch
-              - update
-              - watch
-          - apiGroups:
-              - authentication.k8s.io
-            resources:
-              - tokenreviews
-            verbs:
-              - create
-          - apiGroups:
-              - authorization.k8s.io
-            resources:
-              - subjectaccessreviews
-            verbs:
-              - create
+            - apiGroups:
+                - shipwright.io
+              resources:
+                - clusterbuildstrategies
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - shipwright.io
+              resources:
+                - buildstrategies
+              verbs:
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - patch
+                - delete
+            - apiGroups:
+                - shipwright.io
+              resources:
+                - builds
+              verbs:
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - patch
+                - delete
+            - apiGroups:
+                - shipwright.io
+              resources:
+                - buildruns
+              verbs:
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - patch
+                - delete
+            - apiGroups:
+                - shipwright.io
+              resources:
+                - buildruns
+              verbs:
+                - get
+                - list
+                - watch
+                - update
+                - delete
+            - apiGroups:
+                - shipwright.io
+              resources:
+                - buildruns/finalizers
+              verbs:
+                - update
+            - apiGroups:
+                - shipwright.io
+              resources:
+                - buildruns/status
+              verbs:
+                - update
+            - apiGroups:
+                - shipwright.io
+              resources:
+                - builds
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - shipwright.io
+              resources:
+                - builds/finalizers
+              verbs:
+                - update
+            - apiGroups:
+                - shipwright.io
+              resources:
+                - builds/status
+              verbs:
+                - update
+            - apiGroups:
+                - shipwright.io
+              resources:
+                - buildstrategies
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - shipwright.io
+              resources:
+                - clusterbuildstrategies
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - tekton.dev
+              resources:
+                - taskruns
+              verbs:
+                - get
+                - list
+                - watch
+                - create
+                - delete
+                - patch
+            - apiGroups:
+                - ""
+              resources:
+                - pods
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - ""
+              resources:
+                - secrets
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - ""
+              resources:
+                - configmaps
+              verbs:
+                - list
+            - apiGroups:
+                - ""
+              resources:
+                - serviceaccounts
+              verbs:
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - delete
+            - apiGroups:
+                - apiextensions.k8s.io
+              resources:
+                - customresourcedefinitions
+                - customresourcedefinitions/status
+              verbs:
+                - get
+                - patch
+            - apiGroups:
+                - ""
+              resources:
+                - configmaps
+              verbs:
+                - get
+                - create
+                - update
+            - apiGroups:
+                - coordination.k8s.io
+              resources:
+                - leases
+              verbs:
+                - create
+                - get
+                - update
+            - apiGroups:
+                - ""
+              resources:
+                - events
+              verbs:
+                - create
+            - apiGroups:
+                - ""
+              resources:
+                - pods
+                - events
+                - configmaps
+                - secrets
+                - limitranges
+                - namespaces
+                - services
+              verbs:
+                - '*'
+            - apiGroups:
+                - admissionregistration.k8s.io
+                - admissionregistration.k8s.io/v1beta1
+              resources:
+                - validatingwebhookconfigurations
+              verbs:
+                - '*'
+            - apiGroups:
+                - ""
+              resources:
+                - configmaps
+                - events
+                - limitranges
+                - namespaces
+                - pods
+                - secrets
+                - services
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - ""
+              resources:
+                - endpoints
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - ""
+              resources:
+                - serviceaccounts
+              verbs:
+                - create
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - ""
+              resourceNames:
+                - shipwright-build-controller
+              resources:
+                - serviceaccounts
+              verbs:
+                - delete
+                - patch
+                - update
+            - apiGroups:
+                - ""
+              resourceNames:
+                - shipwright-build-webhook
+              resources:
+                - serviceaccounts
+              verbs:
+                - delete
+                - patch
+                - update
+            - apiGroups:
+                - admissionregistration.k8s.io
+                - admissionregistration.k8s.io/v1beta1
+              resources:
+                - validatingwebhookconfigurations
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - apiextensions.k8s.io
+              resources:
+                - customresourcedefinitions
+              verbs:
+                - create
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - apiextensions.k8s.io
+              resourceNames:
+                - buildruns.shipwright.io
+                - builds.shipwright.io
+                - buildstrategies.shipwright.io
+                - clusterbuildstrategies.shipwright.io
+              resources:
+                - customresourcedefinitions
+              verbs:
+                - delete
+                - patch
+                - update
+            - apiGroups:
+                - apiextensions.k8s.io
+              resourceNames:
+                - sharedconfigmaps.sharedresource.openshift.io
+                - sharedsecrets.sharedresource.openshift.io
+              resources:
+                - customresourcedefinitions
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - apps
+              resources:
+                - daemonsets
+                - deployments
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - update
+                - watch
+            - apiGroups:
+                - apps
+              resourceNames:
+                - shipwright-build-controller
+              resources:
+                - deployments
+              verbs:
+                - delete
+                - patch
+                - update
+            - apiGroups:
+                - apps
+              resourceNames:
+                - shipwright-build-webhook
+              resources:
+                - deployments
+              verbs:
+                - delete
+                - patch
+                - update
+            - apiGroups:
+                - apps
+              resourceNames:
+                - shipwright-build-controller
+              resources:
+                - deployments/finalizers
+              verbs:
+                - update
+            - apiGroups:
+                - apps
+              resourceNames:
+                - shipwright-build-webhook
+              resources:
+                - deployments/finalizers
+              verbs:
+                - update
+            - apiGroups:
+                - cert-manager.io
+              resourceNames:
+                - shipwright-build-webhook-cert
+              resources:
+                - certificates
+              verbs:
+                - delete
+                - patch
+                - update
+            - apiGroups:
+                - cert-manager.io
+              resources:
+                - certificates
+                - issuers
+              verbs:
+                - create
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - cert-manager.io
+              resourceNames:
+                - selfsigned-issuer
+              resources:
+                - issuers
+              verbs:
+                - delete
+                - patch
+                - update
+            - apiGroups:
+                - monitoring.coreos.com
+              resources:
+                - servicemonitors
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - update
+                - watch
+            - apiGroups:
+                - operator.openshift.io
+              resources:
+                - openshiftbuilds
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - operator.openshift.io
+              resources:
+                - openshiftbuilds/finalizers
+              verbs:
+                - update
+            - apiGroups:
+                - operator.openshift.io
+              resources:
+                - openshiftbuilds/status
+              verbs:
+                - get
+                - patch
+                - update
+            - apiGroups:
+                - operator.shipwright.io
+              resources:
+                - shipwrightbuilds
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - operator.shipwright.io
+              resources:
+                - shipwrightbuilds/finalizers
+              verbs:
+                - update
+            - apiGroups:
+                - operator.shipwright.io
+              resources:
+                - shipwrightbuilds/status
+              verbs:
+                - get
+                - patch
+                - update
+            - apiGroups:
+                - operator.tekton.dev
+              resources:
+                - tektonconfigs
+              verbs:
+                - create
+                - get
+                - list
+            - apiGroups:
+                - policy
+              resources:
+                - poddisruptionbudgets
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - update
+                - watch
+            - apiGroups:
+                - rbac.authorization.k8s.io
+              resources:
+                - clusterrolebindings
+                - clusterroles
+                - rolebindings
+                - roles
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - update
+                - watch
+            - apiGroups:
+                - rbac.authorization.k8s.io
+              resourceNames:
+                - shipwright-build-controller
+              resources:
+                - clusterrolebindings
+                - clusterroles
+                - rolebindings
+                - roles
+              verbs:
+                - delete
+                - patch
+                - update
+            - apiGroups:
+                - rbac.authorization.k8s.io
+              resourceNames:
+                - shipwright-build-webhook
+              resources:
+                - clusterrolebindings
+                - clusterroles
+                - rolebindings
+                - roles
+              verbs:
+                - delete
+                - patch
+                - update
+            - apiGroups:
+                - rbac.authorization.k8s.io
+              resourceNames:
+                - shipwright-build-aggregate-edit
+              resources:
+                - clusterroles
+              verbs:
+                - delete
+                - patch
+                - update
+            - apiGroups:
+                - rbac.authorization.k8s.io
+              resourceNames:
+                - shipwright-build-aggregate-view
+              resources:
+                - clusterroles
+              verbs:
+                - delete
+                - patch
+                - update
+            - apiGroups:
+                - security.openshift.io
+              resourceNames:
+                - privileged
+              resources:
+                - securitycontextconstraints
+              verbs:
+                - use
+            - apiGroups:
+                - sharedresource.openshift.io
+              resources:
+                - sharedconfigmaps
+                - sharedsecrets
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - shipwright.io
+              resources:
+                - clusterbuildstrategies
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - storage.k8s.io
+              resources:
+                - csidrivers
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - authentication.k8s.io
+              resources:
+                - tokenreviews
+              verbs:
+                - create
+            - apiGroups:
+                - authorization.k8s.io
+              resources:
+                - subjectaccessreviews
+              verbs:
+                - create
           serviceAccountName: openshift-builds-operator
       deployments:
         - label:
             app: openshift-builds-operator
             app.kubernetes.io/part-of: openshift-builds
-            app.kubernetes.io/version: v1.2.0
+            app.kubernetes.io/version: 1.4.0
             control-plane: controller-manager
           name: openshift-builds-operator
           spec:
@@ -837,7 +695,7 @@ spec:
                       - --upstream=http://127.0.0.1:8080/
                       - --logtostderr=true
                       - --v=0
-                    image: registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9@sha256:3fa22124916523b958c67af8ad652e73a2c3d68bb5579da1cba1ade537f3b7ae
+                    image: registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9@sha256:bbf95f039dcc3a1be3c376f668d903493dd3b9edcf52f1789653978d664dc867
                     name: kube-rbac-proxy
                     ports:
                       - containerPort: 8443
@@ -876,7 +734,7 @@ spec:
                         value: registry.redhat.io/openshift-builds/openshift-builds-waiters-rhel9@sha256:b58242d654b67f71844e2dec00506651496381fe9a173e9c719086c7d9519ab6
                       - name: IMAGE_SHIPWRIGHT_SHIPWRIGHT_BUILD_WEBHOOK
                         value: registry.redhat.io/openshift-builds/openshift-builds-webhook-rhel9@sha256:3ce032366c007a161a2fd92d68dc12c123b57693fa974c92aaec9c13ca63cccc
-                    image: registry.redhat.io/openshift-builds/openshift-builds-rhel9-operator@sha256:10e6f445071e25ae2bba88e539869874525456dcf9f3751de604b915e8b70333
+                    image: registry.redhat.io/openshift-builds/openshift-builds-rhel9-operator@sha256:b35eac4eb61aa02259f83ffe609def21af29c52f15e8224c2a5b47d015916d06
                     imagePullPolicy: Always
                     livenessProbe:
                       httpGet:
@@ -958,7 +816,7 @@ spec:
     - cicd
   links:
     - name: Documentation
-      url: https://docs.redhat.com/en/documentation/builds_for_red_hat_openshift/1.2
+      url: https://docs.redhat.com/en/documentation/builds_for_red_hat_openshift/1.4
     - name: Builds for Openshift
       url: https://github.com/redhat-openshift-builds/operator
   maintainers:
@@ -996,4 +854,4 @@ spec:
       name: OPENSHIFT_BUILDS_BUILDAH
     - image: registry.redhat.io/source-to-image/source-to-image-rhel8@sha256:d041c1bbe503d152d0759598f79802e257816d674b342670ef61c6f9e6d401c5
       name: OPENSHIFT_BUILDS_SOURCE_TO_IMAGE
-  version: 1.2.0
+  version: 1.4.0

--- a/bundle/manifests/openshift-builds-shared-resource-node-privileged-binding_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
+++ b/bundle/manifests/openshift-builds-shared-resource-node-privileged-binding_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
@@ -4,7 +4,7 @@ metadata:
   creationTimestamp: null
   labels:
     app.kubernetes.io/part-of: openshift-builds
-    app.kubernetes.io/version: v1.2.0
+    app.kubernetes.io/version: 1.4.0
   name: openshift-builds-shared-resource-node-privileged-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/bundle/manifests/openshift-builds-shared-resource-privileged-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/openshift-builds-shared-resource-privileged-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -4,7 +4,7 @@ metadata:
   creationTimestamp: null
   labels:
     app.kubernetes.io/part-of: openshift-builds
-    app.kubernetes.io/version: v1.2.0
+    app.kubernetes.io/version: 1.4.0
   name: openshift-builds-shared-resource-privileged-role
 rules:
 - apiGroups:

--- a/bundle/manifests/openshift-builds-shared-resource-prometheus_rbac.authorization.k8s.io_v1_role.yaml
+++ b/bundle/manifests/openshift-builds-shared-resource-prometheus_rbac.authorization.k8s.io_v1_role.yaml
@@ -4,7 +4,7 @@ metadata:
   creationTimestamp: null
   labels:
     app.kubernetes.io/part-of: openshift-builds
-    app.kubernetes.io/version: v1.2.0
+    app.kubernetes.io/version: 1.4.0
   name: openshift-builds-shared-resource-prometheus
 rules:
 - apiGroups:

--- a/bundle/manifests/openshift-builds-shared-resource-prometheus_rbac.authorization.k8s.io_v1_rolebinding.yaml
+++ b/bundle/manifests/openshift-builds-shared-resource-prometheus_rbac.authorization.k8s.io_v1_rolebinding.yaml
@@ -4,7 +4,7 @@ metadata:
   creationTimestamp: null
   labels:
     app.kubernetes.io/part-of: openshift-builds
-    app.kubernetes.io/version: v1.2.0
+    app.kubernetes.io/version: 1.4.0
   name: openshift-builds-shared-resource-prometheus
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/bundle/manifests/operator.openshift.io_openshiftbuilds.yaml
+++ b/bundle/manifests/operator.openshift.io_openshiftbuilds.yaml
@@ -2,11 +2,11 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.17.3
   creationTimestamp: null
   labels:
     app.kubernetes.io/part-of: openshift-builds
-    app.kubernetes.io/version: v1.2.0
+    app.kubernetes.io/version: 1.4.0
   name: openshiftbuilds.operator.openshift.io
 spec:
   group: operator.openshift.io
@@ -89,16 +89,8 @@ spec:
                 description: Conditions holds the latest available observations of
                   a resource's current state.
                 items:
-                  description: "Condition contains details for one aspect of the current
-                    state of this API Resource.\n---\nThis struct is intended for
-                    direct use as an array at the field path .status.conditions.  For
-                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
-                    observations of a foo's current state.\n\t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
-                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                    \   // other fields\n\t}"
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
                   properties:
                     lastTransitionTime:
                       description: |-
@@ -139,12 +131,7 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: |-
-                        type of condition in CamelCase or in foo.example.com/CamelCase.
-                        ---
-                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                        useful (see .node.status.conditions), the ability to deconflict is important.
-                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string

--- a/bundle/manifests/operator.shipwright.io_shipwrightbuilds.yaml
+++ b/bundle/manifests/operator.shipwright.io_shipwrightbuilds.yaml
@@ -2,11 +2,11 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.15.0
   creationTimestamp: null
   labels:
     app.kubernetes.io/part-of: openshift-builds
-    app.kubernetes.io/version: v1.2.0
+    app.kubernetes.io/version: 1.4.0
   name: shipwrightbuilds.operator.shipwright.io
 spec:
   group: operator.shipwright.io
@@ -24,14 +24,19 @@ spec:
           controller on a Kubernetes cluster.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -52,42 +57,42 @@ spec:
                   a resource's current state.
                 items:
                   description: "Condition contains details for one aspect of the current
-                    state of this API Resource. --- This struct is intended for direct
-                    use as an array at the field path .status.conditions.  For example,
-                    \n type FooStatus struct{ // Represents the observations of a
-                    foo's current state. // Known .status.conditions.type are: \"Available\",
-                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
-                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
-                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
-                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
                   properties:
                     lastTransitionTime:
-                      description: lastTransitionTime is the last time the condition
-                        transitioned from one status to another. This should be when
-                        the underlying condition changed.  If that is not known, then
-                        using the time when the API field changed is acceptable.
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: message is a human readable message indicating
-                        details about the transition. This may be an empty string.
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: observedGeneration represents the .metadata.generation
-                        that the condition was set based upon. For instance, if .metadata.generation
-                        is currently 12, but the .status.conditions[x].observedGeneration
-                        is 9, the condition is out of date with respect to the current
-                        state of the instance.
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
                     reason:
-                      description: reason contains a programmatic identifier indicating
-                        the reason for the condition's last transition. Producers
-                        of specific condition types may define expected values and
-                        meanings for this field, and whether the values are considered
-                        a guaranteed API. The value should be a CamelCase string.
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
                         This field may not be empty.
                       maxLength: 1024
                       minLength: 1
@@ -101,11 +106,12 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                        --- Many .condition.type values are consistent across resources
-                        like Available, but because arbitrary conditions can be useful
-                        (see .node.status.conditions), the ability to deconflict is
-                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
@@ -127,5 +133,5 @@ status:
   acceptedNames:
     kind: ""
     plural: ""
-  conditions: []
-  storedVersions: []
+  conditions: null
+  storedVersions: null

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -14,7 +14,7 @@ namePrefix: openshift-builds-
 labels:
   - pairs:
       app.kubernetes.io/part-of: openshift-builds
-      app.kubernetes.io/version: v1.2.0
+      app.kubernetes.io/version: 1.4.0
 
 resources:
 - ../crd

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -3,6 +3,6 @@ resources:
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
-- digest: sha256:10e6f445071e25ae2bba88e539869874525456dcf9f3751de604b915e8b70333
-  name: operator
+- name: operator
   newName: registry.redhat.io/openshift-builds/openshift-builds-rhel9-operator
+  newTag: 1.4.0

--- a/config/manifests/bases/openshift-builds-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/openshift-builds-operator.clusterserviceversion.yaml
@@ -43,8 +43,9 @@ spec:
       kind: ShipwrightBuild
       name: shipwrightbuilds.operator.shipwright.io
       version: v1alpha1
-    - description: OpenShiftBuild describes the desired state of Builds for OpenShift,
-        and the status of all deployed components.
+    - description: |-
+        OpenShiftBuild describes the desired state of Builds for OpenShift, and the status of
+        all deployed components.
       displayName: Open Shift Build
       kind: OpenShiftBuild
       name: openshiftbuilds.operator.openshift.io


### PR DESCRIPTION
Changes:
Right now the `relatedImages` section is not correctly generated because the operand images used are declared in the environment variable and hence hte `--use-image-digest` only extracts and updates the images present in the CSV in deployment spec `image` field only. This fix adds a YQ transformation to copy `relatedImages` from base CSV to bundle CSV.

Also, the version is fixed, pointing to the correct version.