### PR TITLE
Switch bundle build pipeline to single architecture

### DIFF
--- a/.tekton/openshift-builds-operator-bundle-pull-request.yaml
+++ b/.tekton/openshift-builds-operator-bundle-pull-request.yaml
@@ -41,9 +41,10 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
-    - linux/arm64
-  - name: prefetch-input
-    value: '{"packages": [{"type": "gomod"}]}'
+  - name: build-image-index
+    value: "false"
+  - name: image-append-platform
+    value: "false"
   pipelineRef:
     params:
     - name: url

--- a/.tekton/openshift-builds-operator-bundle-push.yaml
+++ b/.tekton/openshift-builds-operator-bundle-push.yaml
@@ -37,12 +37,11 @@ spec:
     value: "true"
   - name: build-platforms
     value:
-    - linux/x86_64
-    - linux/arm64
-    - linux/ppc64le
-    - linux/s390x
-  - name: prefetch-input
-    value: '{"packages": [{"type": "gomod"}]}'
+      - linux/x86_64
+  - name: build-image-index
+    value: "false"
+  - name: image-append-platform
+    value: "false"
   pipelineRef:
     params:
     - name: url


### PR DESCRIPTION
## Changes:
Bundle doesn't need multi-arch build, and with a recent update in Konflux, multiarch bundle build would fail Conforma test. This change switches the pipeline to use a single arch build.