### PR TITLE
fix: fixing openshiftbuild reconcile behaviour and adding tests to verify that

### DIFF
--- a/internal/controller/openshiftbuild_controller_test.go
+++ b/internal/controller/openshiftbuild_controller_test.go
@@ -17,18 +17,29 @@ limitations under the License.
 package controller
 
 import (
+	"context"
+	"fmt"
+	"os"
 	"time"
 
+	manifestivalclient "github.com/manifestival/controller-runtime-client"
+
+	"github.com/manifestival/manifestival"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	rbacv1 "k8s.io/api/rbac/v1"
+
+	"github.com/redhat-openshift-builds/operator/internal/common"
+	"github.com/redhat-openshift-builds/operator/internal/sharedresource"
+	shipwrightbuild "github.com/redhat-openshift-builds/operator/internal/shipwright/build"
 	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	operatorv1alpha1 "github.com/redhat-openshift-builds/operator/api/v1alpha1"
-	"github.com/redhat-openshift-builds/operator/internal/common"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
 )
 
 var _ = Describe("OpenShiftBuild controller", Label("integration", "openshiftbuild"), Serial, func() {
@@ -111,62 +122,157 @@ var _ = Describe("OpenShiftBuild controller", Label("integration", "openshiftbui
 	})
 })
 
