### PR TITLE
BUILD-1429: Adding e2e test for Paketo Buildpacks

### DIFF
--- a/test/data/buildpack-nodejs-build.yaml
+++ b/test/data/buildpack-nodejs-build.yaml
@@ -1,0 +1,23 @@
+apiVersion: shipwright.io/v1beta1
+kind: Build
+metadata:
+  name: buildpack-nodejs-build
+spec:
+  source:
+    type: Git
+    git: 
+      url: https://github.com/redhat-openshift-builds/samples.git
+  strategy:
+    name: buildpacks-extender
+    kind: ClusterBuildStrategy
+  retention:
+    atBuildDeletion: true
+  paramValues:
+    - name: run-image
+      value: paketobuildpacks/run-ubi8-base:latest
+    - name: cnb-builder-image
+      value: paketobuildpacks/builder-jammy-tiny:0.0.344
+    - name: source-subpath
+      value: "buildpacks/nodejs"
+  output:
+    image: image-registry.openshift-image-registry.svc:5000/builds-test/taxi-app

--- a/test/e2e/e2e_buildpacks_test.go
+++ b/test/e2e/e2e_buildpacks_test.go
@@ -1,0 +1,165 @@
+package e2e
+
+import (
+	"fmt"
+	"io"
+
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:golint,revive
+	. "github.com/onsi/gomega"    //nolint:golint,revive
+
+	"sigs.k8s.io/yaml"
+
+	buildv1beta1 "github.com/shipwright-io/build/pkg/apis/build/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("Buildpacks e2e tests", Label("buildpacks"), func() {
+
+	Context("When using the buildpacks ClusterBuildStrategy with a sample Node.js app", func() {
+		var (
+			build           *buildv1beta1.Build
+			createdBuildRun *buildv1beta1.BuildRun
+		)
+
+		AfterEach(func(ctx SpecContext) {
+			if CurrentSpecReport().Failed() && createdBuildRun != nil {
+				By(fmt.Sprintf("Dumping logs for failed BuildRun: %s", createdBuildRun.Name))
+				podList := &corev1.PodList{}
+				err := kubeClient.List(ctx, podList, client.InNamespace(testNamespace), client.MatchingLabels{
+					"buildrun.shipwright.io/name": createdBuildRun.Name,
+				})
+				if err != nil {
+					GinkgoWriter.Printf("Error listing pods for BuildRun %s: %v\n", createdBuildRun.Name, err)
+				} else if len(podList.Items) > 0 {
+					buildPod := &podList.Items[0]
+					for _, container := range buildPod.Spec.Containers {
+						GinkgoWriter.Printf("\n----- Logs from container: %s (Pod: %s)-----\n", container.Name, buildPod.Name)
+						req := clientset.CoreV1().Pods(testNamespace).GetLogs(buildPod.Name, &corev1.PodLogOptions{Container: container.Name})
+						logStream, streamErr := req.Stream(ctx)
+						if streamErr != nil {
+							GinkgoWriter.Printf("Error streaming logs for container %s in pod %s: %v\n", container.Name, buildPod.Name, streamErr)
+							continue
+						}
+						defer logStream.Close()
+						if _, copyErr := io.Copy(GinkgoWriter, logStream); copyErr != nil {
+							GinkgoWriter.Printf("Error copying log stream for container %s in pod %s: %v\n", container.Name, buildPod.Name, copyErr)
+						}
+					}
+					GinkgoWriter.Println("\n----- End of logs -----")
+				}
+			}
+
+			By("Cleaning up test-specific Build and BuildRun resources")
+			if createdBuildRun != nil {
+				GinkgoWriter.Printf("Attempting to delete BuildRun '%s'\n", createdBuildRun.Name)
+				if err := kubeClient.Delete(ctx, createdBuildRun); err != nil && !errors.IsNotFound(err) {
+					GinkgoWriter.Printf("Error deleting BuildRun '%s': %v\n", createdBuildRun.Name, err)
+				}
+				Eventually(func() bool {
+					err := kubeClient.Get(ctx, client.ObjectKeyFromObject(createdBuildRun), &buildv1beta1.BuildRun{})
+					return errors.IsNotFound(err)
+				}, 1*time.Minute, 5*time.Second).Should(BeTrue(), "BuildRun not deleted within timeout")
+			}
+			if build != nil {
+				GinkgoWriter.Printf("Attempting to delete Build '%s'\n", build.Name)
+				if err := kubeClient.Delete(ctx, build); err != nil && !errors.IsNotFound(err) {
+					GinkgoWriter.Printf("Error deleting Build '%s': %v\n", build.Name, err)
+				}
+				Eventually(func() bool {
+					err := kubeClient.Get(ctx, client.ObjectKeyFromObject(build), &buildv1beta1.Build{})
+					return errors.IsNotFound(err)
+				}, 30*time.Second, 2*time.Second).Should(BeTrue(), "Build not deleted within timeout")
+			}
+		})
+
+		It("Should successfully trigger and complete a BuildRun", func(ctx SpecContext) {
+			buildPath := filepath.Join(projectDir, "test", "data", "buildpack-nodejs-build.yaml")
+			By(fmt.Sprintf("Loading Build resource from file: %s", buildPath))
+			buildPayload, err := os.ReadFile(buildPath)
+			Expect(err).NotTo(HaveOccurred(), "failed to read build definition YAML file")
+
+			// Replace the placeholder in the output image with the correct testing namespace.
+			buildYAML := strings.Replace(string(buildPayload), "##NAMESPACE##", testNamespace, 1)
+
+			build = &buildv1beta1.Build{}
+			err = yaml.Unmarshal([]byte(buildYAML), build)
+			Expect(err).NotTo(HaveOccurred(), "failed to unmarshal build YAML into object")
+
+			build.Namespace = testNamespace
+
+			By(fmt.Sprintf("Ensuring Build resource '%s' doesn't exist before creation", build.Name))
+			existingBuild := &buildv1beta1.Build{}
+			err = kubeClient.Get(ctx, client.ObjectKey{Name: build.Name, Namespace: testNamespace}, existingBuild)
+			if err == nil {
+				GinkgoWriter.Printf("Build '%s' already exists, deleting it before recreation.\n", build.Name)
+				err = kubeClient.Delete(ctx, existingBuild)
+				Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("failed to delete existing Build '%s'", build.Name))
+				Eventually(func() bool {
+					err := kubeClient.Get(ctx, client.ObjectKey{Name: build.Name, Namespace: testNamespace}, &buildv1beta1.Build{})
+					return errors.IsNotFound(err)
+				}, 1*time.Minute, 5*time.Second).Should(BeTrue(), "existing Build %s not deleted within timeout", build.Name)
+			} else if !errors.IsNotFound(err) {
+				Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("failed to check existence of Build '%s'", build.Name))
+			}
+
+			By(fmt.Sprintf("Creating Build resource '%s'", build.Name))
+			Expect(kubeClient.Create(ctx, build)).To(Succeed(), "failed to create Build resource")
+
+			buildRunTemplate := &buildv1beta1.BuildRun{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: fmt.Sprintf("%s-run-", build.Name),
+					Namespace:    testNamespace,
+				},
+				Spec: buildv1beta1.BuildRunSpec{
+					Build: buildv1beta1.ReferencedBuild{
+						Name: &build.Name,
+					},
+				},
+			}
+			By(fmt.Sprintf("Creating BuildRun for Build '%s'", build.Name))
+			Expect(kubeClient.Create(ctx, buildRunTemplate)).To(Succeed(), "failed to create BuildRun")
+
+			By("Waiting for BuildRun to come up with its generated name")
+			Eventually(func() error {
+				brList := &buildv1beta1.BuildRunList{}
+				err := kubeClient.List(ctx, brList, client.InNamespace(testNamespace))
+				if err != nil {
+					return err
+				}
+				for i := range brList.Items {
+					br := &brList.Items[i]
+					if strings.HasPrefix(br.Name, build.Name) && br.Spec.Build.Name != nil && *br.Spec.Build.Name == build.Name {
+						createdBuildRun = br
+						return nil
+					}
+				}
+				return fmt.Errorf("buildrun for build %s not found yet", build.Name)
+			}, "1m", "2s").Should(Succeed(), "failed to fetch created BuildRun")
+
+			By(fmt.Sprintf("Waiting for BuildRun '%s' to complete successfully", createdBuildRun.Name))
+			Eventually(func(g Gomega) {
+				br := &buildv1beta1.BuildRun{}
+				err := kubeClient.Get(ctx, client.ObjectKey{Name: createdBuildRun.Name, Namespace: testNamespace}, br)
+				g.Expect(err).NotTo(HaveOccurred())
+
+				createdBuildRun = br
+
+				succeededCondition := br.Status.GetCondition(buildv1beta1.Succeeded)
+				g.Expect(succeededCondition).NotTo(BeNil(), "Succeeded condition should not be nil")
+				g.Expect(succeededCondition.Status).To(Equal(corev1.ConditionTrue), "BuildRun should have succeeded")
+
+			}, 2*time.Minute, 10*time.Second).Should(Succeed(), "BuildRun %s did not succeed within timeout.", createdBuildRun.Name)
+
+			GinkgoWriter.Printf("BuildRun %s completed successfully.\n", createdBuildRun.Name)
+		})
+	})
+})

