### PR TITLE
Add console samples for buildpack

### DIFF
--- a/bundle/manifests/buildah-build-external-push_console.openshift.io_v1_consoleyamlsample.yaml
+++ b/bundle/manifests/buildah-build-external-push_console.openshift.io_v1_consoleyamlsample.yaml
@@ -1,0 +1,35 @@
+apiVersion: console.openshift.io/v1
+kind: ConsoleYAMLSample
+metadata:
+  name: buildah-build-external-push
+spec:
+  description: A sample Build using buildah BuildStrategy that pushes the built image
+    to an external registry
+  snippet: false
+  targetResource:
+    apiVersion: shipwright.io/v1beta1
+    kind: Build
+  title: Buildah Build External Push
+  yaml: |
+    apiVersion: shipwright.io/v1beta1
+    kind: Build
+    metadata:
+      name: buildah-golang-build-external-push
+    spec:
+      source:
+        type: Git
+        git:
+          url: https://github.com/redhat-openshift-builds/samples..git
+        contextDir: buildah
+      strategy:
+        name: buildah
+        kind: ClusterBuildStrategy
+      paramValues:
+      - name: dockerfile
+        value: Dockerfile
+      output:
+        # For a successful image push, a pushSecret with relevant credentials must be available in the same namespace as builds.
+        # Detailed steps are available at: https://docs.redhat.com/en/documentation/builds_for_red_hat_openshift/1.1/html-single/authentication/index?extIdCarryOver=true&sc_cid=701f2000001Css5AAC#ob-authentication-to-container-registries_understanding-authentication-at-runtime
+        pushSecret: secretName
+        # The "quayRepo" in the image needs to be replaced with a valid Quay.io organization or Quay username.
+        image: quay.io/quayRepo/sample-go-app

--- a/bundle/manifests/buildah-build_console.openshift.io_v1_consoleyamlsample.yaml
+++ b/bundle/manifests/buildah-build_console.openshift.io_v1_consoleyamlsample.yaml
@@ -1,0 +1,32 @@
+apiVersion: console.openshift.io/v1
+kind: ConsoleYAMLSample
+metadata:
+  name: buildah-build
+spec:
+  description: A sample Build using buildah BuildStrategy
+  snippet: false
+  targetResource:
+    apiVersion: shipwright.io/v1beta1
+    kind: Build
+  title: Buildah Build
+  yaml: |
+    apiVersion: shipwright.io/v1beta1
+    kind: Build
+    metadata:
+      name: buildah-golang-build
+    spec:
+      source:
+        type: Git
+        git:
+          url: https://github.com/redhat-openshift-builds/samples.git
+        contextDir: buildah
+      strategy:
+        name: buildah
+        kind: ClusterBuildStrategy
+      paramValues:
+      - name: dockerfile
+        value: Dockerfile
+      output:
+        # The "namespace" in the image needs to be replaced with the namespace name where related build exists.
+        # If the following image value is passed as is, the pod will error out while pushing the image due to authentication failures.
+        image: image-registry.openshift-image-registry.svc:5000/namespace/sample-go-app

--- a/bundle/manifests/buildpack-nodejs-build_console.openshift.io_v1_consoleyamlsample.yaml
+++ b/bundle/manifests/buildpack-nodejs-build_console.openshift.io_v1_consoleyamlsample.yaml
@@ -1,0 +1,35 @@
+apiVersion: console.openshift.io/v1
+kind: ConsoleYAMLSample
+metadata:
+  name: buildpack-nodejs-build
+spec:
+  description: A sample NodeJS application Build using Buildpack BuildStrategy with
+    UBI stack
+  snippet: false
+  targetResource:
+    apiVersion: shipwright.io/v1beta1
+    kind: Build
+  title: Buildpack Nodejs Build
+  yaml: |-
+    apiVersion: shipwright.io/v1beta1
+    kind: Build
+    metadata:
+      name: buildpack-nodejs-build
+    spec:
+      source:
+        type: Git
+        git:
+          url: https://github.com/redhat-openshift-builds/samples.git
+        contextDir: buildpack/nodejs
+      strategy:
+        name: buildpacks
+        kind: ClusterBuildStrategy
+      retention:
+        atBuildDeletion: true
+      paramValues:
+        - name: run-image
+          value: paketobuildpacks/run-ubi8-base:latest
+        - name: cnb-builder-image
+          value: paketobuildpacks/builder-jammy-tiny:0.0.344
+      output:
+        image: ttl.sh/buildpacks-testing:6h

