### PR TITLE
update: use tags instead of SHA for ubi-minimal

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ ENV GOEXPERIMENT=strictfipsruntime
 
 RUN CGO_ENABLED=1 GO111MODULE=on go build -a -mod vendor -tags strictfipsruntime -o operator cmd/main.go
 
-FROM registry.redhat.io/ubi9/ubi-minimal@sha256:ac61c96b93894b9169221e87718733354dd3765dd4a62b275893c7ff0d876869
+FROM registry.redhat.io/ubi9/ubi-minimal:9.6
 
 WORKDIR /
 
@@ -33,7 +33,7 @@ ENTRYPOINT ["/operator"]
 LABEL \
     com.redhat.component="openshift-builds-operator-container" \
     name="openshift-builds/operator" \
-    version="v1.3.0" \
+    version="v1.5.0" \
     summary="Red Hat OpenShift Builds Operator" \
     maintainer="openshift-builds@redhat.com" \
     description="Red Hat OpenShift Builds Operator" \

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -6,14 +6,14 @@ LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=openshift-builds-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=latest
 LABEL operators.operatorframework.io.bundle.channel.default.v1=latest
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.35.0
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.39.2
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v4
 
 LABEL operators.operatorframework.io.test.mediatype.v1=scorecard+v1
 LABEL operators.operatorframework.io.test.config.v1=tests/scorecard/
 
-LABEL com.redhat.openshift.versions="v4.14-v4.18" \
+LABEL com.redhat.openshift.versions="v4.16-v4.19" \
     com.redhat.component="openshift-builds-operator-bundle-container" \
     description="Red Hat OpenShift Builds Operator Bundle" \
     distribution-scope="public" \
@@ -25,8 +25,8 @@ LABEL com.redhat.openshift.versions="v4.14-v4.18" \
     summary="Red Hat OpenShift Builds Operator Bundle" \
     url="https://catalog.redhat.com/software/containers/openshift-builds/openshift-builds-operator-bundle" \
     vendor="Red Hat, Inc." \
-    version="1.4.0" \
-    release="1.4.0"
+    version="1.5.0" \
+    release="1.5.0"
 
 COPY bundle/ /
 COPY LICENSE /licenses/


### PR DESCRIPTION
- update ubi-minimal to latest
- update release versions
- update operator-sdk version tags