--- a/test/e2e/setup.go
+++ b/test/e2e/setup.go
@@ -18,13 +18,19 @@ package e2e
 
 import (
 	"fmt"
+	"io"
+	"net/http"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2" //nolint:golint,revive
 	. "github.com/onsi/gomega"    //nolint:golint,revive
 
+	rbacv1 "k8s.io/api/rbac/v1"
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/client-go/kubernetes"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -39,9 +45,11 @@ import (
 )
 
 var (
-	kubeClient client.Client
-	mgr        *setup.OperatorManager
-	projectDir string
+	kubeClient    client.Client
+	mgr           *setup.OperatorManager
+	projectDir    string
+	clientset     *kubernetes.Clientset
+	testNamespace = "builds-test"
 )
 
 var _ = BeforeSuite(func(ctx SpecContext) {
@@ -51,6 +59,7 @@ var _ = BeforeSuite(func(ctx SpecContext) {
 	Expect(operatorv1alpha1.AddToScheme(scheme)).To(Succeed(), "setting up kubeClient")
 	Expect(shpoperatorv1alpha1.AddToScheme(scheme)).To(Succeed(), "setting up kubeClient")
 	Expect(buildv1beta1.AddToScheme(scheme)).To(Succeed(), "adding build to scheme")
+	Expect(rbacv1.AddToScheme(scheme)).To(Succeed(), "adding rbacv1 to scheme")
 
 	ctrl.SetLogger(GinkgoLogr)
 	config, err := ctrl.GetConfig()
@@ -59,6 +68,10 @@ var _ = BeforeSuite(func(ctx SpecContext) {
 		Scheme: scheme,
 	})
 	Expect(err).NotTo(HaveOccurred(), "setting up kubeClient")
+
+	// clientset - to retrieve streaming logs from pods' containers for debugging purposes.
+	clientset, err = kubernetes.NewForConfig(config)
+	Expect(err).NotTo(HaveOccurred(), "failed to create Kubernetes clientset")
 
 	By("Setting up project directory value")
 	projectDir, err = utils.GetProjectDir()
@@ -70,15 +83,103 @@ var _ = BeforeSuite(func(ctx SpecContext) {
 		Expect(err).NotTo(HaveOccurred(), "ensure Builds for OpenShift installed")
 	})
 
-	By("Creating the builds-test namespace", func() {
+	By(fmt.Sprintf("Creating the %s namespace", testNamespace), func() {
 		ns := &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "builds-test",
+				Name: testNamespace,
 			},
 		}
-		Expect(kubeClient.Create(ctx, ns)).To(Succeed())
+		err := kubeClient.Create(ctx, ns)
+		if err != nil && !errors.IsAlreadyExists(err) {
+			Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("failed to create namespace %s", testNamespace))
+		} else if errors.IsAlreadyExists(err) {
+			GinkgoWriter.Printf("Namespace %s already exists, proceeding.\n", testNamespace)
+		}
 	})
 
+	By("Ensuring 'buildpacks' ClusterBuildStrategy is present", func() {
+		cbsName := "buildpacks-extender"
+		cbs := &buildv1beta1.ClusterBuildStrategy{}
+
+		// Check if the ClusterBuildStrategy already exists
+		err := kubeClient.Get(ctx, client.ObjectKey{Name: cbsName}, cbs)
+		if err != nil {
+			if errors.IsNotFound(err) {
+				GinkgoWriter.Printf("ClusterBuildStrategy '%s' not found. Applying it from remote URL.\n", cbsName)
+
+				resp, fetchErr := http.Get("https://raw.githubusercontent.com/redhat-developer/openshift-builds-catalog/main/clusterBuildStrategy/buildpacks-extender/buildpacks-extender.yaml")
+				Expect(fetchErr).NotTo(HaveOccurred(), "failed to fetch ClusterBuildStrategy YAML")
+				defer resp.Body.Close()
+				Expect(resp.StatusCode).To(Equal(http.StatusOK), fmt.Sprintf("expected HTTP 200, got %d from URL", resp.StatusCode))
+
+				yamlBytes, readErr := io.ReadAll(resp.Body)
+				Expect(readErr).NotTo(HaveOccurred(), "failed to read ClusterBuildStrategy YAML")
+
+				// Decode the YAML into a ClusterBuildStrategy object using the scheme
+				deserializer := serializer.NewCodecFactory(scheme).UniversalDeserializer()
+
+				newCBS := &buildv1beta1.ClusterBuildStrategy{}
+				_, _, decodeErr := deserializer.Decode(yamlBytes, nil, newCBS)
+				Expect(decodeErr).NotTo(HaveOccurred(), "failed to decode ClusterBuildStrategy YAML")
+
+				if newCBS.Name == "" {
+					newCBS.Name = cbsName
+				}
+
+				createErr := kubeClient.Create(ctx, newCBS)
+				Expect(createErr).NotTo(HaveOccurred(), fmt.Sprintf("failed to create ClusterBuildStrategy %s", cbsName))
+				GinkgoWriter.Printf("ClusterBuildStrategy '%s' applied successfully.\n", cbsName)
+			} else {
+				Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("failed to get ClusterBuildStrategy '%s': %v", cbsName, err))
+			}
+		} else {
+			GinkgoWriter.Printf("ClusterBuildStrategy '%s' already exists. No action needed.\n", cbsName)
+		}
+	})
+
+	By(fmt.Sprintf("Granting default service account the ability to pull images in namespace %s", testNamespace), func() {
+		defaultSaName := "default"
+		Eventually(func() error {
+			return kubeClient.Get(ctx, client.ObjectKey{Name: defaultSaName, Namespace: testNamespace}, &corev1.ServiceAccount{})
+		}, 2*time.Minute, 5*time.Second).Should(Succeed(), "service account %s not found", defaultSaName)
+
+		roleBindingName := fmt.Sprintf("%s-image-puller", defaultSaName)
+		roleBinding := &rbacv1.RoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      roleBindingName,
+				Namespace: testNamespace,
+			},
+			Subjects: []rbacv1.Subject{
+				{
+					Kind:      "ServiceAccount",
+					Name:      defaultSaName,
+					Namespace: testNamespace,
+				},
+			},
+			RoleRef: rbacv1.RoleRef{
+				APIGroup: "rbac.authorization.k8s.io",
+				Kind:     "ClusterRole",
+				Name:     "system:image-puller",
+			},
+		}
+
+		// Check if the RoleBinding already exists
+		getRoleBinding := &rbacv1.RoleBinding{}
+		err := kubeClient.Get(ctx, client.ObjectKey{Name: roleBindingName, Namespace: testNamespace}, getRoleBinding)
+
+		if err != nil {
+			if errors.IsNotFound(err) {
+				GinkgoWriter.Printf("RoleBinding '%s' not found. Creating it.\n", roleBindingName)
+				createErr := kubeClient.Create(ctx, roleBinding)
+				Expect(createErr).NotTo(HaveOccurred(), fmt.Sprintf("failed to create RoleBinding %s for service account %s: %v", roleBindingName, defaultSaName, createErr))
+				GinkgoWriter.Printf("RoleBinding '%s' created successfully.\n", roleBindingName)
+			} else {
+				Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("failed to get RoleBinding '%s': %v", roleBindingName, err))
+			}
+		} else {
+			GinkgoWriter.Printf("RoleBinding '%s' already exists. No action needed.\n", roleBindingName)
+		}
+	})
 })
 
 var _ = AfterSuite(func(ctx SpecContext) {


### PR DESCRIPTION
This test sets up a dedicated testing namespace, ensure the buildpacks ClusterBuildStrategy and essential RBAC permissions are in place, and then trigger and monitor the successful completion of BuildRuns for a sample Node.js application, verifying the image build process from source to a finished container image within the cluster.

Jira issue linked for this PR: https://issues.redhat.com/browse/BUILD-1429