--- a/bundle/manifests/source-to-image-java-build_console.openshift.io_v1_consoleyamlsample.yaml
+++ b/bundle/manifests/source-to-image-java-build_console.openshift.io_v1_consoleyamlsample.yaml
@@ -1,0 +1,20 @@
+apiVersion: console.openshift.io/v1
+kind: ConsoleYAMLSample
+metadata:
+  name: source-to-image-java-build
+spec:
+  description: A sample Build using source-to-image BuildStrategy with java builder
+    image
+  snippet: false
+  targetResource:
+    apiVersion: shipwright.io/v1beta1
+    kind: Build
+  title: Source-to-Image Java Build
+  yaml: "apiVersion: shipwright.io/v1beta1\nkind: Build\nmetadata:\n  name: s2i-java-build\nspec:\n
+    \ source: \n    type: Git\n    git:\n      url: https://github.com/redhat-openshift-builds/samples.git\n
+    \   contextDir: s2i/java\n  strategy: \n    name: source-to-image\n    kind: ClusterBuildStrategy\n
+    \ paramValues: \n  - name: builder-image\n    value: registry.access.redhat.com/ubi9/openjdk-11\n
+    \ output:\n    # The \"namespace\" in the image needs to be replaced with the
+    namespace name where related build exists.\n    # If the following image value
+    is passed as is, the pod will error out while pushing the image due to authentication
+    failures.\n    image: image-registry.openshift-image-registry.svc:5000/namespace/s2i-java-example\n"

--- a/bundle/manifests/source-to-image-nodejs-build_console.openshift.io_v1_consoleyamlsample.yaml
+++ b/bundle/manifests/source-to-image-nodejs-build_console.openshift.io_v1_consoleyamlsample.yaml
@@ -1,32 +1,33 @@
 apiVersion: console.openshift.io/v1
 kind: ConsoleYAMLSample
 metadata:
-  name: source-to-image-java-build
+  name: source-to-image-nodejs-build
 spec:
-  description: A sample Build using source-to-image BuildStrategy with java builder image
+  description: A sample Build using source-to-image BuildStrategy with nodejs builder
+    image
   snippet: false
   targetResource:
     apiVersion: shipwright.io/v1beta1
     kind: Build
-  title: Source-to-Image Java Build
+  title: Source-to-Image Nodejs Build
   yaml: |
     apiVersion: shipwright.io/v1beta1
     kind: Build
     metadata:
-      name: s2i-java-build
+      name: s2i-nodejs-build
     spec:
-      source: 
+      source:
         type: Git
         git:
-          url: https://github.com/redhat-openshift-builds/samples/
-        contextDir: s2i-build/java
-      strategy: 
+          url: https://github.com/redhat-openshift-builds/samples.git
+        contextDir: s2i/nodejs
+      strategy:
         name: source-to-image
         kind: ClusterBuildStrategy
-      paramValues: 
+      paramValues:
       - name: builder-image
-        value: registry.access.redhat.com/ubi9/openjdk-11
+        value: quay.io/centos7/nodejs-12-centos7:master
       output:
         # The "namespace" in the image needs to be replaced with the namespace name where related build exists.
         # If the following image value is passed as is, the pod will error out while pushing the image due to authentication failures.
-        image: image-registry.openshift-image-registry.svc:5000/namespace/s2i-java-example
+        image: image-registry.openshift-image-registry.svc:5000/namespace/s2i-nodejs-example

--- a/config/shipwright/kustomization.yaml
+++ b/config/shipwright/kustomization.yaml
@@ -1,2 +1,3 @@
 resources:
 - cli
+- samples

--- a/config/shipwright/samples/buildah-build.yaml
+++ b/config/shipwright/samples/buildah-build.yaml
@@ -1,0 +1,32 @@
+apiVersion: console.openshift.io/v1
+kind: ConsoleYAMLSample
+metadata:
+  name: buildah-build
+spec:
+  description: A sample Build using buildah BuildStrategy
+  snippet: false
+  targetResource:
+    apiVersion: shipwright.io/v1beta1
+    kind: Build
+  title: Buildah Build
+  yaml: |
+    apiVersion: shipwright.io/v1beta1
+    kind: Build
+    metadata:
+      name: buildah-golang-build
+    spec:
+      source:
+        type: Git
+        git:
+          url: https://github.com/redhat-openshift-builds/samples.git
+        contextDir: buildah
+      strategy:
+        name: buildah
+        kind: ClusterBuildStrategy
+      paramValues:
+      - name: dockerfile
+        value: Dockerfile
+      output:
+        # The "namespace" in the image needs to be replaced with the namespace name where related build exists.
+        # If the following image value is passed as is, the pod will error out while pushing the image due to authentication failures.
+        image: image-registry.openshift-image-registry.svc:5000/namespace/sample-go-app

--- a/config/shipwright/samples/buildah-external-registry.yaml
+++ b/config/shipwright/samples/buildah-external-registry.yaml
@@ -18,8 +18,8 @@ spec:
       source:
         type: Git
         git:
-          url: https://github.com/redhat-openshift-builds/samples/
-        contextDir: buildah-build
+          url: https://github.com/redhat-openshift-builds/samples..git
+        contextDir: buildah
       strategy:
         name: buildah
         kind: ClusterBuildStrategy