-// 	When("bootstrapping the OpenShiftBuild resource", func() {
+var _ = Describe("Main Operator Controller with Sub-Reconciler Failure", func() {
+	const (
+		CRName      = "test-shipwright-build"
+		CRNamespace = "openshift-builds"
+		timeout     = time.Second * 10
+		interval    = time.Millisecond * 250
+	)
 
-// 		AfterEach(func() {
-// 			// Cleanup the created OpenShiftBuild resource
-// 			obj := &operatorv1alpha1.OpenShiftBuild{}
-// 			err := k8sClient.Get(ctx, types.NamespacedName{Name: common.OpenShiftBuildResourceName}, obj)
-// 			Expect(err).NotTo(HaveOccurred(), "get created OpenShiftBuild resource")
+	ctx := context.Background()
 
-// 			controllerutil.RemoveFinalizer(obj, finalizerName)
-// 			err = k8sClient.Update(ctx, obj)
-// 			Expect(err).NotTo(HaveOccurred(), "remove finalizer from OpenShiftBuild resource")
+	var openShiftBuildReconciler *OpenShiftBuildReconciler
 
-// 			err = k8sClient.Delete(ctx, obj)
-// 			Expect(err).NotTo(HaveOccurred(), "delete OpenShiftBuild resource")
-// 		})
+	Context("When ShipwrightBuild sub-component reconciliation fails", func() {
+		It("Should requeue the main operator reconciliation", func() {
+			By("Creating an OpenShiftBuild instance with invalid Shipwright Build state")
 
-// 		It("should create the OpenShiftBuild resource if not present", func() {
-// 			err := reconciler.BootstrapOpenShiftBuild(ctx, k8sClient)
-// 			Expect(err).NotTo(HaveOccurred(), "boostrap OpenShiftBuild resource")
+			openShiftBuildReconciler = &OpenShiftBuildReconciler{
+				Client:         k8sClient,
+				Scheme:         testEnv.Scheme,
+				Logger:         ctrl.Log.WithName("test-openshiftbuild-reconciler"),
+				APIReader:      k8sClient,
+				SharedResource: &sharedresource.SharedResource{},
+				Shipwright:     shipwrightbuild.New(k8sClient, CRNamespace),
+			}
 
-// 			resultObj := &operatorv1alpha1.OpenShiftBuild{}
-// 			err = k8sClient.Get(ctx, types.NamespacedName{Name: common.OpenShiftBuildResourceName}, resultObj)
-// 			Expect(err).NotTo(HaveOccurred(), "get created OpenShiftBuild object")
-// 			validateDefaults(resultObj)
-// 		})
+			cr := &operatorv1alpha1.OpenShiftBuild{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: CRName,
+				},
+				Spec: operatorv1alpha1.OpenShiftBuildSpec{
+					Shipwright: &operatorv1alpha1.Shipwright{
+						Build: &operatorv1alpha1.ShipwrightBuild{
+							State: operatorv1alpha1.Enabled,
+						},
+					},
+					SharedResource: &operatorv1alpha1.SharedResource{
+						State: operatorv1alpha1.Disabled,
+					},
+				},
+				Status: operatorv1alpha1.OpenShiftBuildStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:   operatorv1alpha1.ConditionReady,
+							Status: metav1.ConditionFalse,
+						},
+					},
+				},
+			}
 
-// 		It("should set required fields with default values", func() {
-// 			// Create empty spec object
-// 			buildObj := &operatorv1alpha1.OpenShiftBuild{
-// 				ObjectMeta: metav1.ObjectMeta{
-// 					Name: common.OpenShiftBuildResourceName,
-// 				},
-// 				Spec: operatorv1alpha1.OpenShiftBuildSpec{},
-// 			}
-// 			err := k8sClient.Create(ctx, buildObj)
-// 			Expect(err).NotTo(HaveOccurred(), "create empty OpenShiftBuild resource")
+			Expect(k8sClient.Create(ctx, cr)).Should(Succeed())
 
-// 			err = reconciler.BootstrapOpenShiftBuild(ctx, k8sClient)
-// 			Expect(err).NotTo(HaveOccurred(), "boostrap OpenShiftBuild resource")
+			// Ensure the CR is retrievable before reconciling, so the Get in Reconcile works
+			crKey := types.NamespacedName{Name: CRName, Namespace: CRNamespace}
+			Eventually(func() error {
+				return k8sClient.Get(ctx, crKey, &operatorv1alpha1.OpenShiftBuild{})
+			}, timeout, interval).Should(Succeed())
 
-// 			// Re-fetch an object to get updated values
-// 			resultObj := &operatorv1alpha1.OpenShiftBuild{}
-// 			err = k8sClient.Get(ctx, types.NamespacedName{Name: common.OpenShiftBuildResourceName}, resultObj)
-// 			Expect(err).NotTo(HaveOccurred(), "get updated OpenShiftBuild object")
-// 			validateDefaults(resultObj)
-// 		})
+			By("Directly invoking the main Reconcile function")
+			req := ctrl.Request{
+				NamespacedName: crKey,
+			}
 
-// 	})
-// })
+			result, err := openShiftBuildReconciler.Reconcile(ctx, req)
 
-// func validateDefaults(obj *operatorv1alpha1.OpenShiftBuild) {
-// 	Expect(obj.Spec.Shipwright).NotTo(BeNil())
-// 	Expect(obj.Spec.Shipwright.Build).NotTo(BeNil())
-// 	Expect(obj.Spec.Shipwright.Build.State).To(Equal(operatorv1alpha1.Enabled))
-// 	Expect(controllerutil.ContainsFinalizer(obj, common.OpenShiftBuildFinalizerName)).To(BeTrue(), "checking for finalizer %q", common.OpenShiftBuildFinalizerName)
+			By("Asserting that an error was returned (triggering requeue)")
+			Expect(err).To(HaveOccurred(), "Main Reconcile should return an error when sub-component 1 fails")
 
-// 	Expect(obj.Spec.SharedResource).NotTo(BeNil())
-// 	Expect(obj.Spec.SharedResource.State).To(Equal(operatorv1alpha1.Enabled))
-// }
+			By("Asserting that the result does not ask for RequeueAfter (default requeue-on-error)")
+			Expect(result.Requeue).To(BeFalse(), "Result.Requeue should be false when an error is returned for default backoff requeue")
+			Expect(result.RequeueAfter).To(BeZero(), "Result.RequeueAfter should be zero for default backoff requeue")
+
+			// Cleanup
+			By("Deleting the CR for SharedResource failure test")
+			Expect(k8sClient.Delete(ctx, cr)).Should(Succeed())
+		})
+	})
+
+	Context("When SharedResource sub-component reconciliation fails", func() {
+		It("Should requeue the main operator reconciliation", func() {
+			By("Creating an OpenShiftBuild instance configured to make SharedResource reconciler fail")
+			sharedManifestPath := common.SharedResourceManifestPath
+			if path, ok := os.LookupEnv(common.SharedResourceManifestPath); ok {
+				sharedManifestPath = path
+			}
+			sharedManifest, err := manifestival.NewManifest(sharedManifestPath, []manifestival.Option{
+				manifestival.UseLogger(ctrl.Log.WithName("test-openshiftbuild-reconciler")),
+				manifestival.UseClient(manifestivalclient.NewClient(k8sClient)),
+			}...)
+			if err != nil {
+				fmt.Println("Error creating shared manifest", err)
+			}
+
+			openShiftBuildReconciler = &OpenShiftBuildReconciler{
+				Client:         k8sClient,
+				Scheme:         testEnv.Scheme,
+				Logger:         ctrl.Log.WithName("test-openshiftbuild-reconciler"),
+				APIReader:      k8sClient,
+				SharedResource: sharedresource.New(k8sClient, sharedManifest),
+				Shipwright:     shipwrightbuild.New(k8sClient, CRNamespace),
+			}
+
+			cr := &operatorv1alpha1.OpenShiftBuild{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: CRName,
+				},
+				Spec: operatorv1alpha1.OpenShiftBuildSpec{
+					Shipwright: &operatorv1alpha1.Shipwright{
+						Build: &operatorv1alpha1.ShipwrightBuild{
+							State: operatorv1alpha1.Disabled,
+						},
+					},
+					SharedResource: &operatorv1alpha1.SharedResource{
+						State: operatorv1alpha1.Enabled,
+					},
+				},
+				Status: operatorv1alpha1.OpenShiftBuildStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:   operatorv1alpha1.ConditionReady,
+							Status: metav1.ConditionFalse,
+						},
+					},
+				},
+			}
+
+			Expect(k8sClient.Create(ctx, cr)).Should(Succeed())
+
+			crKey := types.NamespacedName{Name: CRName, Namespace: CRNamespace}
+			Eventually(func() error {
+				return k8sClient.Get(ctx, crKey, &operatorv1alpha1.OpenShiftBuild{})
+			}, timeout, interval).Should(Succeed())
+
+			By("Directly invoking the main Reconcile function")
+			req := ctrl.Request{
+				NamespacedName: crKey,
+			}
+
+			result, err := openShiftBuildReconciler.Reconcile(ctx, req)
+
+			By("Asserting that an error was returned (triggering requeue)")
+			Expect(err).To(HaveOccurred(), "Main Reconcile should return an error when SharedResource sub-component fails")
+
+			Expect(err.Error()).To(ContainSubstring("SharedResources reconciliation failed"))
+
+			By("Asserting that the result does not ask for RequeueAfter (default requeue-on-error)")
+			Expect(result.Requeue).To(BeFalse(), "Result.Requeue should be false when an error is returned for default backoff requeue")
+			Expect(result.RequeueAfter).To(BeZero(), "Result.RequeueAfter should be zero for default backoff requeue")
+
+			// Cleanup
+			By("Deleting the CR for SharedResource failure test")
+			Expect(k8sClient.Delete(ctx, cr)).Should(Succeed())
+		})
+	})
+})


### PR DESCRIPTION
The bug occurred during the reconciliation step for components ShipwrightBuild and SharedResource, where an error was returned upon failure.

Original code was updating the OpenShiftBuild status to reflect this failure by returning the result of the status update attempt; if the status update succeeded (returning nil), the actual reconciliation failure error was masked, preventing the controller-runtime from automatically requeuing the failed reconciliation.

Fix - I modified the return logic within these error handling blocks: after doing status update (and logging any secondary error from that attempt), the Reconcile function now returns the original error(reconciliation failure), ensuring that controller-runtime correctly requeues the request for a retry.