--- a/config/shipwright/samples/buildpack-nodejs-build.yaml
+++ b/config/shipwright/samples/buildpack-nodejs-build.yaml
@@ -1,0 +1,35 @@
+apiVersion: console.openshift.io/v1
+kind: ConsoleYAMLSample
+metadata:
+  name: buildpack-nodejs-build
+spec:
+  description: A sample NodeJS application Build using Buildpack BuildStrategy with UBI stack
+  snippet: false
+  targetResource:
+    apiVersion: shipwright.io/v1beta1
+    kind: Build
+  title: Buildpack Nodejs Build
+  yaml: |
+    apiVersion: shipwright.io/v1beta1
+    kind: Build
+    metadata:
+      name: buildpack-nodejs-build
+    spec:
+      source:
+        type: Git
+        git:
+          url: https://github.com/redhat-openshift-builds/samples.git
+      strategy:
+        name: buildpacks-extender
+        kind: ClusterBuildStrategy
+      retention:
+        atBuildDeletion: true
+      paramValues:
+        - name: run-image
+          value: paketobuildpacks/run-ubi8-base:latest
+        - name: cnb-builder-image
+          value: paketobuildpacks/builder-jammy-tiny:0.0.344
+        - name: source-subpath
+          value: "buildpack/nodejs"
+      output:
+        image: ttl.sh/buildpack-sample:1h

--- a/config/shipwright/samples/buildpack-quarkus-build.yaml
+++ b/config/shipwright/samples/buildpack-quarkus-build.yaml
@@ -1,0 +1,35 @@
+apiVersion: console.openshift.io/v1
+kind: ConsoleYAMLSample
+metadata:
+  name: buildpack-quarkus-build
+spec:
+  description: A sample Quarkus application Build using Buildpack BuildStrategy with UBI stack
+  snippet: false
+  targetResource:
+    apiVersion: shipwright.io/v1beta1
+    kind: Build
+  title: Buildpack Nodejs Build
+  yaml: |
+    apiVersion: shipwright.io/v1beta1
+    kind: Build
+    metadata:
+      name: buildpack-quarkus-build
+    spec:
+      source:
+        type: Git
+        git:
+          url: https://github.com/redhat-openshift-builds/samples.git
+      strategy:
+        name: buildpacks
+        kind: ClusterBuildStrategy
+      retention:
+        atBuildDeletion: true
+      paramValues:
+        - name: run-image
+          value: paketobuildpacks/run-ubi8-base:latest
+        - name: cnb-builder-image
+          value: paketobuildpacks/builder-jammy-tiny:0.0.344
+        - name: source-subpath
+          value: "buildpack/quarkus"
+      output:
+        image: ttl.sh/buildpack-sample:6h

--- a/config/shipwright/samples/kustomization.yaml
+++ b/config/shipwright/samples/kustomization.yaml
@@ -1,0 +1,6 @@
+resources:
+- buildah-build.yaml
+- buildah-external-registry.yaml
+- s2i-nodejs-build.yaml
+- s2i-java-build.yaml
+- buildpack-nodejs-build.yaml

--- a/config/shipwright/samples/s2i-java-build.yaml
+++ b/config/shipwright/samples/s2i-java-build.yaml
@@ -1,32 +1,32 @@
 apiVersion: console.openshift.io/v1
 kind: ConsoleYAMLSample
 metadata:
-  name: buildah-build
+  name: source-to-image-java-build
 spec:
-  description: A sample Build using buildah BuildStrategy
+  description: A sample Build using source-to-image BuildStrategy with java builder image
   snippet: false
   targetResource:
     apiVersion: shipwright.io/v1beta1
     kind: Build
-  title: Buildah Build
+  title: Source-to-Image Java Build
   yaml: |
     apiVersion: shipwright.io/v1beta1
     kind: Build
     metadata:
-      name: buildah-golang-build
+      name: s2i-java-build
     spec:
-      source:
+      source: 
         type: Git
         git:
-          url: https://github.com/redhat-openshift-builds/samples/
-        contextDir: buildah-build
-      strategy:
-        name: buildah
+          url: https://github.com/redhat-openshift-builds/samples.git
+        contextDir: s2i/java
+      strategy: 
+        name: source-to-image
         kind: ClusterBuildStrategy
-      paramValues:
-      - name: dockerfile
-        value: Dockerfile
+      paramValues: 
+      - name: builder-image
+        value: registry.access.redhat.com/ubi9/openjdk-11
       output:
         # The "namespace" in the image needs to be replaced with the namespace name where related build exists.
         # If the following image value is passed as is, the pod will error out while pushing the image due to authentication failures.
-        image: image-registry.openshift-image-registry.svc:5000/namespace/sample-go-app
+        image: image-registry.openshift-image-registry.svc:5000/namespace/s2i-java-example

--- a/config/shipwright/samples/s2i-nodejs-build.yaml
+++ b/config/shipwright/samples/s2i-nodejs-build.yaml
@@ -18,8 +18,8 @@ spec:
       source:
         type: Git
         git:
-          url: https://github.com/redhat-openshift-builds/samples/
-        contextDir: s2i-build/nodejs
+          url: https://github.com/redhat-openshift-builds/samples.git
+        contextDir: s2i/nodejs
       strategy:
         name: source-to-image
         kind: ClusterBuildStrategy


### PR DESCRIPTION
## Changes:
- Moved all console samples to separate kustomized location, so that it can be included in bundle with `make bundle`
- Added new `buildpack-nodejs-build` console sample for nodejs applications.
- Added new `buildpack-quarkus-build` console sample for quarkus applications
- Updated `contextDir` for strategies.