### PR TITLE
chore: bump shipwright release to 0.16

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ endif
 
 # Set the Operator SDK version to use. By default, what is installed on the system is used.
 # This is useful for CI or a project to utilize a specific version of the operator-sdk toolkit.
-OPERATOR_SDK_VERSION ?= v1.35.0
+OPERATOR_SDK_VERSION ?= v1.39.2
 
 # Use OPERATOR_TAG to use a different tag to build and push the operator image.
 # This defaults to semantic version of the operator above.
@@ -234,7 +234,7 @@ YQ ?= $(LOCALBIN)/yq
 #ENVTEST_VERSION ?= release-0.20
 
 ## Upstream Sources
-SHIPWRIGHT_RELEASE ?= release-v0.15
+SHIPWRIGHT_RELEASE ?= release-v0.16
 SHIPWRIGHT_SOURCE ?= https://raw.githubusercontent.com/shipwright-io/operator/$(SHIPWRIGHT_RELEASE)
 
 # ClusterBuildStrategy Sources

--- a/bundle/manifests/buildpack-nodejs-build_console.openshift.io_v1_consoleyamlsample.yaml
+++ b/bundle/manifests/buildpack-nodejs-build_console.openshift.io_v1_consoleyamlsample.yaml
@@ -20,9 +20,8 @@ spec:
         type: Git
         git:
           url: https://github.com/redhat-openshift-builds/samples.git
-        contextDir: buildpack/nodejs
       strategy:
-        name: buildpacks
+        name: buildpacks-extender
         kind: ClusterBuildStrategy
       retention:
         atBuildDeletion: true
@@ -31,5 +30,7 @@ spec:
           value: paketobuildpacks/run-ubi8-base:latest
         - name: cnb-builder-image
           value: paketobuildpacks/builder-jammy-tiny:0.0.344
+        - name: source-subpath
+          value: "buildpack/nodejs"
       output:
-        image: ttl.sh/buildpacks-testing:6h
+        image: ttl.sh/buildpack-sample:1h

--- a/bundle/manifests/openshift-builds-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/openshift-builds-operator.clusterserviceversion.yaml
@@ -36,7 +36,7 @@ metadata:
     categories: Developer Tools, Integration & Delivery
     certified: "true"
     containerImage: registry.redhat.io/openshift-builds/openshift-builds-operator-rhel9
-    createdAt: "2025-05-27T13:04:38Z"
+    createdAt: "2025-07-16T14:55:46Z"
     description: Builds for Red Hat OpenShift is a framework for building container images on Kubernetes.
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
@@ -51,7 +51,7 @@ metadata:
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-builds
     operators.openshift.io/valid-subscription: '["OpenShift Container Platform", "OpenShift Platform Plus"]'
-    operators.operatorframework.io/builder: operator-sdk-v1.39.2
+    operators.operatorframework.io/builder: operator-sdk-v1.35.0
     operators.operatorframework.io/internal-objects: '["openshiftbuilds.operator.openshift.io","shipwrightbuilds.operator.shipwright.io"]'
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
     repository: https://github.com/shipwright-io/operator
@@ -67,9 +67,7 @@ spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
-      - description: |-
-          OpenShiftBuild describes the desired state of Builds for OpenShift, and the status of
-          all deployed components.
+      - description: OpenShiftBuild describes the desired state of Builds for OpenShift, and the status of all deployed components.
         displayName: Open Shift Build
         kind: OpenShiftBuild
         name: openshiftbuilds.operator.openshift.io
@@ -83,7 +81,7 @@ spec:
       - kind: TektonConfig
         name: tektonconfigs.operator.tekton.dev
         version: v1alpha1
-  description: "Builds for Red Hat OpenShift is an extensible build framework based on the Shipwright project, \nwhich you can use to build container images on an OpenShift Container Platform cluster. \nYou can build container images from source code and Dockerfile by using image build tools, \nsuch as Source-to-Image (S2I) and Buildah. You can create and apply build resources, view logs of build runs, \nand manage builds in your OpenShift Container Platform namespaces.\nRead more: [https://shipwright.io](https://shipwright.io)\n\n## Features\n\n* Standard Kubernetes-native API for building container images from source code and Dockerfile\n\n* Support for Source-to-Image (S2I) and Buildah build strategies\n\n* Extensibility with your own custom build strategies\n\n* Execution of builds from source code in a local directory\n\n* Shipwright CLI for creating and viewing logs, and managing builds on the cluster\n\n* Integrated user experience with the Developer perspective of the OpenShift Container Platform web console\n"
+  description: "Builds for Red Hat OpenShift is an extensible build framework based on the Shipwright project, \nwhich you can use to build container images on an OpenShift Container Platform cluster. \nYou can build container images from source code and Dockerfile by using image build tools, \nsuch as Source-to-Image (S2I), Buildah, and Buildpacks. You can create and apply build resources, view logs of build runs, \nand manage builds in your OpenShift Container Platform namespaces.\nRead more: [https://shipwright.io](https://shipwright.io)\n\n## Features\n\n* Standard Kubernetes-native API for building container images from source code and Dockerfile\n\n* Support for Source-to-Image (S2I) and Buildah build strategies\n\n* Extensibility with your own custom build strategies\n\n* Execution of builds from source code in a local directory\n\n* Shipwright CLI for creating and viewing logs, and managing builds on the cluster\n\n* Integrated user experience with the Developer perspective of the OpenShift Container Platform web console\n"
   displayName: Builds for Red Hat OpenShift Operator
   icon:
     - base64data: |
@@ -695,7 +693,7 @@ spec:
                       - --upstream=http://127.0.0.1:8080/
                       - --logtostderr=true
                       - --v=0
-                    image: registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9@sha256:bbf95f039dcc3a1be3c376f668d903493dd3b9edcf52f1789653978d664dc867
+                    image: registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9@sha256:4509d430610a6da34af6611c9673ab7211f59ae931c6931aa006995f6132fe14
                     name: kube-rbac-proxy
                     ports:
                       - containerPort: 8443
@@ -734,7 +732,7 @@ spec:
                         value: registry.redhat.io/openshift-builds/openshift-builds-waiters-rhel9@sha256:753e24a1cd57ca22552447363aed48f064b525b49e52f774f3e25f41d8dcb329
                       - name: IMAGE_SHIPWRIGHT_SHIPWRIGHT_BUILD_WEBHOOK
                         value: registry.redhat.io/openshift-builds/openshift-builds-webhook-rhel9@sha256:f4a75c115b5dc8853845f666f3bd063b2736e01e428a605fb5cd0f02736ecce8
-                    image: registry.redhat.io/openshift-builds/openshift-builds-rhel9-operator@sha256:b35eac4eb61aa02259f83ffe609def21af29c52f15e8224c2a5b47d015916d06
+                    image: registry.redhat.io/openshift-builds/openshift-builds-rhel9-operator@sha256:80b89c37fa242d22edf1b1eebe5ccdd41bbfc362fe779cb808464ba506ef73f2
                     imagePullPolicy: Always
                     livenessProbe:
                       httpGet:

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -3,6 +3,6 @@ resources:
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
-- name: operator
+- digest: sha256:80b89c37fa242d22edf1b1eebe5ccdd41bbfc362fe779cb808464ba506ef73f2
+  name: operator
   newName: registry.redhat.io/openshift-builds/openshift-builds-rhel9-operator
-  digest: sha256:80b89c37fa242d22edf1b1eebe5ccdd41bbfc362fe779cb808464ba506ef73f2

--- a/config/manifests/bases/openshift-builds-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/openshift-builds-operator.clusterserviceversion.yaml
@@ -43,9 +43,8 @@ spec:
       kind: ShipwrightBuild
       name: shipwrightbuilds.operator.shipwright.io
       version: v1alpha1
-    - description: |-
-        OpenShiftBuild describes the desired state of Builds for OpenShift, and the status of
-        all deployed components.
+    - description: OpenShiftBuild describes the desired state of Builds for OpenShift,
+        and the status of all deployed components.
       displayName: Open Shift Build
       kind: OpenShiftBuild
       name: openshiftbuilds.operator.openshift.io
@@ -58,13 +57,13 @@ spec:
     on the Shipwright project, \nwhich you can use to build container images on an
     OpenShift Container Platform cluster. \nYou can build container images from source
     code and Dockerfile by using image build tools, \nsuch as Source-to-Image (S2I),
-    Buildah, and Buildpacks. You can create and apply build resources, view logs of build runs,
-    \nand manage builds in your OpenShift Container Platform namespaces.\nRead more:
-    [https://shipwright.io](https://shipwright.io)\n\n## Features\n\n* Standard Kubernetes-native
-    API for building container images from source code and Dockerfile\n\n* Support
-    for Source-to-Image (S2I) and Buildah build strategies\n\n* Extensibility with
-    your own custom build strategies\n\n* Execution of builds from source code in
-    a local directory\n\n* Shipwright CLI for creating and viewing logs, and managing
+    Buildah, and Buildpacks. You can create and apply build resources, view logs of
+    build runs, \nand manage builds in your OpenShift Container Platform namespaces.\nRead
+    more: [https://shipwright.io](https://shipwright.io)\n\n## Features\n\n* Standard
+    Kubernetes-native API for building container images from source code and Dockerfile\n\n*
+    Support for Source-to-Image (S2I) and Buildah build strategies\n\n* Extensibility
+    with your own custom build strategies\n\n* Execution of builds from source code
+    in a local directory\n\n* Shipwright CLI for creating and viewing logs, and managing
     builds on the cluster\n\n* Integrated user experience with the Developer perspective
     of the OpenShift Container Platform web console\n"
   displayName: Builds for Red Hat OpenShift Operator

--- a/config/shipwright/build/release/release.yaml
+++ b/config/shipwright/build/release/release.yaml
@@ -74,9 +74,6 @@ rules:
   - apiGroups: ['']
     resources: ['serviceaccounts']
     verbs: ['get', 'list', 'watch', 'create', 'update', 'delete']
-  - apiGroups: ['apiextensions.k8s.io']
-    resources: ['customresourcedefinitions', 'customresourcedefinitions/status']
-    verbs: ['get', 'patch']
 
 ---
 kind: ClusterRoleBinding
@@ -155,7 +152,7 @@ spec:
       serviceAccountName: shipwright-build-controller
       containers:
         - name: shipwright-build
-          image: ghcr.io/shipwright-io/build/shipwright-build-controller:v0.15.2@sha256:5dcf4f49a342150ab417e09ff1b8d73c3ef39f780d9d3c41ba7f5d842908e00f
+          image: ghcr.io/shipwright-io/build/shipwright-build-controller:v0.16.0@sha256:26d34f8a1ef756786a840f1619e94f2c031c7849f7992742ed909c4e44c1e004
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -172,15 +169,15 @@ spec:
             - name: CONTROLLER_NAME
               value: "shipwright-build"
             - name: GIT_CONTAINER_IMAGE
-              value: ghcr.io/shipwright-io/build/git:v0.15.2@sha256:649a483c3d87a538761817d5f509ee50a88d6d7b952114002c62ae13315217bd
+              value: ghcr.io/shipwright-io/build/git:v0.16.0@sha256:e8d9fdec3ef0dd146511b0eec5041a57782924d144422db97eab71a56f351da4
             - name: GIT_ENABLE_REWRITE_RULE
               value: "false"
             - name: IMAGE_PROCESSING_CONTAINER_IMAGE
-              value: ghcr.io/shipwright-io/build/image-processing:v0.15.2@sha256:02f9073bcc9ca67c087e4ab954b44366d465ac6fc44e03a9320aeada14c295f0
+              value: ghcr.io/shipwright-io/build/image-processing:v0.16.0@sha256:2b200bc7dfe815eca4d53073911e9c51dfd58906276821a2b22e4835e0dbd243
             - name: BUNDLE_CONTAINER_IMAGE
-              value: ghcr.io/shipwright-io/build/bundle:v0.15.2@sha256:84443b7ba9222f7486656e41b4b48aa9c8b7454ef578812f672232882c8149f8
+              value: ghcr.io/shipwright-io/build/bundle:v0.16.0@sha256:a3005ce84548c797436803b01f6f5192faf4b83f137eb89f8080ea14cd34d83a
             - name: WAITER_CONTAINER_IMAGE
-              value: ghcr.io/shipwright-io/build/waiter:v0.15.2@sha256:adc1c331430970b66ad6a2edfb8c21e89a0f5013e13f9ba9b3b727ed0be50e10
+              value: ghcr.io/shipwright-io/build/waiter:v0.16.0@sha256:d7fa697b8174a20694d9ebdae175ead8da9f1f04121c3db3ddf8bd97353c0917
           ports:
             - containerPort: 8383
               name: metrics-port
@@ -237,7 +234,7 @@ spec:
       serviceAccountName: shipwright-build-webhook
       containers:
         - name: shipwright-build-webhook
-          image: ghcr.io/shipwright-io/build/shipwright-build-webhook:v0.15.2@sha256:48406595f65439706df5a39571f07e0554ac982446013e2af1e893ca99189673
+          image: ghcr.io/shipwright-io/build/shipwright-build-webhook:v0.16.0@sha256:d4e8eea692f490632c5ae643a299c5e88e02b2d1684fe533f2b75c6752120dfd
           volumeMounts:
             - name: webhook-certs
               mountPath: /etc/webhook/certs
@@ -308,7 +305,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: buildruns.shipwright.io
 spec:
   conversion:
@@ -394,7 +391,6 @@ spec:
                         Builder refers to the image containing the build tools inside which
                         the source code would be built.
 
-
                         NOTICE: Builder is deprecated, and will be removed in a future release.
                         Build strategies which rely on "builder" should provide an equivalent parameter instead.
                       properties:
@@ -415,9 +411,7 @@ spec:
                                 This field is effectively required, but due to backwards compatibility is
                                 allowed to be empty. Instances of this type with an empty value here are
                                 almost certainly wrong.
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
@@ -449,7 +443,6 @@ spec:
                         Dockerfile is the path to the Dockerfile to be used for
                         build strategies which bank on the Dockerfile for building
                         an image.
-
 
                         NOTICE: Dockerfile is deprecated, and will be removed in a future release.
                         Build strategies which rely on "dockerfile" should provide an equivalent parameter instead.
@@ -490,9 +483,7 @@ spec:
                                       This field is effectively required, but due to backwards compatibility is
                                       allowed to be empty. Instances of this type with an empty value here are
                                       almost certainly wrong.
-                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                     type: string
                                   optional:
                                     description: Specify whether the ConfigMap or its key must be defined
@@ -551,9 +542,7 @@ spec:
                                       This field is effectively required, but due to backwards compatibility is
                                       allowed to be empty. Instances of this type with an empty value here are
                                       almost certainly wrong.
-                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                     type: string
                                   optional:
                                     description: Specify whether the Secret or its key must be defined
@@ -587,9 +576,7 @@ spec:
                                 This field is effectively required, but due to backwards compatibility is
                                 allowed to be empty. Instances of this type with an empty value here are
                                 almost certainly wrong.
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
@@ -748,7 +735,6 @@ spec:
                                 values are 'Never' (no deletion) and `AfterPull` (removal after the
                                 image was successfully pulled from the registry).
 
-
                                 If not defined, it defaults to 'Never'.
                               type: string
                           required:
@@ -769,9 +755,7 @@ spec:
                                 This field is effectively required, but due to backwards compatibility is
                                 allowed to be empty. Instances of this type with an empty value here are
                                 almost certainly wrong.
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
@@ -779,7 +763,6 @@ spec:
                           description: |-
                             Revision describes the Git revision (e.g., branch, tag, commit SHA,
                             etc.) to fetch.
-
 
                             If not defined, it will fallback to the repository's default branch.
                           type: string
@@ -791,7 +774,6 @@ spec:
                       description: |-
                         Sources slice of BuildSource, defining external build artifacts complementary to VCS
                         (`.spec.source`) data.
-
 
                         NOTICE: Multiple sources in a build are deprecated. This feature will be removed in a future release.
                       items:
@@ -849,9 +831,7 @@ spec:
                                 This field is effectively required, but due to backwards compatibility is
                                 allowed to be empty. Instances of this type with an empty value here are
                                 almost certainly wrong.
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
@@ -927,6 +907,8 @@ spec:
                             description: |-
                               awsElasticBlockStore represents an AWS Disk resource that is attached to a
                               kubelet's host machine and then exposed to the pod.
+                              Deprecated: AWSElasticBlockStore is deprecated. All operations for the in-tree
+                              awsElasticBlockStore type are redirected to the ebs.csi.aws.com CSI driver.
                               More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                             properties:
                               fsType:
@@ -935,7 +917,6 @@ spec:
                                   Tip: Ensure that the filesystem type is supported by the host operating system.
                                   Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                                  TODO: how do we prevent errors in the filesystem from compromising the machine
                                 type: string
                               partition:
                                 description: |-
@@ -959,7 +940,10 @@ spec:
                               - volumeID
                             type: object
                           azureDisk:
-                            description: azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
+                            description: |-
+                              azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
+                              Deprecated: AzureDisk is deprecated. All operations for the in-tree azureDisk type
+                              are redirected to the disk.csi.azure.com CSI driver.
                             properties:
                               cachingMode:
                                 description: 'cachingMode is the Host Caching mode: None, Read Only, Read Write.'
@@ -971,6 +955,7 @@ spec:
                                 description: diskURI is the URI of data disk in the blob storage
                                 type: string
                               fsType:
+                                default: ext4
                                 description: |-
                                   fsType is Filesystem type to mount.
                                   Must be a filesystem type supported by the host operating system.
@@ -980,6 +965,7 @@ spec:
                                 description: 'kind expected values are Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared'
                                 type: string
                               readOnly:
+                                default: false
                                 description: |-
                                   readOnly Defaults to false (read/write). ReadOnly here will force
                                   the ReadOnly setting in VolumeMounts.
@@ -989,7 +975,10 @@ spec:
                               - diskURI
                             type: object
                           azureFile:
-                            description: azureFile represents an Azure File Service mount on the host and bind mount to the pod.
+                            description: |-
+                              azureFile represents an Azure File Service mount on the host and bind mount to the pod.
+                              Deprecated: AzureFile is deprecated. All operations for the in-tree azureFile type
+                              are redirected to the file.csi.azure.com CSI driver.
                             properties:
                               readOnly:
                                 description: |-
@@ -1007,7 +996,9 @@ spec:
                               - shareName
                             type: object
                           cephfs:
-                            description: cephFS represents a Ceph FS mount on the host that shares a pod's lifetime
+                            description: |-
+                              cephFS represents a Ceph FS mount on the host that shares a pod's lifetime.
+                              Deprecated: CephFS is deprecated and the in-tree cephfs type is no longer supported.
                             properties:
                               monitors:
                                 description: |-
@@ -1043,9 +1034,7 @@ spec:
                                       This field is effectively required, but due to backwards compatibility is
                                       allowed to be empty. Instances of this type with an empty value here are
                                       almost certainly wrong.
-                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                     type: string
                                 type: object
                                 x-kubernetes-map-type: atomic
@@ -1060,6 +1049,8 @@ spec:
                           cinder:
                             description: |-
                               cinder represents a cinder volume attached and mounted on kubelets host machine.
+                              Deprecated: Cinder is deprecated. All operations for the in-tree cinder type
+                              are redirected to the cinder.csi.openstack.org CSI driver.
                               More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                             properties:
                               fsType:
@@ -1087,9 +1078,7 @@ spec:
                                       This field is effectively required, but due to backwards compatibility is
                                       allowed to be empty. Instances of this type with an empty value here are
                                       almost certainly wrong.
-                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                     type: string
                                 type: object
                                 x-kubernetes-map-type: atomic
@@ -1160,9 +1149,7 @@ spec:
                                   This field is effectively required, but due to backwards compatibility is
                                   allowed to be empty. Instances of this type with an empty value here are
                                   almost certainly wrong.
-                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                 type: string
                               optional:
                                 description: optional specify whether the ConfigMap or its keys must be defined
@@ -1170,7 +1157,7 @@ spec:
                             type: object
                             x-kubernetes-map-type: atomic
                           csi:
-                            description: csi (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers (Beta feature).
+                            description: csi (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers.
                             properties:
                               driver:
                                 description: |-
@@ -1198,9 +1185,7 @@ spec:
                                       This field is effectively required, but due to backwards compatibility is
                                       allowed to be empty. Instances of this type with an empty value here are
                                       almost certainly wrong.
-                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                     type: string
                                 type: object
                                 x-kubernetes-map-type: atomic
@@ -1222,7 +1207,6 @@ spec:
                           description:
                             description: |-
                               Description of the Build Volume
-
 
                               NOTICE: Description is deprecated, and will be removed in a future release.
                             type: string
@@ -1332,7 +1316,6 @@ spec:
                               The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,
                               and deleted when the pod is removed.
 
-
                               Use this if:
                               a) the volume is only needed while the pod runs,
                               b) features of normal volumes like restoring from snapshot or capacity
@@ -1343,16 +1326,13 @@ spec:
                                  information on the connection between this volume type
                                  and PersistentVolumeClaim).
 
-
                               Use PersistentVolumeClaim or one of the vendor-specific
                               APIs for volumes that persist for longer than the lifecycle
                               of an individual pod.
 
-
                               Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to
                               be used that way - see the documentation of the driver for
                               more information.
-
 
                               A pod can use both types of ephemeral volumes and
                               persistent volumes at the same time.
@@ -1367,7 +1347,6 @@ spec:
                                   entry. Pod validation will reject the pod if the concatenated name
                                   is not valid for a PVC (for example, too long).
 
-
                                   An existing PVC with that name that is not owned by the pod
                                   will *not* be used for the pod to avoid using an unrelated
                                   volume by mistake. Starting the pod is then blocked until
@@ -1377,10 +1356,8 @@ spec:
                                   this should not be necessary, but it may be useful when
                                   manually reconstructing a broken cluster.
 
-
                                   This field is read-only and no changes will be made by Kubernetes
                                   to the PVC after it has been created.
-
 
                                   Required, must not be nil.
                                 properties:
@@ -1576,7 +1553,7 @@ spec:
                                           set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
                                           exists.
                                           More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
-                                          (Alpha) Using this field requires the VolumeAttributesClass feature gate to be enabled.
+                                          (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).
                                         type: string
                                       volumeMode:
                                         description: |-
@@ -1599,7 +1576,6 @@ spec:
                                   fsType is the filesystem type to mount.
                                   Must be a filesystem type supported by the host operating system.
                                   Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                  TODO: how do we prevent errors in the filesystem from compromising the machine
                                 type: string
                               lun:
                                 description: 'lun is Optional: FC target lun number'
@@ -1629,6 +1605,7 @@ spec:
                             description: |-
                               flexVolume represents a generic volume resource that is
                               provisioned/attached using an exec based plugin.
+                              Deprecated: FlexVolume is deprecated. Consider using a CSIDriver instead.
                             properties:
                               driver:
                                 description: driver is the name of the driver to use for this volume.
@@ -1664,9 +1641,7 @@ spec:
                                       This field is effectively required, but due to backwards compatibility is
                                       allowed to be empty. Instances of this type with an empty value here are
                                       almost certainly wrong.
-                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                     type: string
                                 type: object
                                 x-kubernetes-map-type: atomic
@@ -1674,7 +1649,9 @@ spec:
                               - driver
                             type: object
                           flocker:
-                            description: flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running
+                            description: |-
+                              flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running.
+                              Deprecated: Flocker is deprecated and the in-tree flocker type is no longer supported.
                             properties:
                               datasetName:
                                 description: |-
@@ -1689,6 +1666,8 @@ spec:
                             description: |-
                               gcePersistentDisk represents a GCE Disk resource that is attached to a
                               kubelet's host machine and then exposed to the pod.
+                              Deprecated: GCEPersistentDisk is deprecated. All operations for the in-tree
+                              gcePersistentDisk type are redirected to the pd.csi.storage.gke.io CSI driver.
                               More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                             properties:
                               fsType:
@@ -1697,7 +1676,6 @@ spec:
                                   Tip: Ensure that the filesystem type is supported by the host operating system.
                                   Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                                  TODO: how do we prevent errors in the filesystem from compromising the machine
                                 type: string
                               partition:
                                 description: |-
@@ -1725,7 +1703,7 @@ spec:
                           gitRepo:
                             description: |-
                               gitRepo represents a git repository at a particular revision.
-                              DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an
+                              Deprecated: GitRepo is deprecated. To provision a container with a git repo, mount an
                               EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
                               into the Pod's container.
                             properties:
@@ -1748,6 +1726,7 @@ spec:
                           glusterfs:
                             description: |-
                               glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
+                              Deprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported.
                               More info: https://examples.k8s.io/volumes/glusterfs/README.md
                             properties:
                               endpoints:
@@ -1777,9 +1756,6 @@ spec:
                               used for system agents or other privileged things that are allowed
                               to see the host machine. Most containers will NOT need this.
                               More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-                              ---
-                              TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not
-                              mount host directories as read/write.
                             properties:
                               path:
                                 description: |-
@@ -1795,6 +1771,41 @@ spec:
                                 type: string
                             required:
                               - path
+                            type: object
+                          image:
+                            description: |-
+                              image represents an OCI object (a container image or artifact) pulled and mounted on the kubelet's host machine.
+                              The volume is resolved at pod startup depending on which PullPolicy value is provided:
+
+                              - Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                              - Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                              - IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+
+                              The volume gets re-resolved if the pod gets deleted and recreated, which means that new remote content will become available on pod recreation.
+                              A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
+                              The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
+                              The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
+                              The volume will be mounted read-only (ro) and non-executable files (noexec).
+                              Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath).
+                              The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
+                            properties:
+                              pullPolicy:
+                                description: |-
+                                  Policy for pulling OCI objects. Possible values are:
+                                  Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                                  Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                                  IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+                                  Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                type: string
+                              reference:
+                                description: |-
+                                  Required: Image or artifact reference to be used.
+                                  Behaves in the same way as pod.spec.containers[*].image.
+                                  Pull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets.
+                                  More info: https://kubernetes.io/docs/concepts/containers/images
+                                  This field is optional to allow higher level config management to default or override
+                                  container images in workload controllers like Deployments and StatefulSets.
+                                type: string
                             type: object
                           iscsi:
                             description: |-
@@ -1814,7 +1825,6 @@ spec:
                                   Tip: Ensure that the filesystem type is supported by the host operating system.
                                   Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                                  TODO: how do we prevent errors in the filesystem from compromising the machine
                                 type: string
                               initiatorName:
                                 description: |-
@@ -1826,6 +1836,7 @@ spec:
                                 description: iqn is the target iSCSI Qualified Name.
                                 type: string
                               iscsiInterface:
+                                default: default
                                 description: |-
                                   iscsiInterface is the interface Name that uses an iSCSI transport.
                                   Defaults to 'default' (tcp).
@@ -1857,9 +1868,7 @@ spec:
                                       This field is effectively required, but due to backwards compatibility is
                                       allowed to be empty. Instances of this type with an empty value here are
                                       almost certainly wrong.
-                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                     type: string
                                 type: object
                                 x-kubernetes-map-type: atomic
@@ -1921,7 +1930,9 @@ spec:
                               - claimName
                             type: object
                           photonPersistentDisk:
-                            description: photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine
+                            description: |-
+                              photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine.
+                              Deprecated: PhotonPersistentDisk is deprecated and the in-tree photonPersistentDisk type is no longer supported.
                             properties:
                               fsType:
                                 description: |-
@@ -1936,7 +1947,11 @@ spec:
                               - pdID
                             type: object
                           portworxVolume:
-                            description: portworxVolume represents a portworx volume attached and mounted on kubelets host machine
+                            description: |-
+                              portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
+                              Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
+                              are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
+                              is on.
                             properties:
                               fsType:
                                 description: |-
@@ -1969,22 +1984,23 @@ spec:
                                 format: int32
                                 type: integer
                               sources:
-                                description: sources is the list of volume projections
+                                description: |-
+                                  sources is the list of volume projections. Each entry in this list
+                                  handles one source.
                                 items:
-                                  description: Projection that may be projected along with other supported volume types
+                                  description: |-
+                                    Projection that may be projected along with other supported volume types.
+                                    Exactly one of these fields must be set.
                                   properties:
                                     clusterTrustBundle:
                                       description: |-
                                         ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field
                                         of ClusterTrustBundle objects in an auto-updating file.
 
-
                                         Alpha, gated by the ClusterTrustBundleProjection feature gate.
-
 
                                         ClusterTrustBundle objects can either be selected by name, or by the
                                         combination of signer name and a label selector.
-
 
                                         Kubelet performs aggressive normalization of the PEM contents written
                                         into the pod filesystem.  Esoteric PEM features such as inter-block
@@ -2113,9 +2129,7 @@ spec:
                                             This field is effectively required, but due to backwards compatibility is
                                             allowed to be empty. Instances of this type with an empty value here are
                                             almost certainly wrong.
-                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                             More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                           type: string
                                         optional:
                                           description: optional specify whether the ConfigMap or its keys must be defined
@@ -2232,9 +2246,7 @@ spec:
                                             This field is effectively required, but due to backwards compatibility is
                                             allowed to be empty. Instances of this type with an empty value here are
                                             almost certainly wrong.
-                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                             More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                           type: string
                                         optional:
                                           description: optional field specify whether the Secret or its key must be defined
@@ -2274,7 +2286,9 @@ spec:
                                 x-kubernetes-list-type: atomic
                             type: object
                           quobyte:
-                            description: quobyte represents a Quobyte mount on the host that shares a pod's lifetime
+                            description: |-
+                              quobyte represents a Quobyte mount on the host that shares a pod's lifetime.
+                              Deprecated: Quobyte is deprecated and the in-tree quobyte type is no longer supported.
                             properties:
                               group:
                                 description: |-
@@ -2312,6 +2326,7 @@ spec:
                           rbd:
                             description: |-
                               rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
+                              Deprecated: RBD is deprecated and the in-tree rbd type is no longer supported.
                               More info: https://examples.k8s.io/volumes/rbd/README.md
                             properties:
                               fsType:
@@ -2320,7 +2335,6 @@ spec:
                                   Tip: Ensure that the filesystem type is supported by the host operating system.
                                   Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                                  TODO: how do we prevent errors in the filesystem from compromising the machine
                                 type: string
                               image:
                                 description: |-
@@ -2328,6 +2342,7 @@ spec:
                                   More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                 type: string
                               keyring:
+                                default: /etc/ceph/keyring
                                 description: |-
                                   keyring is the path to key ring for RBDUser.
                                   Default is /etc/ceph/keyring.
@@ -2342,6 +2357,7 @@ spec:
                                 type: array
                                 x-kubernetes-list-type: atomic
                               pool:
+                                default: rbd
                                 description: |-
                                   pool is the rados pool name.
                                   Default is rbd.
@@ -2367,13 +2383,12 @@ spec:
                                       This field is effectively required, but due to backwards compatibility is
                                       allowed to be empty. Instances of this type with an empty value here are
                                       almost certainly wrong.
-                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                     type: string
                                 type: object
                                 x-kubernetes-map-type: atomic
                               user:
+                                default: admin
                                 description: |-
                                   user is the rados user name.
                                   Default is admin.
@@ -2384,9 +2399,12 @@ spec:
                               - monitors
                             type: object
                           scaleIO:
-                            description: scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
+                            description: |-
+                              scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
+                              Deprecated: ScaleIO is deprecated and the in-tree scaleIO type is no longer supported.
                             properties:
                               fsType:
+                                default: xfs
                                 description: |-
                                   fsType is the filesystem type to mount.
                                   Must be a filesystem type supported by the host operating system.
@@ -2416,9 +2434,7 @@ spec:
                                       This field is effectively required, but due to backwards compatibility is
                                       allowed to be empty. Instances of this type with an empty value here are
                                       almost certainly wrong.
-                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                     type: string
                                 type: object
                                 x-kubernetes-map-type: atomic
@@ -2426,6 +2442,7 @@ spec:
                                 description: sslEnabled Flag enable/disable SSL communication with Gateway, default false
                                 type: boolean
                               storageMode:
+                                default: ThinProvisioned
                                 description: |-
                                   storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
                                   Default is ThinProvisioned.
@@ -2510,7 +2527,9 @@ spec:
                                 type: string
                             type: object
                           storageos:
-                            description: storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
+                            description: |-
+                              storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
+                              Deprecated: StorageOS is deprecated and the in-tree storageos type is no longer supported.
                             properties:
                               fsType:
                                 description: |-
@@ -2535,9 +2554,7 @@ spec:
                                       This field is effectively required, but due to backwards compatibility is
                                       allowed to be empty. Instances of this type with an empty value here are
                                       almost certainly wrong.
-                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                     type: string
                                 type: object
                                 x-kubernetes-map-type: atomic
@@ -2557,7 +2574,10 @@ spec:
                                 type: string
                             type: object
                           vsphereVolume:
-                            description: vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine
+                            description: |-
+                              vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine.
+                              Deprecated: VsphereVolume is deprecated. All operations for the in-tree vsphereVolume type
+                              are redirected to the csi.vsphere.vmware.com CSI driver.
                             properties:
                               fsType:
                                 description: |-
@@ -2578,6 +2598,7 @@ spec:
                               - volumePath
                             type: object
                         required:
+                          - ""
                           - name
                         type: object
                       type: array
@@ -2622,9 +2643,7 @@ spec:
                                   This field is effectively required, but due to backwards compatibility is
                                   allowed to be empty. Instances of this type with an empty value here are
                                   almost certainly wrong.
-                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                 type: string
                               optional:
                                 description: Specify whether the ConfigMap or its key must be defined
@@ -2683,9 +2702,7 @@ spec:
                                   This field is effectively required, but due to backwards compatibility is
                                   allowed to be empty. Instances of this type with an empty value here are
                                   almost certainly wrong.
-                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                 type: string
                               optional:
                                 description: Specify whether the Secret or its key must be defined
@@ -2721,9 +2738,7 @@ spec:
                             This field is effectively required, but due to backwards compatibility is
                             allowed to be empty. Instances of this type with an empty value here are
                             almost certainly wrong.
-                            TODO: Add other useful fields. apiVersion, kind, uid?
                             More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                           type: string
                       type: object
                       x-kubernetes-map-type: atomic
@@ -2867,7 +2882,6 @@ spec:
                       description: |-
                         If generates a new ServiceAccount for the build
 
-
                         NOTICE: Generated ServiceAccounts are deprecated, and will be removed in a future release.
                       type: boolean
                     name:
@@ -2917,6 +2931,8 @@ spec:
                         description: |-
                           awsElasticBlockStore represents an AWS Disk resource that is attached to a
                           kubelet's host machine and then exposed to the pod.
+                          Deprecated: AWSElasticBlockStore is deprecated. All operations for the in-tree
+                          awsElasticBlockStore type are redirected to the ebs.csi.aws.com CSI driver.
                           More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                         properties:
                           fsType:
@@ -2925,7 +2941,6 @@ spec:
                               Tip: Ensure that the filesystem type is supported by the host operating system.
                               Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                               More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                              TODO: how do we prevent errors in the filesystem from compromising the machine
                             type: string
                           partition:
                             description: |-
@@ -2949,7 +2964,10 @@ spec:
                           - volumeID
                         type: object
                       azureDisk:
-                        description: azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
+                        description: |-
+                          azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
+                          Deprecated: AzureDisk is deprecated. All operations for the in-tree azureDisk type
+                          are redirected to the disk.csi.azure.com CSI driver.
                         properties:
                           cachingMode:
                             description: 'cachingMode is the Host Caching mode: None, Read Only, Read Write.'
@@ -2961,6 +2979,7 @@ spec:
                             description: diskURI is the URI of data disk in the blob storage
                             type: string
                           fsType:
+                            default: ext4
                             description: |-
                               fsType is Filesystem type to mount.
                               Must be a filesystem type supported by the host operating system.
@@ -2970,6 +2989,7 @@ spec:
                             description: 'kind expected values are Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared'
                             type: string
                           readOnly:
+                            default: false
                             description: |-
                               readOnly Defaults to false (read/write). ReadOnly here will force
                               the ReadOnly setting in VolumeMounts.
@@ -2979,7 +2999,10 @@ spec:
                           - diskURI
                         type: object
                       azureFile:
-                        description: azureFile represents an Azure File Service mount on the host and bind mount to the pod.
+                        description: |-
+                          azureFile represents an Azure File Service mount on the host and bind mount to the pod.
+                          Deprecated: AzureFile is deprecated. All operations for the in-tree azureFile type
+                          are redirected to the file.csi.azure.com CSI driver.
                         properties:
                           readOnly:
                             description: |-
@@ -2997,7 +3020,9 @@ spec:
                           - shareName
                         type: object
                       cephfs:
-                        description: cephFS represents a Ceph FS mount on the host that shares a pod's lifetime
+                        description: |-
+                          cephFS represents a Ceph FS mount on the host that shares a pod's lifetime.
+                          Deprecated: CephFS is deprecated and the in-tree cephfs type is no longer supported.
                         properties:
                           monitors:
                             description: |-
@@ -3033,9 +3058,7 @@ spec:
                                   This field is effectively required, but due to backwards compatibility is
                                   allowed to be empty. Instances of this type with an empty value here are
                                   almost certainly wrong.
-                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
@@ -3050,6 +3073,8 @@ spec:
                       cinder:
                         description: |-
                           cinder represents a cinder volume attached and mounted on kubelets host machine.
+                          Deprecated: Cinder is deprecated. All operations for the in-tree cinder type
+                          are redirected to the cinder.csi.openstack.org CSI driver.
                           More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                         properties:
                           fsType:
@@ -3077,9 +3102,7 @@ spec:
                                   This field is effectively required, but due to backwards compatibility is
                                   allowed to be empty. Instances of this type with an empty value here are
                                   almost certainly wrong.
-                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
@@ -3150,9 +3173,7 @@ spec:
                               This field is effectively required, but due to backwards compatibility is
                               allowed to be empty. Instances of this type with an empty value here are
                               almost certainly wrong.
-                              TODO: Add other useful fields. apiVersion, kind, uid?
                               More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                             type: string
                           optional:
                             description: optional specify whether the ConfigMap or its keys must be defined
@@ -3160,7 +3181,7 @@ spec:
                         type: object
                         x-kubernetes-map-type: atomic
                       csi:
-                        description: csi (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers (Beta feature).
+                        description: csi (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers.
                         properties:
                           driver:
                             description: |-
@@ -3188,9 +3209,7 @@ spec:
                                   This field is effectively required, but due to backwards compatibility is
                                   allowed to be empty. Instances of this type with an empty value here are
                                   almost certainly wrong.
-                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
@@ -3212,7 +3231,6 @@ spec:
                       description:
                         description: |-
                           Description of the Build Volume
-
 
                           NOTICE: Description is deprecated, and will be removed in a future release.
                         type: string
@@ -3322,7 +3340,6 @@ spec:
                           The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,
                           and deleted when the pod is removed.
 
-
                           Use this if:
                           a) the volume is only needed while the pod runs,
                           b) features of normal volumes like restoring from snapshot or capacity
@@ -3333,16 +3350,13 @@ spec:
                              information on the connection between this volume type
                              and PersistentVolumeClaim).
 
-
                           Use PersistentVolumeClaim or one of the vendor-specific
                           APIs for volumes that persist for longer than the lifecycle
                           of an individual pod.
 
-
                           Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to
                           be used that way - see the documentation of the driver for
                           more information.
-
 
                           A pod can use both types of ephemeral volumes and
                           persistent volumes at the same time.
@@ -3357,7 +3371,6 @@ spec:
                               entry. Pod validation will reject the pod if the concatenated name
                               is not valid for a PVC (for example, too long).
 
-
                               An existing PVC with that name that is not owned by the pod
                               will *not* be used for the pod to avoid using an unrelated
                               volume by mistake. Starting the pod is then blocked until
@@ -3367,10 +3380,8 @@ spec:
                               this should not be necessary, but it may be useful when
                               manually reconstructing a broken cluster.
 
-
                               This field is read-only and no changes will be made by Kubernetes
                               to the PVC after it has been created.
-
 
                               Required, must not be nil.
                             properties:
@@ -3566,7 +3577,7 @@ spec:
                                       set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
                                       exists.
                                       More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
-                                      (Alpha) Using this field requires the VolumeAttributesClass feature gate to be enabled.
+                                      (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).
                                     type: string
                                   volumeMode:
                                     description: |-
@@ -3589,7 +3600,6 @@ spec:
                               fsType is the filesystem type to mount.
                               Must be a filesystem type supported by the host operating system.
                               Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                              TODO: how do we prevent errors in the filesystem from compromising the machine
                             type: string
                           lun:
                             description: 'lun is Optional: FC target lun number'
@@ -3619,6 +3629,7 @@ spec:
                         description: |-
                           flexVolume represents a generic volume resource that is
                           provisioned/attached using an exec based plugin.
+                          Deprecated: FlexVolume is deprecated. Consider using a CSIDriver instead.
                         properties:
                           driver:
                             description: driver is the name of the driver to use for this volume.
@@ -3654,9 +3665,7 @@ spec:
                                   This field is effectively required, but due to backwards compatibility is
                                   allowed to be empty. Instances of this type with an empty value here are
                                   almost certainly wrong.
-                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
@@ -3664,7 +3673,9 @@ spec:
                           - driver
                         type: object
                       flocker:
-                        description: flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running
+                        description: |-
+                          flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running.
+                          Deprecated: Flocker is deprecated and the in-tree flocker type is no longer supported.
                         properties:
                           datasetName:
                             description: |-
@@ -3679,6 +3690,8 @@ spec:
                         description: |-
                           gcePersistentDisk represents a GCE Disk resource that is attached to a
                           kubelet's host machine and then exposed to the pod.
+                          Deprecated: GCEPersistentDisk is deprecated. All operations for the in-tree
+                          gcePersistentDisk type are redirected to the pd.csi.storage.gke.io CSI driver.
                           More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                         properties:
                           fsType:
@@ -3687,7 +3700,6 @@ spec:
                               Tip: Ensure that the filesystem type is supported by the host operating system.
                               Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                               More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                              TODO: how do we prevent errors in the filesystem from compromising the machine
                             type: string
                           partition:
                             description: |-
@@ -3715,7 +3727,7 @@ spec:
                       gitRepo:
                         description: |-
                           gitRepo represents a git repository at a particular revision.
-                          DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an
+                          Deprecated: GitRepo is deprecated. To provision a container with a git repo, mount an
                           EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
                           into the Pod's container.
                         properties:
@@ -3738,6 +3750,7 @@ spec:
                       glusterfs:
                         description: |-
                           glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
+                          Deprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported.
                           More info: https://examples.k8s.io/volumes/glusterfs/README.md
                         properties:
                           endpoints:
@@ -3767,9 +3780,6 @@ spec:
                           used for system agents or other privileged things that are allowed
                           to see the host machine. Most containers will NOT need this.
                           More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-                          ---
-                          TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not
-                          mount host directories as read/write.
                         properties:
                           path:
                             description: |-
@@ -3785,6 +3795,41 @@ spec:
                             type: string
                         required:
                           - path
+                        type: object
+                      image:
+                        description: |-
+                          image represents an OCI object (a container image or artifact) pulled and mounted on the kubelet's host machine.
+                          The volume is resolved at pod startup depending on which PullPolicy value is provided:
+
+                          - Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                          - Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                          - IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+
+                          The volume gets re-resolved if the pod gets deleted and recreated, which means that new remote content will become available on pod recreation.
+                          A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
+                          The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
+                          The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
+                          The volume will be mounted read-only (ro) and non-executable files (noexec).
+                          Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath).
+                          The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
+                        properties:
+                          pullPolicy:
+                            description: |-
+                              Policy for pulling OCI objects. Possible values are:
+                              Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                              Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                              IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+                              Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                            type: string
+                          reference:
+                            description: |-
+                              Required: Image or artifact reference to be used.
+                              Behaves in the same way as pod.spec.containers[*].image.
+                              Pull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets.
+                              More info: https://kubernetes.io/docs/concepts/containers/images
+                              This field is optional to allow higher level config management to default or override
+                              container images in workload controllers like Deployments and StatefulSets.
+                            type: string
                         type: object
                       iscsi:
                         description: |-
@@ -3804,7 +3849,6 @@ spec:
                               Tip: Ensure that the filesystem type is supported by the host operating system.
                               Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                               More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                              TODO: how do we prevent errors in the filesystem from compromising the machine
                             type: string
                           initiatorName:
                             description: |-
@@ -3816,6 +3860,7 @@ spec:
                             description: iqn is the target iSCSI Qualified Name.
                             type: string
                           iscsiInterface:
+                            default: default
                             description: |-
                               iscsiInterface is the interface Name that uses an iSCSI transport.
                               Defaults to 'default' (tcp).
@@ -3847,9 +3892,7 @@ spec:
                                   This field is effectively required, but due to backwards compatibility is
                                   allowed to be empty. Instances of this type with an empty value here are
                                   almost certainly wrong.
-                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
@@ -3911,7 +3954,9 @@ spec:
                           - claimName
                         type: object
                       photonPersistentDisk:
-                        description: photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine
+                        description: |-
+                          photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine.
+                          Deprecated: PhotonPersistentDisk is deprecated and the in-tree photonPersistentDisk type is no longer supported.
                         properties:
                           fsType:
                             description: |-
@@ -3926,7 +3971,11 @@ spec:
                           - pdID
                         type: object
                       portworxVolume:
-                        description: portworxVolume represents a portworx volume attached and mounted on kubelets host machine
+                        description: |-
+                          portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
+                          Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
+                          are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
+                          is on.
                         properties:
                           fsType:
                             description: |-
@@ -3959,22 +4008,23 @@ spec:
                             format: int32
                             type: integer
                           sources:
-                            description: sources is the list of volume projections
+                            description: |-
+                              sources is the list of volume projections. Each entry in this list
+                              handles one source.
                             items:
-                              description: Projection that may be projected along with other supported volume types
+                              description: |-
+                                Projection that may be projected along with other supported volume types.
+                                Exactly one of these fields must be set.
                               properties:
                                 clusterTrustBundle:
                                   description: |-
                                     ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field
                                     of ClusterTrustBundle objects in an auto-updating file.
 
-
                                     Alpha, gated by the ClusterTrustBundleProjection feature gate.
-
 
                                     ClusterTrustBundle objects can either be selected by name, or by the
                                     combination of signer name and a label selector.
-
 
                                     Kubelet performs aggressive normalization of the PEM contents written
                                     into the pod filesystem.  Esoteric PEM features such as inter-block
@@ -4103,9 +4153,7 @@ spec:
                                         This field is effectively required, but due to backwards compatibility is
                                         allowed to be empty. Instances of this type with an empty value here are
                                         almost certainly wrong.
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                         More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                       type: string
                                     optional:
                                       description: optional specify whether the ConfigMap or its keys must be defined
@@ -4222,9 +4270,7 @@ spec:
                                         This field is effectively required, but due to backwards compatibility is
                                         allowed to be empty. Instances of this type with an empty value here are
                                         almost certainly wrong.
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                         More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                       type: string
                                     optional:
                                       description: optional field specify whether the Secret or its key must be defined
@@ -4264,7 +4310,9 @@ spec:
                             x-kubernetes-list-type: atomic
                         type: object
                       quobyte:
-                        description: quobyte represents a Quobyte mount on the host that shares a pod's lifetime
+                        description: |-
+                          quobyte represents a Quobyte mount on the host that shares a pod's lifetime.
+                          Deprecated: Quobyte is deprecated and the in-tree quobyte type is no longer supported.
                         properties:
                           group:
                             description: |-
@@ -4302,6 +4350,7 @@ spec:
                       rbd:
                         description: |-
                           rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
+                          Deprecated: RBD is deprecated and the in-tree rbd type is no longer supported.
                           More info: https://examples.k8s.io/volumes/rbd/README.md
                         properties:
                           fsType:
@@ -4310,7 +4359,6 @@ spec:
                               Tip: Ensure that the filesystem type is supported by the host operating system.
                               Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                               More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                              TODO: how do we prevent errors in the filesystem from compromising the machine
                             type: string
                           image:
                             description: |-
@@ -4318,6 +4366,7 @@ spec:
                               More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                             type: string
                           keyring:
+                            default: /etc/ceph/keyring
                             description: |-
                               keyring is the path to key ring for RBDUser.
                               Default is /etc/ceph/keyring.
@@ -4332,6 +4381,7 @@ spec:
                             type: array
                             x-kubernetes-list-type: atomic
                           pool:
+                            default: rbd
                             description: |-
                               pool is the rados pool name.
                               Default is rbd.
@@ -4357,13 +4407,12 @@ spec:
                                   This field is effectively required, but due to backwards compatibility is
                                   allowed to be empty. Instances of this type with an empty value here are
                                   almost certainly wrong.
-                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
                           user:
+                            default: admin
                             description: |-
                               user is the rados user name.
                               Default is admin.
@@ -4374,9 +4423,12 @@ spec:
                           - monitors
                         type: object
                       scaleIO:
-                        description: scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
+                        description: |-
+                          scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
+                          Deprecated: ScaleIO is deprecated and the in-tree scaleIO type is no longer supported.
                         properties:
                           fsType:
+                            default: xfs
                             description: |-
                               fsType is the filesystem type to mount.
                               Must be a filesystem type supported by the host operating system.
@@ -4406,9 +4458,7 @@ spec:
                                   This field is effectively required, but due to backwards compatibility is
                                   allowed to be empty. Instances of this type with an empty value here are
                                   almost certainly wrong.
-                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
@@ -4416,6 +4466,7 @@ spec:
                             description: sslEnabled Flag enable/disable SSL communication with Gateway, default false
                             type: boolean
                           storageMode:
+                            default: ThinProvisioned
                             description: |-
                               storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
                               Default is ThinProvisioned.
@@ -4500,7 +4551,9 @@ spec:
                             type: string
                         type: object
                       storageos:
-                        description: storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
+                        description: |-
+                          storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
+                          Deprecated: StorageOS is deprecated and the in-tree storageos type is no longer supported.
                         properties:
                           fsType:
                             description: |-
@@ -4525,9 +4578,7 @@ spec:
                                   This field is effectively required, but due to backwards compatibility is
                                   allowed to be empty. Instances of this type with an empty value here are
                                   almost certainly wrong.
-                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
@@ -4547,7 +4598,10 @@ spec:
                             type: string
                         type: object
                       vsphereVolume:
-                        description: vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine
+                        description: |-
+                          vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine.
+                          Deprecated: VsphereVolume is deprecated. All operations for the in-tree vsphereVolume type
+                          are redirected to the csi.vsphere.vmware.com CSI driver.
                         properties:
                           fsType:
                             description: |-
@@ -4568,6 +4622,7 @@ spec:
                           - volumePath
                         type: object
                     required:
+                      - ""
                       - name
                     type: object
                   type: array
@@ -4582,7 +4637,6 @@ spec:
                       description: |-
                         Builder refers to the image containing the build tools inside which
                         the source code would be built.
-
 
                         NOTICE: Builder is deprecated, and will be removed in a future release.
                         Build strategies which rely on "builder" should provide an equivalent parameter instead.
@@ -4604,9 +4658,7 @@ spec:
                                 This field is effectively required, but due to backwards compatibility is
                                 allowed to be empty. Instances of this type with an empty value here are
                                 almost certainly wrong.
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
@@ -4638,7 +4690,6 @@ spec:
                         Dockerfile is the path to the Dockerfile to be used for
                         build strategies which bank on the Dockerfile for building
                         an image.
-
 
                         NOTICE: Dockerfile is deprecated, and will be removed in a future release.
                         Build strategies which rely on "dockerfile" should provide an equivalent parameter instead.
@@ -4679,9 +4730,7 @@ spec:
                                       This field is effectively required, but due to backwards compatibility is
                                       allowed to be empty. Instances of this type with an empty value here are
                                       almost certainly wrong.
-                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                     type: string
                                   optional:
                                     description: Specify whether the ConfigMap or its key must be defined
@@ -4740,9 +4789,7 @@ spec:
                                       This field is effectively required, but due to backwards compatibility is
                                       allowed to be empty. Instances of this type with an empty value here are
                                       almost certainly wrong.
-                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                     type: string
                                   optional:
                                     description: Specify whether the Secret or its key must be defined
@@ -4776,9 +4823,7 @@ spec:
                                 This field is effectively required, but due to backwards compatibility is
                                 allowed to be empty. Instances of this type with an empty value here are
                                 almost certainly wrong.
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
@@ -4937,7 +4982,6 @@ spec:
                                 values are 'Never' (no deletion) and `AfterPull` (removal after the
                                 image was successfully pulled from the registry).
 
-
                                 If not defined, it defaults to 'Never'.
                               type: string
                           required:
@@ -4958,9 +5002,7 @@ spec:
                                 This field is effectively required, but due to backwards compatibility is
                                 allowed to be empty. Instances of this type with an empty value here are
                                 almost certainly wrong.
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
@@ -4968,7 +5010,6 @@ spec:
                           description: |-
                             Revision describes the Git revision (e.g., branch, tag, commit SHA,
                             etc.) to fetch.
-
 
                             If not defined, it will fallback to the repository's default branch.
                           type: string
@@ -4980,7 +5021,6 @@ spec:
                       description: |-
                         Sources slice of BuildSource, defining external build artifacts complementary to VCS
                         (`.spec.source`) data.
-
 
                         NOTICE: Multiple sources in a build are deprecated. This feature will be removed in a future release.
                       items:
@@ -5038,9 +5078,7 @@ spec:
                                 This field is effectively required, but due to backwards compatibility is
                                 allowed to be empty. Instances of this type with an empty value here are
                                 almost certainly wrong.
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
@@ -5116,6 +5154,8 @@ spec:
                             description: |-
                               awsElasticBlockStore represents an AWS Disk resource that is attached to a
                               kubelet's host machine and then exposed to the pod.
+                              Deprecated: AWSElasticBlockStore is deprecated. All operations for the in-tree
+                              awsElasticBlockStore type are redirected to the ebs.csi.aws.com CSI driver.
                               More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                             properties:
                               fsType:
@@ -5124,7 +5164,6 @@ spec:
                                   Tip: Ensure that the filesystem type is supported by the host operating system.
                                   Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                                  TODO: how do we prevent errors in the filesystem from compromising the machine
                                 type: string
                               partition:
                                 description: |-
@@ -5148,7 +5187,10 @@ spec:
                               - volumeID
                             type: object
                           azureDisk:
-                            description: azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
+                            description: |-
+                              azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
+                              Deprecated: AzureDisk is deprecated. All operations for the in-tree azureDisk type
+                              are redirected to the disk.csi.azure.com CSI driver.
                             properties:
                               cachingMode:
                                 description: 'cachingMode is the Host Caching mode: None, Read Only, Read Write.'
@@ -5160,6 +5202,7 @@ spec:
                                 description: diskURI is the URI of data disk in the blob storage
                                 type: string
                               fsType:
+                                default: ext4
                                 description: |-
                                   fsType is Filesystem type to mount.
                                   Must be a filesystem type supported by the host operating system.
@@ -5169,6 +5212,7 @@ spec:
                                 description: 'kind expected values are Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared'
                                 type: string
                               readOnly:
+                                default: false
                                 description: |-
                                   readOnly Defaults to false (read/write). ReadOnly here will force
                                   the ReadOnly setting in VolumeMounts.
@@ -5178,7 +5222,10 @@ spec:
                               - diskURI
                             type: object
                           azureFile:
-                            description: azureFile represents an Azure File Service mount on the host and bind mount to the pod.
+                            description: |-
+                              azureFile represents an Azure File Service mount on the host and bind mount to the pod.
+                              Deprecated: AzureFile is deprecated. All operations for the in-tree azureFile type
+                              are redirected to the file.csi.azure.com CSI driver.
                             properties:
                               readOnly:
                                 description: |-
@@ -5196,7 +5243,9 @@ spec:
                               - shareName
                             type: object
                           cephfs:
-                            description: cephFS represents a Ceph FS mount on the host that shares a pod's lifetime
+                            description: |-
+                              cephFS represents a Ceph FS mount on the host that shares a pod's lifetime.
+                              Deprecated: CephFS is deprecated and the in-tree cephfs type is no longer supported.
                             properties:
                               monitors:
                                 description: |-
@@ -5232,9 +5281,7 @@ spec:
                                       This field is effectively required, but due to backwards compatibility is
                                       allowed to be empty. Instances of this type with an empty value here are
                                       almost certainly wrong.
-                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                     type: string
                                 type: object
                                 x-kubernetes-map-type: atomic
@@ -5249,6 +5296,8 @@ spec:
                           cinder:
                             description: |-
                               cinder represents a cinder volume attached and mounted on kubelets host machine.
+                              Deprecated: Cinder is deprecated. All operations for the in-tree cinder type
+                              are redirected to the cinder.csi.openstack.org CSI driver.
                               More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                             properties:
                               fsType:
@@ -5276,9 +5325,7 @@ spec:
                                       This field is effectively required, but due to backwards compatibility is
                                       allowed to be empty. Instances of this type with an empty value here are
                                       almost certainly wrong.
-                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                     type: string
                                 type: object
                                 x-kubernetes-map-type: atomic
@@ -5349,9 +5396,7 @@ spec:
                                   This field is effectively required, but due to backwards compatibility is
                                   allowed to be empty. Instances of this type with an empty value here are
                                   almost certainly wrong.
-                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                 type: string
                               optional:
                                 description: optional specify whether the ConfigMap or its keys must be defined
@@ -5359,7 +5404,7 @@ spec:
                             type: object
                             x-kubernetes-map-type: atomic
                           csi:
-                            description: csi (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers (Beta feature).
+                            description: csi (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers.
                             properties:
                               driver:
                                 description: |-
@@ -5387,9 +5432,7 @@ spec:
                                       This field is effectively required, but due to backwards compatibility is
                                       allowed to be empty. Instances of this type with an empty value here are
                                       almost certainly wrong.
-                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                     type: string
                                 type: object
                                 x-kubernetes-map-type: atomic
@@ -5411,7 +5454,6 @@ spec:
                           description:
                             description: |-
                               Description of the Build Volume
-
 
                               NOTICE: Description is deprecated, and will be removed in a future release.
                             type: string
@@ -5521,7 +5563,6 @@ spec:
                               The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,
                               and deleted when the pod is removed.
 
-
                               Use this if:
                               a) the volume is only needed while the pod runs,
                               b) features of normal volumes like restoring from snapshot or capacity
@@ -5532,16 +5573,13 @@ spec:
                                  information on the connection between this volume type
                                  and PersistentVolumeClaim).
 
-
                               Use PersistentVolumeClaim or one of the vendor-specific
                               APIs for volumes that persist for longer than the lifecycle
                               of an individual pod.
 
-
                               Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to
                               be used that way - see the documentation of the driver for
                               more information.
-
 
                               A pod can use both types of ephemeral volumes and
                               persistent volumes at the same time.
@@ -5556,7 +5594,6 @@ spec:
                                   entry. Pod validation will reject the pod if the concatenated name
                                   is not valid for a PVC (for example, too long).
 
-
                                   An existing PVC with that name that is not owned by the pod
                                   will *not* be used for the pod to avoid using an unrelated
                                   volume by mistake. Starting the pod is then blocked until
@@ -5566,10 +5603,8 @@ spec:
                                   this should not be necessary, but it may be useful when
                                   manually reconstructing a broken cluster.
 
-
                                   This field is read-only and no changes will be made by Kubernetes
                                   to the PVC after it has been created.
-
 
                                   Required, must not be nil.
                                 properties:
@@ -5765,7 +5800,7 @@ spec:
                                           set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
                                           exists.
                                           More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
-                                          (Alpha) Using this field requires the VolumeAttributesClass feature gate to be enabled.
+                                          (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).
                                         type: string
                                       volumeMode:
                                         description: |-
@@ -5788,7 +5823,6 @@ spec:
                                   fsType is the filesystem type to mount.
                                   Must be a filesystem type supported by the host operating system.
                                   Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                  TODO: how do we prevent errors in the filesystem from compromising the machine
                                 type: string
                               lun:
                                 description: 'lun is Optional: FC target lun number'
@@ -5818,6 +5852,7 @@ spec:
                             description: |-
                               flexVolume represents a generic volume resource that is
                               provisioned/attached using an exec based plugin.
+                              Deprecated: FlexVolume is deprecated. Consider using a CSIDriver instead.
                             properties:
                               driver:
                                 description: driver is the name of the driver to use for this volume.
@@ -5853,9 +5888,7 @@ spec:
                                       This field is effectively required, but due to backwards compatibility is
                                       allowed to be empty. Instances of this type with an empty value here are
                                       almost certainly wrong.
-                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                     type: string
                                 type: object
                                 x-kubernetes-map-type: atomic
@@ -5863,7 +5896,9 @@ spec:
                               - driver
                             type: object
                           flocker:
-                            description: flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running
+                            description: |-
+                              flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running.
+                              Deprecated: Flocker is deprecated and the in-tree flocker type is no longer supported.
                             properties:
                               datasetName:
                                 description: |-
@@ -5878,6 +5913,8 @@ spec:
                             description: |-
                               gcePersistentDisk represents a GCE Disk resource that is attached to a
                               kubelet's host machine and then exposed to the pod.
+                              Deprecated: GCEPersistentDisk is deprecated. All operations for the in-tree
+                              gcePersistentDisk type are redirected to the pd.csi.storage.gke.io CSI driver.
                               More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                             properties:
                               fsType:
@@ -5886,7 +5923,6 @@ spec:
                                   Tip: Ensure that the filesystem type is supported by the host operating system.
                                   Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                                  TODO: how do we prevent errors in the filesystem from compromising the machine
                                 type: string
                               partition:
                                 description: |-
@@ -5914,7 +5950,7 @@ spec:
                           gitRepo:
                             description: |-
                               gitRepo represents a git repository at a particular revision.
-                              DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an
+                              Deprecated: GitRepo is deprecated. To provision a container with a git repo, mount an
                               EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
                               into the Pod's container.
                             properties:
@@ -5937,6 +5973,7 @@ spec:
                           glusterfs:
                             description: |-
                               glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
+                              Deprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported.
                               More info: https://examples.k8s.io/volumes/glusterfs/README.md
                             properties:
                               endpoints:
@@ -5966,9 +6003,6 @@ spec:
                               used for system agents or other privileged things that are allowed
                               to see the host machine. Most containers will NOT need this.
                               More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-                              ---
-                              TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not
-                              mount host directories as read/write.
                             properties:
                               path:
                                 description: |-
@@ -5984,6 +6018,41 @@ spec:
                                 type: string
                             required:
                               - path
+                            type: object
+                          image:
+                            description: |-
+                              image represents an OCI object (a container image or artifact) pulled and mounted on the kubelet's host machine.
+                              The volume is resolved at pod startup depending on which PullPolicy value is provided:
+
+                              - Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                              - Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                              - IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+
+                              The volume gets re-resolved if the pod gets deleted and recreated, which means that new remote content will become available on pod recreation.
+                              A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
+                              The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
+                              The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
+                              The volume will be mounted read-only (ro) and non-executable files (noexec).
+                              Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath).
+                              The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
+                            properties:
+                              pullPolicy:
+                                description: |-
+                                  Policy for pulling OCI objects. Possible values are:
+                                  Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                                  Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                                  IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+                                  Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                type: string
+                              reference:
+                                description: |-
+                                  Required: Image or artifact reference to be used.
+                                  Behaves in the same way as pod.spec.containers[*].image.
+                                  Pull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets.
+                                  More info: https://kubernetes.io/docs/concepts/containers/images
+                                  This field is optional to allow higher level config management to default or override
+                                  container images in workload controllers like Deployments and StatefulSets.
+                                type: string
                             type: object
                           iscsi:
                             description: |-
@@ -6003,7 +6072,6 @@ spec:
                                   Tip: Ensure that the filesystem type is supported by the host operating system.
                                   Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                                  TODO: how do we prevent errors in the filesystem from compromising the machine
                                 type: string
                               initiatorName:
                                 description: |-
@@ -6015,6 +6083,7 @@ spec:
                                 description: iqn is the target iSCSI Qualified Name.
                                 type: string
                               iscsiInterface:
+                                default: default
                                 description: |-
                                   iscsiInterface is the interface Name that uses an iSCSI transport.
                                   Defaults to 'default' (tcp).
@@ -6046,9 +6115,7 @@ spec:
                                       This field is effectively required, but due to backwards compatibility is
                                       allowed to be empty. Instances of this type with an empty value here are
                                       almost certainly wrong.
-                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                     type: string
                                 type: object
                                 x-kubernetes-map-type: atomic
@@ -6110,7 +6177,9 @@ spec:
                               - claimName
                             type: object
                           photonPersistentDisk:
-                            description: photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine
+                            description: |-
+                              photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine.
+                              Deprecated: PhotonPersistentDisk is deprecated and the in-tree photonPersistentDisk type is no longer supported.
                             properties:
                               fsType:
                                 description: |-
@@ -6125,7 +6194,11 @@ spec:
                               - pdID
                             type: object
                           portworxVolume:
-                            description: portworxVolume represents a portworx volume attached and mounted on kubelets host machine
+                            description: |-
+                              portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
+                              Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
+                              are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
+                              is on.
                             properties:
                               fsType:
                                 description: |-
@@ -6158,22 +6231,23 @@ spec:
                                 format: int32
                                 type: integer
                               sources:
-                                description: sources is the list of volume projections
+                                description: |-
+                                  sources is the list of volume projections. Each entry in this list
+                                  handles one source.
                                 items:
-                                  description: Projection that may be projected along with other supported volume types
+                                  description: |-
+                                    Projection that may be projected along with other supported volume types.
+                                    Exactly one of these fields must be set.
                                   properties:
                                     clusterTrustBundle:
                                       description: |-
                                         ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field
                                         of ClusterTrustBundle objects in an auto-updating file.
 
-
                                         Alpha, gated by the ClusterTrustBundleProjection feature gate.
-
 
                                         ClusterTrustBundle objects can either be selected by name, or by the
                                         combination of signer name and a label selector.
-
 
                                         Kubelet performs aggressive normalization of the PEM contents written
                                         into the pod filesystem.  Esoteric PEM features such as inter-block
@@ -6302,9 +6376,7 @@ spec:
                                             This field is effectively required, but due to backwards compatibility is
                                             allowed to be empty. Instances of this type with an empty value here are
                                             almost certainly wrong.
-                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                             More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                           type: string
                                         optional:
                                           description: optional specify whether the ConfigMap or its keys must be defined
@@ -6421,9 +6493,7 @@ spec:
                                             This field is effectively required, but due to backwards compatibility is
                                             allowed to be empty. Instances of this type with an empty value here are
                                             almost certainly wrong.
-                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                             More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                           type: string
                                         optional:
                                           description: optional field specify whether the Secret or its key must be defined
@@ -6463,7 +6533,9 @@ spec:
                                 x-kubernetes-list-type: atomic
                             type: object
                           quobyte:
-                            description: quobyte represents a Quobyte mount on the host that shares a pod's lifetime
+                            description: |-
+                              quobyte represents a Quobyte mount on the host that shares a pod's lifetime.
+                              Deprecated: Quobyte is deprecated and the in-tree quobyte type is no longer supported.
                             properties:
                               group:
                                 description: |-
@@ -6501,6 +6573,7 @@ spec:
                           rbd:
                             description: |-
                               rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
+                              Deprecated: RBD is deprecated and the in-tree rbd type is no longer supported.
                               More info: https://examples.k8s.io/volumes/rbd/README.md
                             properties:
                               fsType:
@@ -6509,7 +6582,6 @@ spec:
                                   Tip: Ensure that the filesystem type is supported by the host operating system.
                                   Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                                  TODO: how do we prevent errors in the filesystem from compromising the machine
                                 type: string
                               image:
                                 description: |-
@@ -6517,6 +6589,7 @@ spec:
                                   More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                 type: string
                               keyring:
+                                default: /etc/ceph/keyring
                                 description: |-
                                   keyring is the path to key ring for RBDUser.
                                   Default is /etc/ceph/keyring.
@@ -6531,6 +6604,7 @@ spec:
                                 type: array
                                 x-kubernetes-list-type: atomic
                               pool:
+                                default: rbd
                                 description: |-
                                   pool is the rados pool name.
                                   Default is rbd.
@@ -6556,13 +6630,12 @@ spec:
                                       This field is effectively required, but due to backwards compatibility is
                                       allowed to be empty. Instances of this type with an empty value here are
                                       almost certainly wrong.
-                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                     type: string
                                 type: object
                                 x-kubernetes-map-type: atomic
                               user:
+                                default: admin
                                 description: |-
                                   user is the rados user name.
                                   Default is admin.
@@ -6573,9 +6646,12 @@ spec:
                               - monitors
                             type: object
                           scaleIO:
-                            description: scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
+                            description: |-
+                              scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
+                              Deprecated: ScaleIO is deprecated and the in-tree scaleIO type is no longer supported.
                             properties:
                               fsType:
+                                default: xfs
                                 description: |-
                                   fsType is the filesystem type to mount.
                                   Must be a filesystem type supported by the host operating system.
@@ -6605,9 +6681,7 @@ spec:
                                       This field is effectively required, but due to backwards compatibility is
                                       allowed to be empty. Instances of this type with an empty value here are
                                       almost certainly wrong.
-                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                     type: string
                                 type: object
                                 x-kubernetes-map-type: atomic
@@ -6615,6 +6689,7 @@ spec:
                                 description: sslEnabled Flag enable/disable SSL communication with Gateway, default false
                                 type: boolean
                               storageMode:
+                                default: ThinProvisioned
                                 description: |-
                                   storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
                                   Default is ThinProvisioned.
@@ -6699,7 +6774,9 @@ spec:
                                 type: string
                             type: object
                           storageos:
-                            description: storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
+                            description: |-
+                              storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
+                              Deprecated: StorageOS is deprecated and the in-tree storageos type is no longer supported.
                             properties:
                               fsType:
                                 description: |-
@@ -6724,9 +6801,7 @@ spec:
                                       This field is effectively required, but due to backwards compatibility is
                                       allowed to be empty. Instances of this type with an empty value here are
                                       almost certainly wrong.
-                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                     type: string
                                 type: object
                                 x-kubernetes-map-type: atomic
@@ -6746,7 +6821,10 @@ spec:
                                 type: string
                             type: object
                           vsphereVolume:
-                            description: vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine
+                            description: |-
+                              vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine.
+                              Deprecated: VsphereVolume is deprecated. All operations for the in-tree vsphereVolume type
+                              are redirected to the csi.vsphere.vmware.com CSI driver.
                             properties:
                               fsType:
                                 description: |-
@@ -6767,6 +6845,7 @@ spec:
                               - volumePath
                             type: object
                         required:
+                          - ""
                           - name
                         type: object
                       type: array
@@ -6835,11 +6914,8 @@ spec:
                       type: string
                   type: object
                 latestTaskRunRef:
-                  description: |-
+                  description: |
                     LatestTaskRunRef is the name of the TaskRun responsible for executing this BuildRun.
-
-
-                    TODO: This should be called something like "TaskRunName"
                   type: string
                 output:
                   description: Output holds the results emitted from step definition of an output
@@ -7001,9 +7077,7 @@ spec:
                                           This field is effectively required, but due to backwards compatibility is
                                           allowed to be empty. Instances of this type with an empty value here are
                                           almost certainly wrong.
-                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                           More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                         type: string
                                       optional:
                                         description: Specify whether the ConfigMap or its key must be defined
@@ -7062,9 +7136,7 @@ spec:
                                           This field is effectively required, but due to backwards compatibility is
                                           allowed to be empty. Instances of this type with an empty value here are
                                           almost certainly wrong.
-                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                           More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                         type: string
                                       optional:
                                         description: Specify whether the Secret or its key must be defined
@@ -7283,21 +7355,29 @@ spec:
                             artifact
                           properties:
                             contextDir:
-                              description: ContextDir is a path to subfolder in the repo. Optional.
+                              description: |-
+                                ContextDir is a path to a subdirectory within the source code that should be used as the
+                                build root directory. Optional.
                               type: string
                             git:
-                              description: Git contains the details for the source of type Git
+                              description: Git contains the details for obtaining source code from a git repository.
                               properties:
                                 cloneSecret:
                                   description: |-
                                     CloneSecret references a Secret that contains credentials to access
                                     the repository.
                                   type: string
+                                depth:
+                                  description: |-
+                                    Depth specifies the depth of the shallow clone.
+                                    If not specified the default is set to 1.
+                                    Values greater than 1 will create a clone with the specified depth.
+                                    If value is 0, it will create a full git history clone.
+                                  type: integer
                                 revision:
                                   description: |-
                                     Revision describes the Git revision (e.g., branch, tag, commit SHA,
                                     etc.) to fetch.
-
 
                                     If not defined, it will fallback to the repository's default branch.
                                   type: string
@@ -7308,40 +7388,49 @@ spec:
                                 - url
                               type: object
                             local:
-                              description: Local contains the details for the source of type Local
+                              description: |-
+                                Local contains the details for obtaining source code that is streamed in from a remote
+                                machine's local directory.
                               properties:
                                 name:
                                   description: Name of the local step
                                   type: string
                                 timeout:
-                                  description: Timeout how long the BuildSource execution must take.
+                                  description: |-
+                                    Timeout is the maximum duration the build should wait for source code to be streamed in from
+                                    a remote machine's local directory.
                                   type: string
                               type: object
                             ociArtifact:
-                              description: OCIArtifact contains the details for the source of type OCIArtifact
+                              description: |-
+                                OCIArtifact contains the details for obtaining source code from a container image, also
+                                known as an OCI artifact.
                               properties:
                                 image:
-                                  description: Image reference, i.e. quay.io/org/image:tag
+                                  description: |-
+                                    Image is a reference to a container image to be pulled from a container registry.
+                                    For example, quay.io/org/image:tag
                                   type: string
                                 prune:
                                   description: |-
-                                    Prune specifies whether the image is suppose to be deleted. Allowed
-                                    values are 'Never' (no deletion) and `AfterPull` (removal after the
+                                    Prune specifies whether the image containing the source code should be deleted.
+                                    Allowed values are 'Never' (no deletion) and `AfterPull` (removal after the
                                     image was successfully pulled from the registry).
-
 
                                     If not defined, it defaults to 'Never'.
                                   type: string
                                 pullSecret:
                                   description: |-
                                     PullSecret references a Secret that contains credentials to access
-                                    the repository.
+                                    the container image.
                                   type: string
                               required:
                                 - image
                               type: object
                             type:
-                              description: Type is the BuildSource qualifier, the type of the source.
+                              description: |-
+                                Type is the type of source code used as input for the build. Allowed values are
+                                `Git`, `OCI`, and `Local`.
                               type: string
                           required:
                             - type
@@ -7481,6 +7570,8 @@ spec:
                                 description: |-
                                   awsElasticBlockStore represents an AWS Disk resource that is attached to a
                                   kubelet's host machine and then exposed to the pod.
+                                  Deprecated: AWSElasticBlockStore is deprecated. All operations for the in-tree
+                                  awsElasticBlockStore type are redirected to the ebs.csi.aws.com CSI driver.
                                   More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                 properties:
                                   fsType:
@@ -7489,7 +7580,6 @@ spec:
                                       Tip: Ensure that the filesystem type is supported by the host operating system.
                                       Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                       More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                                      TODO: how do we prevent errors in the filesystem from compromising the machine
                                     type: string
                                   partition:
                                     description: |-
@@ -7513,7 +7603,10 @@ spec:
                                   - volumeID
                                 type: object
                               azureDisk:
-                                description: azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
+                                description: |-
+                                  azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
+                                  Deprecated: AzureDisk is deprecated. All operations for the in-tree azureDisk type
+                                  are redirected to the disk.csi.azure.com CSI driver.
                                 properties:
                                   cachingMode:
                                     description: 'cachingMode is the Host Caching mode: None, Read Only, Read Write.'
@@ -7525,6 +7618,7 @@ spec:
                                     description: diskURI is the URI of data disk in the blob storage
                                     type: string
                                   fsType:
+                                    default: ext4
                                     description: |-
                                       fsType is Filesystem type to mount.
                                       Must be a filesystem type supported by the host operating system.
@@ -7534,6 +7628,7 @@ spec:
                                     description: 'kind expected values are Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared'
                                     type: string
                                   readOnly:
+                                    default: false
                                     description: |-
                                       readOnly Defaults to false (read/write). ReadOnly here will force
                                       the ReadOnly setting in VolumeMounts.
@@ -7543,7 +7638,10 @@ spec:
                                   - diskURI
                                 type: object
                               azureFile:
-                                description: azureFile represents an Azure File Service mount on the host and bind mount to the pod.
+                                description: |-
+                                  azureFile represents an Azure File Service mount on the host and bind mount to the pod.
+                                  Deprecated: AzureFile is deprecated. All operations for the in-tree azureFile type
+                                  are redirected to the file.csi.azure.com CSI driver.
                                 properties:
                                   readOnly:
                                     description: |-
@@ -7561,7 +7659,9 @@ spec:
                                   - shareName
                                 type: object
                               cephfs:
-                                description: cephFS represents a Ceph FS mount on the host that shares a pod's lifetime
+                                description: |-
+                                  cephFS represents a Ceph FS mount on the host that shares a pod's lifetime.
+                                  Deprecated: CephFS is deprecated and the in-tree cephfs type is no longer supported.
                                 properties:
                                   monitors:
                                     description: |-
@@ -7597,9 +7697,7 @@ spec:
                                           This field is effectively required, but due to backwards compatibility is
                                           allowed to be empty. Instances of this type with an empty value here are
                                           almost certainly wrong.
-                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                           More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                         type: string
                                     type: object
                                     x-kubernetes-map-type: atomic
@@ -7614,6 +7712,8 @@ spec:
                               cinder:
                                 description: |-
                                   cinder represents a cinder volume attached and mounted on kubelets host machine.
+                                  Deprecated: Cinder is deprecated. All operations for the in-tree cinder type
+                                  are redirected to the cinder.csi.openstack.org CSI driver.
                                   More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                 properties:
                                   fsType:
@@ -7641,9 +7741,7 @@ spec:
                                           This field is effectively required, but due to backwards compatibility is
                                           allowed to be empty. Instances of this type with an empty value here are
                                           almost certainly wrong.
-                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                           More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                         type: string
                                     type: object
                                     x-kubernetes-map-type: atomic
@@ -7714,9 +7812,7 @@ spec:
                                       This field is effectively required, but due to backwards compatibility is
                                       allowed to be empty. Instances of this type with an empty value here are
                                       almost certainly wrong.
-                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                     type: string
                                   optional:
                                     description: optional specify whether the ConfigMap or its keys must be defined
@@ -7724,7 +7820,7 @@ spec:
                                 type: object
                                 x-kubernetes-map-type: atomic
                               csi:
-                                description: csi (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers (Beta feature).
+                                description: csi (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers.
                                 properties:
                                   driver:
                                     description: |-
@@ -7752,9 +7848,7 @@ spec:
                                           This field is effectively required, but due to backwards compatibility is
                                           allowed to be empty. Instances of this type with an empty value here are
                                           almost certainly wrong.
-                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                           More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                         type: string
                                     type: object
                                     x-kubernetes-map-type: atomic
@@ -7879,7 +7973,6 @@ spec:
                                   The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,
                                   and deleted when the pod is removed.
 
-
                                   Use this if:
                                   a) the volume is only needed while the pod runs,
                                   b) features of normal volumes like restoring from snapshot or capacity
@@ -7890,16 +7983,13 @@ spec:
                                      information on the connection between this volume type
                                      and PersistentVolumeClaim).
 
-
                                   Use PersistentVolumeClaim or one of the vendor-specific
                                   APIs for volumes that persist for longer than the lifecycle
                                   of an individual pod.
 
-
                                   Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to
                                   be used that way - see the documentation of the driver for
                                   more information.
-
 
                                   A pod can use both types of ephemeral volumes and
                                   persistent volumes at the same time.
@@ -7914,7 +8004,6 @@ spec:
                                       entry. Pod validation will reject the pod if the concatenated name
                                       is not valid for a PVC (for example, too long).
 
-
                                       An existing PVC with that name that is not owned by the pod
                                       will *not* be used for the pod to avoid using an unrelated
                                       volume by mistake. Starting the pod is then blocked until
@@ -7924,10 +8013,8 @@ spec:
                                       this should not be necessary, but it may be useful when
                                       manually reconstructing a broken cluster.
 
-
                                       This field is read-only and no changes will be made by Kubernetes
                                       to the PVC after it has been created.
-
 
                                       Required, must not be nil.
                                     properties:
@@ -8123,7 +8210,7 @@ spec:
                                               set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
                                               exists.
                                               More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
-                                              (Alpha) Using this field requires the VolumeAttributesClass feature gate to be enabled.
+                                              (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).
                                             type: string
                                           volumeMode:
                                             description: |-
@@ -8146,7 +8233,6 @@ spec:
                                       fsType is the filesystem type to mount.
                                       Must be a filesystem type supported by the host operating system.
                                       Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                      TODO: how do we prevent errors in the filesystem from compromising the machine
                                     type: string
                                   lun:
                                     description: 'lun is Optional: FC target lun number'
@@ -8176,6 +8262,7 @@ spec:
                                 description: |-
                                   flexVolume represents a generic volume resource that is
                                   provisioned/attached using an exec based plugin.
+                                  Deprecated: FlexVolume is deprecated. Consider using a CSIDriver instead.
                                 properties:
                                   driver:
                                     description: driver is the name of the driver to use for this volume.
@@ -8211,9 +8298,7 @@ spec:
                                           This field is effectively required, but due to backwards compatibility is
                                           allowed to be empty. Instances of this type with an empty value here are
                                           almost certainly wrong.
-                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                           More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                         type: string
                                     type: object
                                     x-kubernetes-map-type: atomic
@@ -8221,7 +8306,9 @@ spec:
                                   - driver
                                 type: object
                               flocker:
-                                description: flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running
+                                description: |-
+                                  flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running.
+                                  Deprecated: Flocker is deprecated and the in-tree flocker type is no longer supported.
                                 properties:
                                   datasetName:
                                     description: |-
@@ -8236,6 +8323,8 @@ spec:
                                 description: |-
                                   gcePersistentDisk represents a GCE Disk resource that is attached to a
                                   kubelet's host machine and then exposed to the pod.
+                                  Deprecated: GCEPersistentDisk is deprecated. All operations for the in-tree
+                                  gcePersistentDisk type are redirected to the pd.csi.storage.gke.io CSI driver.
                                   More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                 properties:
                                   fsType:
@@ -8244,7 +8333,6 @@ spec:
                                       Tip: Ensure that the filesystem type is supported by the host operating system.
                                       Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                       More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                                      TODO: how do we prevent errors in the filesystem from compromising the machine
                                     type: string
                                   partition:
                                     description: |-
@@ -8272,7 +8360,7 @@ spec:
                               gitRepo:
                                 description: |-
                                   gitRepo represents a git repository at a particular revision.
-                                  DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an
+                                  Deprecated: GitRepo is deprecated. To provision a container with a git repo, mount an
                                   EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
                                   into the Pod's container.
                                 properties:
@@ -8295,6 +8383,7 @@ spec:
                               glusterfs:
                                 description: |-
                                   glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
+                                  Deprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported.
                                   More info: https://examples.k8s.io/volumes/glusterfs/README.md
                                 properties:
                                   endpoints:
@@ -8324,9 +8413,6 @@ spec:
                                   used for system agents or other privileged things that are allowed
                                   to see the host machine. Most containers will NOT need this.
                                   More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-                                  ---
-                                  TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not
-                                  mount host directories as read/write.
                                 properties:
                                   path:
                                     description: |-
@@ -8342,6 +8428,41 @@ spec:
                                     type: string
                                 required:
                                   - path
+                                type: object
+                              image:
+                                description: |-
+                                  image represents an OCI object (a container image or artifact) pulled and mounted on the kubelet's host machine.
+                                  The volume is resolved at pod startup depending on which PullPolicy value is provided:
+
+                                  - Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                                  - Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                                  - IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+
+                                  The volume gets re-resolved if the pod gets deleted and recreated, which means that new remote content will become available on pod recreation.
+                                  A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
+                                  The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
+                                  The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
+                                  The volume will be mounted read-only (ro) and non-executable files (noexec).
+                                  Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath).
+                                  The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
+                                properties:
+                                  pullPolicy:
+                                    description: |-
+                                      Policy for pulling OCI objects. Possible values are:
+                                      Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                                      Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                                      IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+                                      Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                    type: string
+                                  reference:
+                                    description: |-
+                                      Required: Image or artifact reference to be used.
+                                      Behaves in the same way as pod.spec.containers[*].image.
+                                      Pull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets.
+                                      More info: https://kubernetes.io/docs/concepts/containers/images
+                                      This field is optional to allow higher level config management to default or override
+                                      container images in workload controllers like Deployments and StatefulSets.
+                                    type: string
                                 type: object
                               iscsi:
                                 description: |-
@@ -8361,7 +8482,6 @@ spec:
                                       Tip: Ensure that the filesystem type is supported by the host operating system.
                                       Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                       More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                                      TODO: how do we prevent errors in the filesystem from compromising the machine
                                     type: string
                                   initiatorName:
                                     description: |-
@@ -8373,6 +8493,7 @@ spec:
                                     description: iqn is the target iSCSI Qualified Name.
                                     type: string
                                   iscsiInterface:
+                                    default: default
                                     description: |-
                                       iscsiInterface is the interface Name that uses an iSCSI transport.
                                       Defaults to 'default' (tcp).
@@ -8404,9 +8525,7 @@ spec:
                                           This field is effectively required, but due to backwards compatibility is
                                           allowed to be empty. Instances of this type with an empty value here are
                                           almost certainly wrong.
-                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                           More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                         type: string
                                     type: object
                                     x-kubernetes-map-type: atomic
@@ -8468,7 +8587,9 @@ spec:
                                   - claimName
                                 type: object
                               photonPersistentDisk:
-                                description: photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine
+                                description: |-
+                                  photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine.
+                                  Deprecated: PhotonPersistentDisk is deprecated and the in-tree photonPersistentDisk type is no longer supported.
                                 properties:
                                   fsType:
                                     description: |-
@@ -8483,7 +8604,11 @@ spec:
                                   - pdID
                                 type: object
                               portworxVolume:
-                                description: portworxVolume represents a portworx volume attached and mounted on kubelets host machine
+                                description: |-
+                                  portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
+                                  Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
+                                  are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
+                                  is on.
                                 properties:
                                   fsType:
                                     description: |-
@@ -8516,22 +8641,23 @@ spec:
                                     format: int32
                                     type: integer
                                   sources:
-                                    description: sources is the list of volume projections
+                                    description: |-
+                                      sources is the list of volume projections. Each entry in this list
+                                      handles one source.
                                     items:
-                                      description: Projection that may be projected along with other supported volume types
+                                      description: |-
+                                        Projection that may be projected along with other supported volume types.
+                                        Exactly one of these fields must be set.
                                       properties:
                                         clusterTrustBundle:
                                           description: |-
                                             ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field
                                             of ClusterTrustBundle objects in an auto-updating file.
 
-
                                             Alpha, gated by the ClusterTrustBundleProjection feature gate.
-
 
                                             ClusterTrustBundle objects can either be selected by name, or by the
                                             combination of signer name and a label selector.
-
 
                                             Kubelet performs aggressive normalization of the PEM contents written
                                             into the pod filesystem.  Esoteric PEM features such as inter-block
@@ -8660,9 +8786,7 @@ spec:
                                                 This field is effectively required, but due to backwards compatibility is
                                                 allowed to be empty. Instances of this type with an empty value here are
                                                 almost certainly wrong.
-                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                               type: string
                                             optional:
                                               description: optional specify whether the ConfigMap or its keys must be defined
@@ -8779,9 +8903,7 @@ spec:
                                                 This field is effectively required, but due to backwards compatibility is
                                                 allowed to be empty. Instances of this type with an empty value here are
                                                 almost certainly wrong.
-                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                               type: string
                                             optional:
                                               description: optional field specify whether the Secret or its key must be defined
@@ -8821,7 +8943,9 @@ spec:
                                     x-kubernetes-list-type: atomic
                                 type: object
                               quobyte:
-                                description: quobyte represents a Quobyte mount on the host that shares a pod's lifetime
+                                description: |-
+                                  quobyte represents a Quobyte mount on the host that shares a pod's lifetime.
+                                  Deprecated: Quobyte is deprecated and the in-tree quobyte type is no longer supported.
                                 properties:
                                   group:
                                     description: |-
@@ -8859,6 +8983,7 @@ spec:
                               rbd:
                                 description: |-
                                   rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
+                                  Deprecated: RBD is deprecated and the in-tree rbd type is no longer supported.
                                   More info: https://examples.k8s.io/volumes/rbd/README.md
                                 properties:
                                   fsType:
@@ -8867,7 +8992,6 @@ spec:
                                       Tip: Ensure that the filesystem type is supported by the host operating system.
                                       Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                       More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                                      TODO: how do we prevent errors in the filesystem from compromising the machine
                                     type: string
                                   image:
                                     description: |-
@@ -8875,6 +8999,7 @@ spec:
                                       More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                     type: string
                                   keyring:
+                                    default: /etc/ceph/keyring
                                     description: |-
                                       keyring is the path to key ring for RBDUser.
                                       Default is /etc/ceph/keyring.
@@ -8889,6 +9014,7 @@ spec:
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   pool:
+                                    default: rbd
                                     description: |-
                                       pool is the rados pool name.
                                       Default is rbd.
@@ -8914,13 +9040,12 @@ spec:
                                           This field is effectively required, but due to backwards compatibility is
                                           allowed to be empty. Instances of this type with an empty value here are
                                           almost certainly wrong.
-                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                           More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                         type: string
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   user:
+                                    default: admin
                                     description: |-
                                       user is the rados user name.
                                       Default is admin.
@@ -8931,9 +9056,12 @@ spec:
                                   - monitors
                                 type: object
                               scaleIO:
-                                description: scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
+                                description: |-
+                                  scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
+                                  Deprecated: ScaleIO is deprecated and the in-tree scaleIO type is no longer supported.
                                 properties:
                                   fsType:
+                                    default: xfs
                                     description: |-
                                       fsType is the filesystem type to mount.
                                       Must be a filesystem type supported by the host operating system.
@@ -8963,9 +9091,7 @@ spec:
                                           This field is effectively required, but due to backwards compatibility is
                                           allowed to be empty. Instances of this type with an empty value here are
                                           almost certainly wrong.
-                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                           More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                         type: string
                                     type: object
                                     x-kubernetes-map-type: atomic
@@ -8973,6 +9099,7 @@ spec:
                                     description: sslEnabled Flag enable/disable SSL communication with Gateway, default false
                                     type: boolean
                                   storageMode:
+                                    default: ThinProvisioned
                                     description: |-
                                       storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
                                       Default is ThinProvisioned.
@@ -9057,7 +9184,9 @@ spec:
                                     type: string
                                 type: object
                               storageos:
-                                description: storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
+                                description: |-
+                                  storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
+                                  Deprecated: StorageOS is deprecated and the in-tree storageos type is no longer supported.
                                 properties:
                                   fsType:
                                     description: |-
@@ -9082,9 +9211,7 @@ spec:
                                           This field is effectively required, but due to backwards compatibility is
                                           allowed to be empty. Instances of this type with an empty value here are
                                           almost certainly wrong.
-                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                           More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                         type: string
                                     type: object
                                     x-kubernetes-map-type: atomic
@@ -9104,7 +9231,10 @@ spec:
                                     type: string
                                 type: object
                               vsphereVolume:
-                                description: vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine
+                                description: |-
+                                  vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine.
+                                  Deprecated: VsphereVolume is deprecated. All operations for the in-tree vsphereVolume type
+                                  are redirected to the csi.vsphere.vmware.com CSI driver.
                                 properties:
                                   fsType:
                                     description: |-
@@ -9125,6 +9255,7 @@ spec:
                                   - volumePath
                                 type: object
                             required:
+                              - ""
                               - name
                             type: object
                           type: array
@@ -9169,9 +9300,7 @@ spec:
                                   This field is effectively required, but due to backwards compatibility is
                                   allowed to be empty. Instances of this type with an empty value here are
                                   almost certainly wrong.
-                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                 type: string
                               optional:
                                 description: Specify whether the ConfigMap or its key must be defined
@@ -9230,9 +9359,7 @@ spec:
                                   This field is effectively required, but due to backwards compatibility is
                                   allowed to be empty. Instances of this type with an empty value here are
                                   almost certainly wrong.
-                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                 type: string
                               optional:
                                 description: Specify whether the Secret or its key must be defined
@@ -9441,8 +9568,9 @@ spec:
                   type: string
                 source:
                   description: |-
-                    Source refers to the location where the source code is,
-                    this could only be a local source
+                    Source overrides where the source code is obtained for the BuildRun. This can only be used
+                    to obtain source code from a remote machine's local directory, instead of the value defined
+                    in the build.
                   properties:
                     local:
                       description: Local contains the details for the source of type Local
@@ -9451,13 +9579,15 @@ spec:
                           description: Name of the local step
                           type: string
                         timeout:
-                          description: Timeout how long the BuildSource execution must take.
+                          description: |-
+                            Timeout is the maximum duration the build should wait for source code to be streamed in from
+                            a remote machine's local directory.
                           type: string
                       type: object
                     type:
                       description: |-
                         Type is the BuildRunSource qualifier, the type of the source.
-                        Only Local is supported.
+                        Only `Local` is supported.
                       type: string
                   required:
                     - type
@@ -9519,6 +9649,8 @@ spec:
                         description: |-
                           awsElasticBlockStore represents an AWS Disk resource that is attached to a
                           kubelet's host machine and then exposed to the pod.
+                          Deprecated: AWSElasticBlockStore is deprecated. All operations for the in-tree
+                          awsElasticBlockStore type are redirected to the ebs.csi.aws.com CSI driver.
                           More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                         properties:
                           fsType:
@@ -9527,7 +9659,6 @@ spec:
                               Tip: Ensure that the filesystem type is supported by the host operating system.
                               Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                               More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                              TODO: how do we prevent errors in the filesystem from compromising the machine
                             type: string
                           partition:
                             description: |-
@@ -9551,7 +9682,10 @@ spec:
                           - volumeID
                         type: object
                       azureDisk:
-                        description: azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
+                        description: |-
+                          azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
+                          Deprecated: AzureDisk is deprecated. All operations for the in-tree azureDisk type
+                          are redirected to the disk.csi.azure.com CSI driver.
                         properties:
                           cachingMode:
                             description: 'cachingMode is the Host Caching mode: None, Read Only, Read Write.'
@@ -9563,6 +9697,7 @@ spec:
                             description: diskURI is the URI of data disk in the blob storage
                             type: string
                           fsType:
+                            default: ext4
                             description: |-
                               fsType is Filesystem type to mount.
                               Must be a filesystem type supported by the host operating system.
@@ -9572,6 +9707,7 @@ spec:
                             description: 'kind expected values are Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared'
                             type: string
                           readOnly:
+                            default: false
                             description: |-
                               readOnly Defaults to false (read/write). ReadOnly here will force
                               the ReadOnly setting in VolumeMounts.
@@ -9581,7 +9717,10 @@ spec:
                           - diskURI
                         type: object
                       azureFile:
-                        description: azureFile represents an Azure File Service mount on the host and bind mount to the pod.
+                        description: |-
+                          azureFile represents an Azure File Service mount on the host and bind mount to the pod.
+                          Deprecated: AzureFile is deprecated. All operations for the in-tree azureFile type
+                          are redirected to the file.csi.azure.com CSI driver.
                         properties:
                           readOnly:
                             description: |-
@@ -9599,7 +9738,9 @@ spec:
                           - shareName
                         type: object
                       cephfs:
-                        description: cephFS represents a Ceph FS mount on the host that shares a pod's lifetime
+                        description: |-
+                          cephFS represents a Ceph FS mount on the host that shares a pod's lifetime.
+                          Deprecated: CephFS is deprecated and the in-tree cephfs type is no longer supported.
                         properties:
                           monitors:
                             description: |-
@@ -9635,9 +9776,7 @@ spec:
                                   This field is effectively required, but due to backwards compatibility is
                                   allowed to be empty. Instances of this type with an empty value here are
                                   almost certainly wrong.
-                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
@@ -9652,6 +9791,8 @@ spec:
                       cinder:
                         description: |-
                           cinder represents a cinder volume attached and mounted on kubelets host machine.
+                          Deprecated: Cinder is deprecated. All operations for the in-tree cinder type
+                          are redirected to the cinder.csi.openstack.org CSI driver.
                           More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                         properties:
                           fsType:
@@ -9679,9 +9820,7 @@ spec:
                                   This field is effectively required, but due to backwards compatibility is
                                   allowed to be empty. Instances of this type with an empty value here are
                                   almost certainly wrong.
-                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
@@ -9752,9 +9891,7 @@ spec:
                               This field is effectively required, but due to backwards compatibility is
                               allowed to be empty. Instances of this type with an empty value here are
                               almost certainly wrong.
-                              TODO: Add other useful fields. apiVersion, kind, uid?
                               More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                             type: string
                           optional:
                             description: optional specify whether the ConfigMap or its keys must be defined
@@ -9762,7 +9899,7 @@ spec:
                         type: object
                         x-kubernetes-map-type: atomic
                       csi:
-                        description: csi (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers (Beta feature).
+                        description: csi (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers.
                         properties:
                           driver:
                             description: |-
@@ -9790,9 +9927,7 @@ spec:
                                   This field is effectively required, but due to backwards compatibility is
                                   allowed to be empty. Instances of this type with an empty value here are
                                   almost certainly wrong.
-                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
@@ -9917,7 +10052,6 @@ spec:
                           The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,
                           and deleted when the pod is removed.
 
-
                           Use this if:
                           a) the volume is only needed while the pod runs,
                           b) features of normal volumes like restoring from snapshot or capacity
@@ -9928,16 +10062,13 @@ spec:
                              information on the connection between this volume type
                              and PersistentVolumeClaim).
 
-
                           Use PersistentVolumeClaim or one of the vendor-specific
                           APIs for volumes that persist for longer than the lifecycle
                           of an individual pod.
 
-
                           Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to
                           be used that way - see the documentation of the driver for
                           more information.
-
 
                           A pod can use both types of ephemeral volumes and
                           persistent volumes at the same time.
@@ -9952,7 +10083,6 @@ spec:
                               entry. Pod validation will reject the pod if the concatenated name
                               is not valid for a PVC (for example, too long).
 
-
                               An existing PVC with that name that is not owned by the pod
                               will *not* be used for the pod to avoid using an unrelated
                               volume by mistake. Starting the pod is then blocked until
@@ -9962,10 +10092,8 @@ spec:
                               this should not be necessary, but it may be useful when
                               manually reconstructing a broken cluster.
 
-
                               This field is read-only and no changes will be made by Kubernetes
                               to the PVC after it has been created.
-
 
                               Required, must not be nil.
                             properties:
@@ -10161,7 +10289,7 @@ spec:
                                       set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
                                       exists.
                                       More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
-                                      (Alpha) Using this field requires the VolumeAttributesClass feature gate to be enabled.
+                                      (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).
                                     type: string
                                   volumeMode:
                                     description: |-
@@ -10184,7 +10312,6 @@ spec:
                               fsType is the filesystem type to mount.
                               Must be a filesystem type supported by the host operating system.
                               Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                              TODO: how do we prevent errors in the filesystem from compromising the machine
                             type: string
                           lun:
                             description: 'lun is Optional: FC target lun number'
@@ -10214,6 +10341,7 @@ spec:
                         description: |-
                           flexVolume represents a generic volume resource that is
                           provisioned/attached using an exec based plugin.
+                          Deprecated: FlexVolume is deprecated. Consider using a CSIDriver instead.
                         properties:
                           driver:
                             description: driver is the name of the driver to use for this volume.
@@ -10249,9 +10377,7 @@ spec:
                                   This field is effectively required, but due to backwards compatibility is
                                   allowed to be empty. Instances of this type with an empty value here are
                                   almost certainly wrong.
-                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
@@ -10259,7 +10385,9 @@ spec:
                           - driver
                         type: object
                       flocker:
-                        description: flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running
+                        description: |-
+                          flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running.
+                          Deprecated: Flocker is deprecated and the in-tree flocker type is no longer supported.
                         properties:
                           datasetName:
                             description: |-
@@ -10274,6 +10402,8 @@ spec:
                         description: |-
                           gcePersistentDisk represents a GCE Disk resource that is attached to a
                           kubelet's host machine and then exposed to the pod.
+                          Deprecated: GCEPersistentDisk is deprecated. All operations for the in-tree
+                          gcePersistentDisk type are redirected to the pd.csi.storage.gke.io CSI driver.
                           More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                         properties:
                           fsType:
@@ -10282,7 +10412,6 @@ spec:
                               Tip: Ensure that the filesystem type is supported by the host operating system.
                               Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                               More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                              TODO: how do we prevent errors in the filesystem from compromising the machine
                             type: string
                           partition:
                             description: |-
@@ -10310,7 +10439,7 @@ spec:
                       gitRepo:
                         description: |-
                           gitRepo represents a git repository at a particular revision.
-                          DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an
+                          Deprecated: GitRepo is deprecated. To provision a container with a git repo, mount an
                           EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
                           into the Pod's container.
                         properties:
@@ -10333,6 +10462,7 @@ spec:
                       glusterfs:
                         description: |-
                           glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
+                          Deprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported.
                           More info: https://examples.k8s.io/volumes/glusterfs/README.md
                         properties:
                           endpoints:
@@ -10362,9 +10492,6 @@ spec:
                           used for system agents or other privileged things that are allowed
                           to see the host machine. Most containers will NOT need this.
                           More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-                          ---
-                          TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not
-                          mount host directories as read/write.
                         properties:
                           path:
                             description: |-
@@ -10380,6 +10507,41 @@ spec:
                             type: string
                         required:
                           - path
+                        type: object
+                      image:
+                        description: |-
+                          image represents an OCI object (a container image or artifact) pulled and mounted on the kubelet's host machine.
+                          The volume is resolved at pod startup depending on which PullPolicy value is provided:
+
+                          - Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                          - Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                          - IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+
+                          The volume gets re-resolved if the pod gets deleted and recreated, which means that new remote content will become available on pod recreation.
+                          A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
+                          The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
+                          The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
+                          The volume will be mounted read-only (ro) and non-executable files (noexec).
+                          Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath).
+                          The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
+                        properties:
+                          pullPolicy:
+                            description: |-
+                              Policy for pulling OCI objects. Possible values are:
+                              Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                              Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                              IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+                              Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                            type: string
+                          reference:
+                            description: |-
+                              Required: Image or artifact reference to be used.
+                              Behaves in the same way as pod.spec.containers[*].image.
+                              Pull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets.
+                              More info: https://kubernetes.io/docs/concepts/containers/images
+                              This field is optional to allow higher level config management to default or override
+                              container images in workload controllers like Deployments and StatefulSets.
+                            type: string
                         type: object
                       iscsi:
                         description: |-
@@ -10399,7 +10561,6 @@ spec:
                               Tip: Ensure that the filesystem type is supported by the host operating system.
                               Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                               More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                              TODO: how do we prevent errors in the filesystem from compromising the machine
                             type: string
                           initiatorName:
                             description: |-
@@ -10411,6 +10572,7 @@ spec:
                             description: iqn is the target iSCSI Qualified Name.
                             type: string
                           iscsiInterface:
+                            default: default
                             description: |-
                               iscsiInterface is the interface Name that uses an iSCSI transport.
                               Defaults to 'default' (tcp).
@@ -10442,9 +10604,7 @@ spec:
                                   This field is effectively required, but due to backwards compatibility is
                                   allowed to be empty. Instances of this type with an empty value here are
                                   almost certainly wrong.
-                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
@@ -10506,7 +10666,9 @@ spec:
                           - claimName
                         type: object
                       photonPersistentDisk:
-                        description: photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine
+                        description: |-
+                          photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine.
+                          Deprecated: PhotonPersistentDisk is deprecated and the in-tree photonPersistentDisk type is no longer supported.
                         properties:
                           fsType:
                             description: |-
@@ -10521,7 +10683,11 @@ spec:
                           - pdID
                         type: object
                       portworxVolume:
-                        description: portworxVolume represents a portworx volume attached and mounted on kubelets host machine
+                        description: |-
+                          portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
+                          Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
+                          are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
+                          is on.
                         properties:
                           fsType:
                             description: |-
@@ -10554,22 +10720,23 @@ spec:
                             format: int32
                             type: integer
                           sources:
-                            description: sources is the list of volume projections
+                            description: |-
+                              sources is the list of volume projections. Each entry in this list
+                              handles one source.
                             items:
-                              description: Projection that may be projected along with other supported volume types
+                              description: |-
+                                Projection that may be projected along with other supported volume types.
+                                Exactly one of these fields must be set.
                               properties:
                                 clusterTrustBundle:
                                   description: |-
                                     ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field
                                     of ClusterTrustBundle objects in an auto-updating file.
 
-
                                     Alpha, gated by the ClusterTrustBundleProjection feature gate.
-
 
                                     ClusterTrustBundle objects can either be selected by name, or by the
                                     combination of signer name and a label selector.
-
 
                                     Kubelet performs aggressive normalization of the PEM contents written
                                     into the pod filesystem.  Esoteric PEM features such as inter-block
@@ -10698,9 +10865,7 @@ spec:
                                         This field is effectively required, but due to backwards compatibility is
                                         allowed to be empty. Instances of this type with an empty value here are
                                         almost certainly wrong.
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                         More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                       type: string
                                     optional:
                                       description: optional specify whether the ConfigMap or its keys must be defined
@@ -10817,9 +10982,7 @@ spec:
                                         This field is effectively required, but due to backwards compatibility is
                                         allowed to be empty. Instances of this type with an empty value here are
                                         almost certainly wrong.
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                         More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                       type: string
                                     optional:
                                       description: optional field specify whether the Secret or its key must be defined
@@ -10859,7 +11022,9 @@ spec:
                             x-kubernetes-list-type: atomic
                         type: object
                       quobyte:
-                        description: quobyte represents a Quobyte mount on the host that shares a pod's lifetime
+                        description: |-
+                          quobyte represents a Quobyte mount on the host that shares a pod's lifetime.
+                          Deprecated: Quobyte is deprecated and the in-tree quobyte type is no longer supported.
                         properties:
                           group:
                             description: |-
@@ -10897,6 +11062,7 @@ spec:
                       rbd:
                         description: |-
                           rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
+                          Deprecated: RBD is deprecated and the in-tree rbd type is no longer supported.
                           More info: https://examples.k8s.io/volumes/rbd/README.md
                         properties:
                           fsType:
@@ -10905,7 +11071,6 @@ spec:
                               Tip: Ensure that the filesystem type is supported by the host operating system.
                               Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                               More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                              TODO: how do we prevent errors in the filesystem from compromising the machine
                             type: string
                           image:
                             description: |-
@@ -10913,6 +11078,7 @@ spec:
                               More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                             type: string
                           keyring:
+                            default: /etc/ceph/keyring
                             description: |-
                               keyring is the path to key ring for RBDUser.
                               Default is /etc/ceph/keyring.
@@ -10927,6 +11093,7 @@ spec:
                             type: array
                             x-kubernetes-list-type: atomic
                           pool:
+                            default: rbd
                             description: |-
                               pool is the rados pool name.
                               Default is rbd.
@@ -10952,13 +11119,12 @@ spec:
                                   This field is effectively required, but due to backwards compatibility is
                                   allowed to be empty. Instances of this type with an empty value here are
                                   almost certainly wrong.
-                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
                           user:
+                            default: admin
                             description: |-
                               user is the rados user name.
                               Default is admin.
@@ -10969,9 +11135,12 @@ spec:
                           - monitors
                         type: object
                       scaleIO:
-                        description: scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
+                        description: |-
+                          scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
+                          Deprecated: ScaleIO is deprecated and the in-tree scaleIO type is no longer supported.
                         properties:
                           fsType:
+                            default: xfs
                             description: |-
                               fsType is the filesystem type to mount.
                               Must be a filesystem type supported by the host operating system.
@@ -11001,9 +11170,7 @@ spec:
                                   This field is effectively required, but due to backwards compatibility is
                                   allowed to be empty. Instances of this type with an empty value here are
                                   almost certainly wrong.
-                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
@@ -11011,6 +11178,7 @@ spec:
                             description: sslEnabled Flag enable/disable SSL communication with Gateway, default false
                             type: boolean
                           storageMode:
+                            default: ThinProvisioned
                             description: |-
                               storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
                               Default is ThinProvisioned.
@@ -11095,7 +11263,9 @@ spec:
                             type: string
                         type: object
                       storageos:
-                        description: storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
+                        description: |-
+                          storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
+                          Deprecated: StorageOS is deprecated and the in-tree storageos type is no longer supported.
                         properties:
                           fsType:
                             description: |-
@@ -11120,9 +11290,7 @@ spec:
                                   This field is effectively required, but due to backwards compatibility is
                                   allowed to be empty. Instances of this type with an empty value here are
                                   almost certainly wrong.
-                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
@@ -11142,7 +11310,10 @@ spec:
                             type: string
                         type: object
                       vsphereVolume:
-                        description: vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine
+                        description: |-
+                          vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine.
+                          Deprecated: VsphereVolume is deprecated. All operations for the in-tree vsphereVolume type
+                          are redirected to the csi.vsphere.vmware.com CSI driver.
                         properties:
                           fsType:
                             description: |-
@@ -11163,6 +11334,7 @@ spec:
                           - volumePath
                         type: object
                     required:
+                      - ""
                       - name
                     type: object
                   type: array
@@ -11211,9 +11383,7 @@ spec:
                                       This field is effectively required, but due to backwards compatibility is
                                       allowed to be empty. Instances of this type with an empty value here are
                                       almost certainly wrong.
-                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                     type: string
                                   optional:
                                     description: Specify whether the ConfigMap or its key must be defined
@@ -11272,9 +11442,7 @@ spec:
                                       This field is effectively required, but due to backwards compatibility is
                                       allowed to be empty. Instances of this type with an empty value here are
                                       almost certainly wrong.
-                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                     type: string
                                   optional:
                                     description: Specify whether the Secret or its key must be defined
@@ -11493,21 +11661,29 @@ spec:
                         artifact
                       properties:
                         contextDir:
-                          description: ContextDir is a path to subfolder in the repo. Optional.
+                          description: |-
+                            ContextDir is a path to a subdirectory within the source code that should be used as the
+                            build root directory. Optional.
                           type: string
                         git:
-                          description: Git contains the details for the source of type Git
+                          description: Git contains the details for obtaining source code from a git repository.
                           properties:
                             cloneSecret:
                               description: |-
                                 CloneSecret references a Secret that contains credentials to access
                                 the repository.
                               type: string
+                            depth:
+                              description: |-
+                                Depth specifies the depth of the shallow clone.
+                                If not specified the default is set to 1.
+                                Values greater than 1 will create a clone with the specified depth.
+                                If value is 0, it will create a full git history clone.
+                              type: integer
                             revision:
                               description: |-
                                 Revision describes the Git revision (e.g., branch, tag, commit SHA,
                                 etc.) to fetch.
-
 
                                 If not defined, it will fallback to the repository's default branch.
                               type: string
@@ -11518,40 +11694,49 @@ spec:
                             - url
                           type: object
                         local:
-                          description: Local contains the details for the source of type Local
+                          description: |-
+                            Local contains the details for obtaining source code that is streamed in from a remote
+                            machine's local directory.
                           properties:
                             name:
                               description: Name of the local step
                               type: string
                             timeout:
-                              description: Timeout how long the BuildSource execution must take.
+                              description: |-
+                                Timeout is the maximum duration the build should wait for source code to be streamed in from
+                                a remote machine's local directory.
                               type: string
                           type: object
                         ociArtifact:
-                          description: OCIArtifact contains the details for the source of type OCIArtifact
+                          description: |-
+                            OCIArtifact contains the details for obtaining source code from a container image, also
+                            known as an OCI artifact.
                           properties:
                             image:
-                              description: Image reference, i.e. quay.io/org/image:tag
+                              description: |-
+                                Image is a reference to a container image to be pulled from a container registry.
+                                For example, quay.io/org/image:tag
                               type: string
                             prune:
                               description: |-
-                                Prune specifies whether the image is suppose to be deleted. Allowed
-                                values are 'Never' (no deletion) and `AfterPull` (removal after the
+                                Prune specifies whether the image containing the source code should be deleted.
+                                Allowed values are 'Never' (no deletion) and `AfterPull` (removal after the
                                 image was successfully pulled from the registry).
-
 
                                 If not defined, it defaults to 'Never'.
                               type: string
                             pullSecret:
                               description: |-
                                 PullSecret references a Secret that contains credentials to access
-                                the repository.
+                                the container image.
                               type: string
                           required:
                             - image
                           type: object
                         type:
-                          description: Type is the BuildSource qualifier, the type of the source.
+                          description: |-
+                            Type is the type of source code used as input for the build. Allowed values are
+                            `Git`, `OCI`, and `Local`.
                           type: string
                       required:
                         - type
@@ -11691,6 +11876,8 @@ spec:
                             description: |-
                               awsElasticBlockStore represents an AWS Disk resource that is attached to a
                               kubelet's host machine and then exposed to the pod.
+                              Deprecated: AWSElasticBlockStore is deprecated. All operations for the in-tree
+                              awsElasticBlockStore type are redirected to the ebs.csi.aws.com CSI driver.
                               More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                             properties:
                               fsType:
@@ -11699,7 +11886,6 @@ spec:
                                   Tip: Ensure that the filesystem type is supported by the host operating system.
                                   Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                                  TODO: how do we prevent errors in the filesystem from compromising the machine
                                 type: string
                               partition:
                                 description: |-
@@ -11723,7 +11909,10 @@ spec:
                               - volumeID
                             type: object
                           azureDisk:
-                            description: azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
+                            description: |-
+                              azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
+                              Deprecated: AzureDisk is deprecated. All operations for the in-tree azureDisk type
+                              are redirected to the disk.csi.azure.com CSI driver.
                             properties:
                               cachingMode:
                                 description: 'cachingMode is the Host Caching mode: None, Read Only, Read Write.'
@@ -11735,6 +11924,7 @@ spec:
                                 description: diskURI is the URI of data disk in the blob storage
                                 type: string
                               fsType:
+                                default: ext4
                                 description: |-
                                   fsType is Filesystem type to mount.
                                   Must be a filesystem type supported by the host operating system.
@@ -11744,6 +11934,7 @@ spec:
                                 description: 'kind expected values are Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared'
                                 type: string
                               readOnly:
+                                default: false
                                 description: |-
                                   readOnly Defaults to false (read/write). ReadOnly here will force
                                   the ReadOnly setting in VolumeMounts.
@@ -11753,7 +11944,10 @@ spec:
                               - diskURI
                             type: object
                           azureFile:
-                            description: azureFile represents an Azure File Service mount on the host and bind mount to the pod.
+                            description: |-
+                              azureFile represents an Azure File Service mount on the host and bind mount to the pod.
+                              Deprecated: AzureFile is deprecated. All operations for the in-tree azureFile type
+                              are redirected to the file.csi.azure.com CSI driver.
                             properties:
                               readOnly:
                                 description: |-
@@ -11771,7 +11965,9 @@ spec:
                               - shareName
                             type: object
                           cephfs:
-                            description: cephFS represents a Ceph FS mount on the host that shares a pod's lifetime
+                            description: |-
+                              cephFS represents a Ceph FS mount on the host that shares a pod's lifetime.
+                              Deprecated: CephFS is deprecated and the in-tree cephfs type is no longer supported.
                             properties:
                               monitors:
                                 description: |-
@@ -11807,9 +12003,7 @@ spec:
                                       This field is effectively required, but due to backwards compatibility is
                                       allowed to be empty. Instances of this type with an empty value here are
                                       almost certainly wrong.
-                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                     type: string
                                 type: object
                                 x-kubernetes-map-type: atomic
@@ -11824,6 +12018,8 @@ spec:
                           cinder:
                             description: |-
                               cinder represents a cinder volume attached and mounted on kubelets host machine.
+                              Deprecated: Cinder is deprecated. All operations for the in-tree cinder type
+                              are redirected to the cinder.csi.openstack.org CSI driver.
                               More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                             properties:
                               fsType:
@@ -11851,9 +12047,7 @@ spec:
                                       This field is effectively required, but due to backwards compatibility is
                                       allowed to be empty. Instances of this type with an empty value here are
                                       almost certainly wrong.
-                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                     type: string
                                 type: object
                                 x-kubernetes-map-type: atomic
@@ -11924,9 +12118,7 @@ spec:
                                   This field is effectively required, but due to backwards compatibility is
                                   allowed to be empty. Instances of this type with an empty value here are
                                   almost certainly wrong.
-                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                 type: string
                               optional:
                                 description: optional specify whether the ConfigMap or its keys must be defined
@@ -11934,7 +12126,7 @@ spec:
                             type: object
                             x-kubernetes-map-type: atomic
                           csi:
-                            description: csi (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers (Beta feature).
+                            description: csi (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers.
                             properties:
                               driver:
                                 description: |-
@@ -11962,9 +12154,7 @@ spec:
                                       This field is effectively required, but due to backwards compatibility is
                                       allowed to be empty. Instances of this type with an empty value here are
                                       almost certainly wrong.
-                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                     type: string
                                 type: object
                                 x-kubernetes-map-type: atomic
@@ -12089,7 +12279,6 @@ spec:
                               The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,
                               and deleted when the pod is removed.
 
-
                               Use this if:
                               a) the volume is only needed while the pod runs,
                               b) features of normal volumes like restoring from snapshot or capacity
@@ -12100,16 +12289,13 @@ spec:
                                  information on the connection between this volume type
                                  and PersistentVolumeClaim).
 
-
                               Use PersistentVolumeClaim or one of the vendor-specific
                               APIs for volumes that persist for longer than the lifecycle
                               of an individual pod.
 
-
                               Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to
                               be used that way - see the documentation of the driver for
                               more information.
-
 
                               A pod can use both types of ephemeral volumes and
                               persistent volumes at the same time.
@@ -12124,7 +12310,6 @@ spec:
                                   entry. Pod validation will reject the pod if the concatenated name
                                   is not valid for a PVC (for example, too long).
 
-
                                   An existing PVC with that name that is not owned by the pod
                                   will *not* be used for the pod to avoid using an unrelated
                                   volume by mistake. Starting the pod is then blocked until
@@ -12134,10 +12319,8 @@ spec:
                                   this should not be necessary, but it may be useful when
                                   manually reconstructing a broken cluster.
 
-
                                   This field is read-only and no changes will be made by Kubernetes
                                   to the PVC after it has been created.
-
 
                                   Required, must not be nil.
                                 properties:
@@ -12333,7 +12516,7 @@ spec:
                                           set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
                                           exists.
                                           More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
-                                          (Alpha) Using this field requires the VolumeAttributesClass feature gate to be enabled.
+                                          (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).
                                         type: string
                                       volumeMode:
                                         description: |-
@@ -12356,7 +12539,6 @@ spec:
                                   fsType is the filesystem type to mount.
                                   Must be a filesystem type supported by the host operating system.
                                   Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                  TODO: how do we prevent errors in the filesystem from compromising the machine
                                 type: string
                               lun:
                                 description: 'lun is Optional: FC target lun number'
@@ -12386,6 +12568,7 @@ spec:
                             description: |-
                               flexVolume represents a generic volume resource that is
                               provisioned/attached using an exec based plugin.
+                              Deprecated: FlexVolume is deprecated. Consider using a CSIDriver instead.
                             properties:
                               driver:
                                 description: driver is the name of the driver to use for this volume.
@@ -12421,9 +12604,7 @@ spec:
                                       This field is effectively required, but due to backwards compatibility is
                                       allowed to be empty. Instances of this type with an empty value here are
                                       almost certainly wrong.
-                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                     type: string
                                 type: object
                                 x-kubernetes-map-type: atomic
@@ -12431,7 +12612,9 @@ spec:
                               - driver
                             type: object
                           flocker:
-                            description: flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running
+                            description: |-
+                              flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running.
+                              Deprecated: Flocker is deprecated and the in-tree flocker type is no longer supported.
                             properties:
                               datasetName:
                                 description: |-
@@ -12446,6 +12629,8 @@ spec:
                             description: |-
                               gcePersistentDisk represents a GCE Disk resource that is attached to a
                               kubelet's host machine and then exposed to the pod.
+                              Deprecated: GCEPersistentDisk is deprecated. All operations for the in-tree
+                              gcePersistentDisk type are redirected to the pd.csi.storage.gke.io CSI driver.
                               More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                             properties:
                               fsType:
@@ -12454,7 +12639,6 @@ spec:
                                   Tip: Ensure that the filesystem type is supported by the host operating system.
                                   Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                                  TODO: how do we prevent errors in the filesystem from compromising the machine
                                 type: string
                               partition:
                                 description: |-
@@ -12482,7 +12666,7 @@ spec:
                           gitRepo:
                             description: |-
                               gitRepo represents a git repository at a particular revision.
-                              DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an
+                              Deprecated: GitRepo is deprecated. To provision a container with a git repo, mount an
                               EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
                               into the Pod's container.
                             properties:
@@ -12505,6 +12689,7 @@ spec:
                           glusterfs:
                             description: |-
                               glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
+                              Deprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported.
                               More info: https://examples.k8s.io/volumes/glusterfs/README.md
                             properties:
                               endpoints:
@@ -12534,9 +12719,6 @@ spec:
                               used for system agents or other privileged things that are allowed
                               to see the host machine. Most containers will NOT need this.
                               More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-                              ---
-                              TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not
-                              mount host directories as read/write.
                             properties:
                               path:
                                 description: |-
@@ -12552,6 +12734,41 @@ spec:
                                 type: string
                             required:
                               - path
+                            type: object
+                          image:
+                            description: |-
+                              image represents an OCI object (a container image or artifact) pulled and mounted on the kubelet's host machine.
+                              The volume is resolved at pod startup depending on which PullPolicy value is provided:
+
+                              - Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                              - Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                              - IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+
+                              The volume gets re-resolved if the pod gets deleted and recreated, which means that new remote content will become available on pod recreation.
+                              A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
+                              The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
+                              The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
+                              The volume will be mounted read-only (ro) and non-executable files (noexec).
+                              Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath).
+                              The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
+                            properties:
+                              pullPolicy:
+                                description: |-
+                                  Policy for pulling OCI objects. Possible values are:
+                                  Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                                  Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                                  IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+                                  Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                type: string
+                              reference:
+                                description: |-
+                                  Required: Image or artifact reference to be used.
+                                  Behaves in the same way as pod.spec.containers[*].image.
+                                  Pull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets.
+                                  More info: https://kubernetes.io/docs/concepts/containers/images
+                                  This field is optional to allow higher level config management to default or override
+                                  container images in workload controllers like Deployments and StatefulSets.
+                                type: string
                             type: object
                           iscsi:
                             description: |-
@@ -12571,7 +12788,6 @@ spec:
                                   Tip: Ensure that the filesystem type is supported by the host operating system.
                                   Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                                  TODO: how do we prevent errors in the filesystem from compromising the machine
                                 type: string
                               initiatorName:
                                 description: |-
@@ -12583,6 +12799,7 @@ spec:
                                 description: iqn is the target iSCSI Qualified Name.
                                 type: string
                               iscsiInterface:
+                                default: default
                                 description: |-
                                   iscsiInterface is the interface Name that uses an iSCSI transport.
                                   Defaults to 'default' (tcp).
@@ -12614,9 +12831,7 @@ spec:
                                       This field is effectively required, but due to backwards compatibility is
                                       allowed to be empty. Instances of this type with an empty value here are
                                       almost certainly wrong.
-                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                     type: string
                                 type: object
                                 x-kubernetes-map-type: atomic
@@ -12678,7 +12893,9 @@ spec:
                               - claimName
                             type: object
                           photonPersistentDisk:
-                            description: photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine
+                            description: |-
+                              photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine.
+                              Deprecated: PhotonPersistentDisk is deprecated and the in-tree photonPersistentDisk type is no longer supported.
                             properties:
                               fsType:
                                 description: |-
@@ -12693,7 +12910,11 @@ spec:
                               - pdID
                             type: object
                           portworxVolume:
-                            description: portworxVolume represents a portworx volume attached and mounted on kubelets host machine
+                            description: |-
+                              portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
+                              Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
+                              are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
+                              is on.
                             properties:
                               fsType:
                                 description: |-
@@ -12726,22 +12947,23 @@ spec:
                                 format: int32
                                 type: integer
                               sources:
-                                description: sources is the list of volume projections
+                                description: |-
+                                  sources is the list of volume projections. Each entry in this list
+                                  handles one source.
                                 items:
-                                  description: Projection that may be projected along with other supported volume types
+                                  description: |-
+                                    Projection that may be projected along with other supported volume types.
+                                    Exactly one of these fields must be set.
                                   properties:
                                     clusterTrustBundle:
                                       description: |-
                                         ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field
                                         of ClusterTrustBundle objects in an auto-updating file.
 
-
                                         Alpha, gated by the ClusterTrustBundleProjection feature gate.
-
 
                                         ClusterTrustBundle objects can either be selected by name, or by the
                                         combination of signer name and a label selector.
-
 
                                         Kubelet performs aggressive normalization of the PEM contents written
                                         into the pod filesystem.  Esoteric PEM features such as inter-block
@@ -12870,9 +13092,7 @@ spec:
                                             This field is effectively required, but due to backwards compatibility is
                                             allowed to be empty. Instances of this type with an empty value here are
                                             almost certainly wrong.
-                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                             More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                           type: string
                                         optional:
                                           description: optional specify whether the ConfigMap or its keys must be defined
@@ -12989,9 +13209,7 @@ spec:
                                             This field is effectively required, but due to backwards compatibility is
                                             allowed to be empty. Instances of this type with an empty value here are
                                             almost certainly wrong.
-                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                             More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                           type: string
                                         optional:
                                           description: optional field specify whether the Secret or its key must be defined
@@ -13031,7 +13249,9 @@ spec:
                                 x-kubernetes-list-type: atomic
                             type: object
                           quobyte:
-                            description: quobyte represents a Quobyte mount on the host that shares a pod's lifetime
+                            description: |-
+                              quobyte represents a Quobyte mount on the host that shares a pod's lifetime.
+                              Deprecated: Quobyte is deprecated and the in-tree quobyte type is no longer supported.
                             properties:
                               group:
                                 description: |-
@@ -13069,6 +13289,7 @@ spec:
                           rbd:
                             description: |-
                               rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
+                              Deprecated: RBD is deprecated and the in-tree rbd type is no longer supported.
                               More info: https://examples.k8s.io/volumes/rbd/README.md
                             properties:
                               fsType:
@@ -13077,7 +13298,6 @@ spec:
                                   Tip: Ensure that the filesystem type is supported by the host operating system.
                                   Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                                  TODO: how do we prevent errors in the filesystem from compromising the machine
                                 type: string
                               image:
                                 description: |-
@@ -13085,6 +13305,7 @@ spec:
                                   More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                 type: string
                               keyring:
+                                default: /etc/ceph/keyring
                                 description: |-
                                   keyring is the path to key ring for RBDUser.
                                   Default is /etc/ceph/keyring.
@@ -13099,6 +13320,7 @@ spec:
                                 type: array
                                 x-kubernetes-list-type: atomic
                               pool:
+                                default: rbd
                                 description: |-
                                   pool is the rados pool name.
                                   Default is rbd.
@@ -13124,13 +13346,12 @@ spec:
                                       This field is effectively required, but due to backwards compatibility is
                                       allowed to be empty. Instances of this type with an empty value here are
                                       almost certainly wrong.
-                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                     type: string
                                 type: object
                                 x-kubernetes-map-type: atomic
                               user:
+                                default: admin
                                 description: |-
                                   user is the rados user name.
                                   Default is admin.
@@ -13141,9 +13362,12 @@ spec:
                               - monitors
                             type: object
                           scaleIO:
-                            description: scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
+                            description: |-
+                              scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
+                              Deprecated: ScaleIO is deprecated and the in-tree scaleIO type is no longer supported.
                             properties:
                               fsType:
+                                default: xfs
                                 description: |-
                                   fsType is the filesystem type to mount.
                                   Must be a filesystem type supported by the host operating system.
@@ -13173,9 +13397,7 @@ spec:
                                       This field is effectively required, but due to backwards compatibility is
                                       allowed to be empty. Instances of this type with an empty value here are
                                       almost certainly wrong.
-                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                     type: string
                                 type: object
                                 x-kubernetes-map-type: atomic
@@ -13183,6 +13405,7 @@ spec:
                                 description: sslEnabled Flag enable/disable SSL communication with Gateway, default false
                                 type: boolean
                               storageMode:
+                                default: ThinProvisioned
                                 description: |-
                                   storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
                                   Default is ThinProvisioned.
@@ -13267,7 +13490,9 @@ spec:
                                 type: string
                             type: object
                           storageos:
-                            description: storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
+                            description: |-
+                              storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
+                              Deprecated: StorageOS is deprecated and the in-tree storageos type is no longer supported.
                             properties:
                               fsType:
                                 description: |-
@@ -13292,9 +13517,7 @@ spec:
                                       This field is effectively required, but due to backwards compatibility is
                                       allowed to be empty. Instances of this type with an empty value here are
                                       almost certainly wrong.
-                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                     type: string
                                 type: object
                                 x-kubernetes-map-type: atomic
@@ -13314,7 +13537,10 @@ spec:
                                 type: string
                             type: object
                           vsphereVolume:
-                            description: vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine
+                            description: |-
+                              vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine.
+                              Deprecated: VsphereVolume is deprecated. All operations for the in-tree vsphereVolume type
+                              are redirected to the csi.vsphere.vmware.com CSI driver.
                             properties:
                               fsType:
                                 description: |-
@@ -13335,6 +13561,7 @@ spec:
                               - volumePath
                             type: object
                         required:
+                          - ""
                           - name
                         type: object
                       type: array
@@ -13475,7 +13702,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: builds.shipwright.io
 spec:
   conversion:
@@ -13547,7 +13774,6 @@ spec:
                     Builder refers to the image containing the build tools inside which
                     the source code would be built.
 
-
                     NOTICE: Builder is deprecated, and will be removed in a future release.
                     Build strategies which rely on "builder" should provide an equivalent parameter instead.
                   properties:
@@ -13568,9 +13794,7 @@ spec:
                             This field is effectively required, but due to backwards compatibility is
                             allowed to be empty. Instances of this type with an empty value here are
                             almost certainly wrong.
-                            TODO: Add other useful fields. apiVersion, kind, uid?
                             More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                           type: string
                       type: object
                       x-kubernetes-map-type: atomic
@@ -13602,7 +13826,6 @@ spec:
                     Dockerfile is the path to the Dockerfile to be used for
                     build strategies which bank on the Dockerfile for building
                     an image.
-
 
                     NOTICE: Dockerfile is deprecated, and will be removed in a future release.
                     Build strategies which rely on "dockerfile" should provide an equivalent parameter instead.
@@ -13643,9 +13866,7 @@ spec:
                                   This field is effectively required, but due to backwards compatibility is
                                   allowed to be empty. Instances of this type with an empty value here are
                                   almost certainly wrong.
-                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                 type: string
                               optional:
                                 description: Specify whether the ConfigMap or its key must be defined
@@ -13704,9 +13925,7 @@ spec:
                                   This field is effectively required, but due to backwards compatibility is
                                   allowed to be empty. Instances of this type with an empty value here are
                                   almost certainly wrong.
-                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                 type: string
                               optional:
                                 description: Specify whether the Secret or its key must be defined
@@ -13740,9 +13959,7 @@ spec:
                             This field is effectively required, but due to backwards compatibility is
                             allowed to be empty. Instances of this type with an empty value here are
                             almost certainly wrong.
-                            TODO: Add other useful fields. apiVersion, kind, uid?
                             More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                           type: string
                       type: object
                       x-kubernetes-map-type: atomic
@@ -13901,7 +14118,6 @@ spec:
                             values are 'Never' (no deletion) and `AfterPull` (removal after the
                             image was successfully pulled from the registry).
 
-
                             If not defined, it defaults to 'Never'.
                           type: string
                       required:
@@ -13922,9 +14138,7 @@ spec:
                             This field is effectively required, but due to backwards compatibility is
                             allowed to be empty. Instances of this type with an empty value here are
                             almost certainly wrong.
-                            TODO: Add other useful fields. apiVersion, kind, uid?
                             More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                           type: string
                       type: object
                       x-kubernetes-map-type: atomic
@@ -13932,7 +14146,6 @@ spec:
                       description: |-
                         Revision describes the Git revision (e.g., branch, tag, commit SHA,
                         etc.) to fetch.
-
 
                         If not defined, it will fallback to the repository's default branch.
                       type: string
@@ -13944,7 +14157,6 @@ spec:
                   description: |-
                     Sources slice of BuildSource, defining external build artifacts complementary to VCS
                     (`.spec.source`) data.
-
 
                     NOTICE: Multiple sources in a build are deprecated. This feature will be removed in a future release.
                   items:
@@ -14002,9 +14214,7 @@ spec:
                             This field is effectively required, but due to backwards compatibility is
                             allowed to be empty. Instances of this type with an empty value here are
                             almost certainly wrong.
-                            TODO: Add other useful fields. apiVersion, kind, uid?
                             More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                           type: string
                       type: object
                       x-kubernetes-map-type: atomic
@@ -14080,6 +14290,8 @@ spec:
                         description: |-
                           awsElasticBlockStore represents an AWS Disk resource that is attached to a
                           kubelet's host machine and then exposed to the pod.
+                          Deprecated: AWSElasticBlockStore is deprecated. All operations for the in-tree
+                          awsElasticBlockStore type are redirected to the ebs.csi.aws.com CSI driver.
                           More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                         properties:
                           fsType:
@@ -14088,7 +14300,6 @@ spec:
                               Tip: Ensure that the filesystem type is supported by the host operating system.
                               Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                               More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                              TODO: how do we prevent errors in the filesystem from compromising the machine
                             type: string
                           partition:
                             description: |-
@@ -14112,7 +14323,10 @@ spec:
                           - volumeID
                         type: object
                       azureDisk:
-                        description: azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
+                        description: |-
+                          azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
+                          Deprecated: AzureDisk is deprecated. All operations for the in-tree azureDisk type
+                          are redirected to the disk.csi.azure.com CSI driver.
                         properties:
                           cachingMode:
                             description: 'cachingMode is the Host Caching mode: None, Read Only, Read Write.'
@@ -14124,6 +14338,7 @@ spec:
                             description: diskURI is the URI of data disk in the blob storage
                             type: string
                           fsType:
+                            default: ext4
                             description: |-
                               fsType is Filesystem type to mount.
                               Must be a filesystem type supported by the host operating system.
@@ -14133,6 +14348,7 @@ spec:
                             description: 'kind expected values are Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared'
                             type: string
                           readOnly:
+                            default: false
                             description: |-
                               readOnly Defaults to false (read/write). ReadOnly here will force
                               the ReadOnly setting in VolumeMounts.
@@ -14142,7 +14358,10 @@ spec:
                           - diskURI
                         type: object
                       azureFile:
-                        description: azureFile represents an Azure File Service mount on the host and bind mount to the pod.
+                        description: |-
+                          azureFile represents an Azure File Service mount on the host and bind mount to the pod.
+                          Deprecated: AzureFile is deprecated. All operations for the in-tree azureFile type
+                          are redirected to the file.csi.azure.com CSI driver.
                         properties:
                           readOnly:
                             description: |-
@@ -14160,7 +14379,9 @@ spec:
                           - shareName
                         type: object
                       cephfs:
-                        description: cephFS represents a Ceph FS mount on the host that shares a pod's lifetime
+                        description: |-
+                          cephFS represents a Ceph FS mount on the host that shares a pod's lifetime.
+                          Deprecated: CephFS is deprecated and the in-tree cephfs type is no longer supported.
                         properties:
                           monitors:
                             description: |-
@@ -14196,9 +14417,7 @@ spec:
                                   This field is effectively required, but due to backwards compatibility is
                                   allowed to be empty. Instances of this type with an empty value here are
                                   almost certainly wrong.
-                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
@@ -14213,6 +14432,8 @@ spec:
                       cinder:
                         description: |-
                           cinder represents a cinder volume attached and mounted on kubelets host machine.
+                          Deprecated: Cinder is deprecated. All operations for the in-tree cinder type
+                          are redirected to the cinder.csi.openstack.org CSI driver.
                           More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                         properties:
                           fsType:
@@ -14240,9 +14461,7 @@ spec:
                                   This field is effectively required, but due to backwards compatibility is
                                   allowed to be empty. Instances of this type with an empty value here are
                                   almost certainly wrong.
-                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
@@ -14313,9 +14532,7 @@ spec:
                               This field is effectively required, but due to backwards compatibility is
                               allowed to be empty. Instances of this type with an empty value here are
                               almost certainly wrong.
-                              TODO: Add other useful fields. apiVersion, kind, uid?
                               More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                             type: string
                           optional:
                             description: optional specify whether the ConfigMap or its keys must be defined
@@ -14323,7 +14540,7 @@ spec:
                         type: object
                         x-kubernetes-map-type: atomic
                       csi:
-                        description: csi (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers (Beta feature).
+                        description: csi (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers.
                         properties:
                           driver:
                             description: |-
@@ -14351,9 +14568,7 @@ spec:
                                   This field is effectively required, but due to backwards compatibility is
                                   allowed to be empty. Instances of this type with an empty value here are
                                   almost certainly wrong.
-                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
@@ -14375,7 +14590,6 @@ spec:
                       description:
                         description: |-
                           Description of the Build Volume
-
 
                           NOTICE: Description is deprecated, and will be removed in a future release.
                         type: string
@@ -14485,7 +14699,6 @@ spec:
                           The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,
                           and deleted when the pod is removed.
 
-
                           Use this if:
                           a) the volume is only needed while the pod runs,
                           b) features of normal volumes like restoring from snapshot or capacity
@@ -14496,16 +14709,13 @@ spec:
                              information on the connection between this volume type
                              and PersistentVolumeClaim).
 
-
                           Use PersistentVolumeClaim or one of the vendor-specific
                           APIs for volumes that persist for longer than the lifecycle
                           of an individual pod.
 
-
                           Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to
                           be used that way - see the documentation of the driver for
                           more information.
-
 
                           A pod can use both types of ephemeral volumes and
                           persistent volumes at the same time.
@@ -14520,7 +14730,6 @@ spec:
                               entry. Pod validation will reject the pod if the concatenated name
                               is not valid for a PVC (for example, too long).
 
-
                               An existing PVC with that name that is not owned by the pod
                               will *not* be used for the pod to avoid using an unrelated
                               volume by mistake. Starting the pod is then blocked until
@@ -14530,10 +14739,8 @@ spec:
                               this should not be necessary, but it may be useful when
                               manually reconstructing a broken cluster.
 
-
                               This field is read-only and no changes will be made by Kubernetes
                               to the PVC after it has been created.
-
 
                               Required, must not be nil.
                             properties:
@@ -14729,7 +14936,7 @@ spec:
                                       set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
                                       exists.
                                       More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
-                                      (Alpha) Using this field requires the VolumeAttributesClass feature gate to be enabled.
+                                      (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).
                                     type: string
                                   volumeMode:
                                     description: |-
@@ -14752,7 +14959,6 @@ spec:
                               fsType is the filesystem type to mount.
                               Must be a filesystem type supported by the host operating system.
                               Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                              TODO: how do we prevent errors in the filesystem from compromising the machine
                             type: string
                           lun:
                             description: 'lun is Optional: FC target lun number'
@@ -14782,6 +14988,7 @@ spec:
                         description: |-
                           flexVolume represents a generic volume resource that is
                           provisioned/attached using an exec based plugin.
+                          Deprecated: FlexVolume is deprecated. Consider using a CSIDriver instead.
                         properties:
                           driver:
                             description: driver is the name of the driver to use for this volume.
@@ -14817,9 +15024,7 @@ spec:
                                   This field is effectively required, but due to backwards compatibility is
                                   allowed to be empty. Instances of this type with an empty value here are
                                   almost certainly wrong.
-                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
@@ -14827,7 +15032,9 @@ spec:
                           - driver
                         type: object
                       flocker:
-                        description: flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running
+                        description: |-
+                          flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running.
+                          Deprecated: Flocker is deprecated and the in-tree flocker type is no longer supported.
                         properties:
                           datasetName:
                             description: |-
@@ -14842,6 +15049,8 @@ spec:
                         description: |-
                           gcePersistentDisk represents a GCE Disk resource that is attached to a
                           kubelet's host machine and then exposed to the pod.
+                          Deprecated: GCEPersistentDisk is deprecated. All operations for the in-tree
+                          gcePersistentDisk type are redirected to the pd.csi.storage.gke.io CSI driver.
                           More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                         properties:
                           fsType:
@@ -14850,7 +15059,6 @@ spec:
                               Tip: Ensure that the filesystem type is supported by the host operating system.
                               Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                               More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                              TODO: how do we prevent errors in the filesystem from compromising the machine
                             type: string
                           partition:
                             description: |-
@@ -14878,7 +15086,7 @@ spec:
                       gitRepo:
                         description: |-
                           gitRepo represents a git repository at a particular revision.
-                          DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an
+                          Deprecated: GitRepo is deprecated. To provision a container with a git repo, mount an
                           EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
                           into the Pod's container.
                         properties:
@@ -14901,6 +15109,7 @@ spec:
                       glusterfs:
                         description: |-
                           glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
+                          Deprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported.
                           More info: https://examples.k8s.io/volumes/glusterfs/README.md
                         properties:
                           endpoints:
@@ -14930,9 +15139,6 @@ spec:
                           used for system agents or other privileged things that are allowed
                           to see the host machine. Most containers will NOT need this.
                           More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-                          ---
-                          TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not
-                          mount host directories as read/write.
                         properties:
                           path:
                             description: |-
@@ -14948,6 +15154,41 @@ spec:
                             type: string
                         required:
                           - path
+                        type: object
+                      image:
+                        description: |-
+                          image represents an OCI object (a container image or artifact) pulled and mounted on the kubelet's host machine.
+                          The volume is resolved at pod startup depending on which PullPolicy value is provided:
+
+                          - Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                          - Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                          - IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+
+                          The volume gets re-resolved if the pod gets deleted and recreated, which means that new remote content will become available on pod recreation.
+                          A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
+                          The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
+                          The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
+                          The volume will be mounted read-only (ro) and non-executable files (noexec).
+                          Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath).
+                          The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
+                        properties:
+                          pullPolicy:
+                            description: |-
+                              Policy for pulling OCI objects. Possible values are:
+                              Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                              Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                              IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+                              Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                            type: string
+                          reference:
+                            description: |-
+                              Required: Image or artifact reference to be used.
+                              Behaves in the same way as pod.spec.containers[*].image.
+                              Pull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets.
+                              More info: https://kubernetes.io/docs/concepts/containers/images
+                              This field is optional to allow higher level config management to default or override
+                              container images in workload controllers like Deployments and StatefulSets.
+                            type: string
                         type: object
                       iscsi:
                         description: |-
@@ -14967,7 +15208,6 @@ spec:
                               Tip: Ensure that the filesystem type is supported by the host operating system.
                               Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                               More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                              TODO: how do we prevent errors in the filesystem from compromising the machine
                             type: string
                           initiatorName:
                             description: |-
@@ -14979,6 +15219,7 @@ spec:
                             description: iqn is the target iSCSI Qualified Name.
                             type: string
                           iscsiInterface:
+                            default: default
                             description: |-
                               iscsiInterface is the interface Name that uses an iSCSI transport.
                               Defaults to 'default' (tcp).
@@ -15010,9 +15251,7 @@ spec:
                                   This field is effectively required, but due to backwards compatibility is
                                   allowed to be empty. Instances of this type with an empty value here are
                                   almost certainly wrong.
-                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
@@ -15074,7 +15313,9 @@ spec:
                           - claimName
                         type: object
                       photonPersistentDisk:
-                        description: photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine
+                        description: |-
+                          photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine.
+                          Deprecated: PhotonPersistentDisk is deprecated and the in-tree photonPersistentDisk type is no longer supported.
                         properties:
                           fsType:
                             description: |-
@@ -15089,7 +15330,11 @@ spec:
                           - pdID
                         type: object
                       portworxVolume:
-                        description: portworxVolume represents a portworx volume attached and mounted on kubelets host machine
+                        description: |-
+                          portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
+                          Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
+                          are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
+                          is on.
                         properties:
                           fsType:
                             description: |-
@@ -15122,22 +15367,23 @@ spec:
                             format: int32
                             type: integer
                           sources:
-                            description: sources is the list of volume projections
+                            description: |-
+                              sources is the list of volume projections. Each entry in this list
+                              handles one source.
                             items:
-                              description: Projection that may be projected along with other supported volume types
+                              description: |-
+                                Projection that may be projected along with other supported volume types.
+                                Exactly one of these fields must be set.
                               properties:
                                 clusterTrustBundle:
                                   description: |-
                                     ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field
                                     of ClusterTrustBundle objects in an auto-updating file.
 
-
                                     Alpha, gated by the ClusterTrustBundleProjection feature gate.
-
 
                                     ClusterTrustBundle objects can either be selected by name, or by the
                                     combination of signer name and a label selector.
-
 
                                     Kubelet performs aggressive normalization of the PEM contents written
                                     into the pod filesystem.  Esoteric PEM features such as inter-block
@@ -15266,9 +15512,7 @@ spec:
                                         This field is effectively required, but due to backwards compatibility is
                                         allowed to be empty. Instances of this type with an empty value here are
                                         almost certainly wrong.
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                         More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                       type: string
                                     optional:
                                       description: optional specify whether the ConfigMap or its keys must be defined
@@ -15385,9 +15629,7 @@ spec:
                                         This field is effectively required, but due to backwards compatibility is
                                         allowed to be empty. Instances of this type with an empty value here are
                                         almost certainly wrong.
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                         More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                       type: string
                                     optional:
                                       description: optional field specify whether the Secret or its key must be defined
@@ -15427,7 +15669,9 @@ spec:
                             x-kubernetes-list-type: atomic
                         type: object
                       quobyte:
-                        description: quobyte represents a Quobyte mount on the host that shares a pod's lifetime
+                        description: |-
+                          quobyte represents a Quobyte mount on the host that shares a pod's lifetime.
+                          Deprecated: Quobyte is deprecated and the in-tree quobyte type is no longer supported.
                         properties:
                           group:
                             description: |-
@@ -15465,6 +15709,7 @@ spec:
                       rbd:
                         description: |-
                           rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
+                          Deprecated: RBD is deprecated and the in-tree rbd type is no longer supported.
                           More info: https://examples.k8s.io/volumes/rbd/README.md
                         properties:
                           fsType:
@@ -15473,7 +15718,6 @@ spec:
                               Tip: Ensure that the filesystem type is supported by the host operating system.
                               Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                               More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                              TODO: how do we prevent errors in the filesystem from compromising the machine
                             type: string
                           image:
                             description: |-
@@ -15481,6 +15725,7 @@ spec:
                               More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                             type: string
                           keyring:
+                            default: /etc/ceph/keyring
                             description: |-
                               keyring is the path to key ring for RBDUser.
                               Default is /etc/ceph/keyring.
@@ -15495,6 +15740,7 @@ spec:
                             type: array
                             x-kubernetes-list-type: atomic
                           pool:
+                            default: rbd
                             description: |-
                               pool is the rados pool name.
                               Default is rbd.
@@ -15520,13 +15766,12 @@ spec:
                                   This field is effectively required, but due to backwards compatibility is
                                   allowed to be empty. Instances of this type with an empty value here are
                                   almost certainly wrong.
-                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
                           user:
+                            default: admin
                             description: |-
                               user is the rados user name.
                               Default is admin.
@@ -15537,9 +15782,12 @@ spec:
                           - monitors
                         type: object
                       scaleIO:
-                        description: scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
+                        description: |-
+                          scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
+                          Deprecated: ScaleIO is deprecated and the in-tree scaleIO type is no longer supported.
                         properties:
                           fsType:
+                            default: xfs
                             description: |-
                               fsType is the filesystem type to mount.
                               Must be a filesystem type supported by the host operating system.
@@ -15569,9 +15817,7 @@ spec:
                                   This field is effectively required, but due to backwards compatibility is
                                   allowed to be empty. Instances of this type with an empty value here are
                                   almost certainly wrong.
-                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
@@ -15579,6 +15825,7 @@ spec:
                             description: sslEnabled Flag enable/disable SSL communication with Gateway, default false
                             type: boolean
                           storageMode:
+                            default: ThinProvisioned
                             description: |-
                               storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
                               Default is ThinProvisioned.
@@ -15663,7 +15910,9 @@ spec:
                             type: string
                         type: object
                       storageos:
-                        description: storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
+                        description: |-
+                          storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
+                          Deprecated: StorageOS is deprecated and the in-tree storageos type is no longer supported.
                         properties:
                           fsType:
                             description: |-
@@ -15688,9 +15937,7 @@ spec:
                                   This field is effectively required, but due to backwards compatibility is
                                   allowed to be empty. Instances of this type with an empty value here are
                                   almost certainly wrong.
-                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
@@ -15710,7 +15957,10 @@ spec:
                             type: string
                         type: object
                       vsphereVolume:
-                        description: vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine
+                        description: |-
+                          vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine.
+                          Deprecated: VsphereVolume is deprecated. All operations for the in-tree vsphereVolume type
+                          are redirected to the csi.vsphere.vmware.com CSI driver.
                         properties:
                           fsType:
                             description: |-
@@ -15731,6 +15981,7 @@ spec:
                           - volumePath
                         type: object
                     required:
+                      - ""
                       - name
                     type: object
                   type: array
@@ -15742,7 +15993,6 @@ spec:
             status:
               description: |-
                 BuildStatus defines the observed state of Build
-
 
                 NOTICE: This is deprecated and will be removed in a future release.
               properties:
@@ -15845,9 +16095,7 @@ spec:
                                   This field is effectively required, but due to backwards compatibility is
                                   allowed to be empty. Instances of this type with an empty value here are
                                   almost certainly wrong.
-                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                 type: string
                               optional:
                                 description: Specify whether the ConfigMap or its key must be defined
@@ -15906,9 +16154,7 @@ spec:
                                   This field is effectively required, but due to backwards compatibility is
                                   allowed to be empty. Instances of this type with an empty value here are
                                   almost certainly wrong.
-                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                 type: string
                               optional:
                                 description: Specify whether the Secret or its key must be defined
@@ -16127,21 +16373,29 @@ spec:
                     artifact
                   properties:
                     contextDir:
-                      description: ContextDir is a path to subfolder in the repo. Optional.
+                      description: |-
+                        ContextDir is a path to a subdirectory within the source code that should be used as the
+                        build root directory. Optional.
                       type: string
                     git:
-                      description: Git contains the details for the source of type Git
+                      description: Git contains the details for obtaining source code from a git repository.
                       properties:
                         cloneSecret:
                           description: |-
                             CloneSecret references a Secret that contains credentials to access
                             the repository.
                           type: string
+                        depth:
+                          description: |-
+                            Depth specifies the depth of the shallow clone.
+                            If not specified the default is set to 1.
+                            Values greater than 1 will create a clone with the specified depth.
+                            If value is 0, it will create a full git history clone.
+                          type: integer
                         revision:
                           description: |-
                             Revision describes the Git revision (e.g., branch, tag, commit SHA,
                             etc.) to fetch.
-
 
                             If not defined, it will fallback to the repository's default branch.
                           type: string
@@ -16152,40 +16406,49 @@ spec:
                         - url
                       type: object
                     local:
-                      description: Local contains the details for the source of type Local
+                      description: |-
+                        Local contains the details for obtaining source code that is streamed in from a remote
+                        machine's local directory.
                       properties:
                         name:
                           description: Name of the local step
                           type: string
                         timeout:
-                          description: Timeout how long the BuildSource execution must take.
+                          description: |-
+                            Timeout is the maximum duration the build should wait for source code to be streamed in from
+                            a remote machine's local directory.
                           type: string
                       type: object
                     ociArtifact:
-                      description: OCIArtifact contains the details for the source of type OCIArtifact
+                      description: |-
+                        OCIArtifact contains the details for obtaining source code from a container image, also
+                        known as an OCI artifact.
                       properties:
                         image:
-                          description: Image reference, i.e. quay.io/org/image:tag
+                          description: |-
+                            Image is a reference to a container image to be pulled from a container registry.
+                            For example, quay.io/org/image:tag
                           type: string
                         prune:
                           description: |-
-                            Prune specifies whether the image is suppose to be deleted. Allowed
-                            values are 'Never' (no deletion) and `AfterPull` (removal after the
+                            Prune specifies whether the image containing the source code should be deleted.
+                            Allowed values are 'Never' (no deletion) and `AfterPull` (removal after the
                             image was successfully pulled from the registry).
-
 
                             If not defined, it defaults to 'Never'.
                           type: string
                         pullSecret:
                           description: |-
                             PullSecret references a Secret that contains credentials to access
-                            the repository.
+                            the container image.
                           type: string
                       required:
                         - image
                       type: object
                     type:
-                      description: Type is the BuildSource qualifier, the type of the source.
+                      description: |-
+                        Type is the type of source code used as input for the build. Allowed values are
+                        `Git`, `OCI`, and `Local`.
                       type: string
                   required:
                     - type
@@ -16325,6 +16588,8 @@ spec:
                         description: |-
                           awsElasticBlockStore represents an AWS Disk resource that is attached to a
                           kubelet's host machine and then exposed to the pod.
+                          Deprecated: AWSElasticBlockStore is deprecated. All operations for the in-tree
+                          awsElasticBlockStore type are redirected to the ebs.csi.aws.com CSI driver.
                           More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                         properties:
                           fsType:
@@ -16333,7 +16598,6 @@ spec:
                               Tip: Ensure that the filesystem type is supported by the host operating system.
                               Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                               More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                              TODO: how do we prevent errors in the filesystem from compromising the machine
                             type: string
                           partition:
                             description: |-
@@ -16357,7 +16621,10 @@ spec:
                           - volumeID
                         type: object
                       azureDisk:
-                        description: azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
+                        description: |-
+                          azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
+                          Deprecated: AzureDisk is deprecated. All operations for the in-tree azureDisk type
+                          are redirected to the disk.csi.azure.com CSI driver.
                         properties:
                           cachingMode:
                             description: 'cachingMode is the Host Caching mode: None, Read Only, Read Write.'
@@ -16369,6 +16636,7 @@ spec:
                             description: diskURI is the URI of data disk in the blob storage
                             type: string
                           fsType:
+                            default: ext4
                             description: |-
                               fsType is Filesystem type to mount.
                               Must be a filesystem type supported by the host operating system.
@@ -16378,6 +16646,7 @@ spec:
                             description: 'kind expected values are Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared'
                             type: string
                           readOnly:
+                            default: false
                             description: |-
                               readOnly Defaults to false (read/write). ReadOnly here will force
                               the ReadOnly setting in VolumeMounts.
@@ -16387,7 +16656,10 @@ spec:
                           - diskURI
                         type: object
                       azureFile:
-                        description: azureFile represents an Azure File Service mount on the host and bind mount to the pod.
+                        description: |-
+                          azureFile represents an Azure File Service mount on the host and bind mount to the pod.
+                          Deprecated: AzureFile is deprecated. All operations for the in-tree azureFile type
+                          are redirected to the file.csi.azure.com CSI driver.
                         properties:
                           readOnly:
                             description: |-
@@ -16405,7 +16677,9 @@ spec:
                           - shareName
                         type: object
                       cephfs:
-                        description: cephFS represents a Ceph FS mount on the host that shares a pod's lifetime
+                        description: |-
+                          cephFS represents a Ceph FS mount on the host that shares a pod's lifetime.
+                          Deprecated: CephFS is deprecated and the in-tree cephfs type is no longer supported.
                         properties:
                           monitors:
                             description: |-
@@ -16441,9 +16715,7 @@ spec:
                                   This field is effectively required, but due to backwards compatibility is
                                   allowed to be empty. Instances of this type with an empty value here are
                                   almost certainly wrong.
-                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
@@ -16458,6 +16730,8 @@ spec:
                       cinder:
                         description: |-
                           cinder represents a cinder volume attached and mounted on kubelets host machine.
+                          Deprecated: Cinder is deprecated. All operations for the in-tree cinder type
+                          are redirected to the cinder.csi.openstack.org CSI driver.
                           More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                         properties:
                           fsType:
@@ -16485,9 +16759,7 @@ spec:
                                   This field is effectively required, but due to backwards compatibility is
                                   allowed to be empty. Instances of this type with an empty value here are
                                   almost certainly wrong.
-                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
@@ -16558,9 +16830,7 @@ spec:
                               This field is effectively required, but due to backwards compatibility is
                               allowed to be empty. Instances of this type with an empty value here are
                               almost certainly wrong.
-                              TODO: Add other useful fields. apiVersion, kind, uid?
                               More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                             type: string
                           optional:
                             description: optional specify whether the ConfigMap or its keys must be defined
@@ -16568,7 +16838,7 @@ spec:
                         type: object
                         x-kubernetes-map-type: atomic
                       csi:
-                        description: csi (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers (Beta feature).
+                        description: csi (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers.
                         properties:
                           driver:
                             description: |-
@@ -16596,9 +16866,7 @@ spec:
                                   This field is effectively required, but due to backwards compatibility is
                                   allowed to be empty. Instances of this type with an empty value here are
                                   almost certainly wrong.
-                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
@@ -16723,7 +16991,6 @@ spec:
                           The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,
                           and deleted when the pod is removed.
 
-
                           Use this if:
                           a) the volume is only needed while the pod runs,
                           b) features of normal volumes like restoring from snapshot or capacity
@@ -16734,16 +17001,13 @@ spec:
                              information on the connection between this volume type
                              and PersistentVolumeClaim).
 
-
                           Use PersistentVolumeClaim or one of the vendor-specific
                           APIs for volumes that persist for longer than the lifecycle
                           of an individual pod.
 
-
                           Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to
                           be used that way - see the documentation of the driver for
                           more information.
-
 
                           A pod can use both types of ephemeral volumes and
                           persistent volumes at the same time.
@@ -16758,7 +17022,6 @@ spec:
                               entry. Pod validation will reject the pod if the concatenated name
                               is not valid for a PVC (for example, too long).
 
-
                               An existing PVC with that name that is not owned by the pod
                               will *not* be used for the pod to avoid using an unrelated
                               volume by mistake. Starting the pod is then blocked until
@@ -16768,10 +17031,8 @@ spec:
                               this should not be necessary, but it may be useful when
                               manually reconstructing a broken cluster.
 
-
                               This field is read-only and no changes will be made by Kubernetes
                               to the PVC after it has been created.
-
 
                               Required, must not be nil.
                             properties:
@@ -16967,7 +17228,7 @@ spec:
                                       set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
                                       exists.
                                       More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
-                                      (Alpha) Using this field requires the VolumeAttributesClass feature gate to be enabled.
+                                      (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).
                                     type: string
                                   volumeMode:
                                     description: |-
@@ -16990,7 +17251,6 @@ spec:
                               fsType is the filesystem type to mount.
                               Must be a filesystem type supported by the host operating system.
                               Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                              TODO: how do we prevent errors in the filesystem from compromising the machine
                             type: string
                           lun:
                             description: 'lun is Optional: FC target lun number'
@@ -17020,6 +17280,7 @@ spec:
                         description: |-
                           flexVolume represents a generic volume resource that is
                           provisioned/attached using an exec based plugin.
+                          Deprecated: FlexVolume is deprecated. Consider using a CSIDriver instead.
                         properties:
                           driver:
                             description: driver is the name of the driver to use for this volume.
@@ -17055,9 +17316,7 @@ spec:
                                   This field is effectively required, but due to backwards compatibility is
                                   allowed to be empty. Instances of this type with an empty value here are
                                   almost certainly wrong.
-                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
@@ -17065,7 +17324,9 @@ spec:
                           - driver
                         type: object
                       flocker:
-                        description: flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running
+                        description: |-
+                          flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running.
+                          Deprecated: Flocker is deprecated and the in-tree flocker type is no longer supported.
                         properties:
                           datasetName:
                             description: |-
@@ -17080,6 +17341,8 @@ spec:
                         description: |-
                           gcePersistentDisk represents a GCE Disk resource that is attached to a
                           kubelet's host machine and then exposed to the pod.
+                          Deprecated: GCEPersistentDisk is deprecated. All operations for the in-tree
+                          gcePersistentDisk type are redirected to the pd.csi.storage.gke.io CSI driver.
                           More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                         properties:
                           fsType:
@@ -17088,7 +17351,6 @@ spec:
                               Tip: Ensure that the filesystem type is supported by the host operating system.
                               Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                               More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                              TODO: how do we prevent errors in the filesystem from compromising the machine
                             type: string
                           partition:
                             description: |-
@@ -17116,7 +17378,7 @@ spec:
                       gitRepo:
                         description: |-
                           gitRepo represents a git repository at a particular revision.
-                          DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an
+                          Deprecated: GitRepo is deprecated. To provision a container with a git repo, mount an
                           EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
                           into the Pod's container.
                         properties:
@@ -17139,6 +17401,7 @@ spec:
                       glusterfs:
                         description: |-
                           glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
+                          Deprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported.
                           More info: https://examples.k8s.io/volumes/glusterfs/README.md
                         properties:
                           endpoints:
@@ -17168,9 +17431,6 @@ spec:
                           used for system agents or other privileged things that are allowed
                           to see the host machine. Most containers will NOT need this.
                           More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-                          ---
-                          TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not
-                          mount host directories as read/write.
                         properties:
                           path:
                             description: |-
@@ -17186,6 +17446,41 @@ spec:
                             type: string
                         required:
                           - path
+                        type: object
+                      image:
+                        description: |-
+                          image represents an OCI object (a container image or artifact) pulled and mounted on the kubelet's host machine.
+                          The volume is resolved at pod startup depending on which PullPolicy value is provided:
+
+                          - Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                          - Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                          - IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+
+                          The volume gets re-resolved if the pod gets deleted and recreated, which means that new remote content will become available on pod recreation.
+                          A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
+                          The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
+                          The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
+                          The volume will be mounted read-only (ro) and non-executable files (noexec).
+                          Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath).
+                          The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
+                        properties:
+                          pullPolicy:
+                            description: |-
+                              Policy for pulling OCI objects. Possible values are:
+                              Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                              Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                              IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+                              Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                            type: string
+                          reference:
+                            description: |-
+                              Required: Image or artifact reference to be used.
+                              Behaves in the same way as pod.spec.containers[*].image.
+                              Pull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets.
+                              More info: https://kubernetes.io/docs/concepts/containers/images
+                              This field is optional to allow higher level config management to default or override
+                              container images in workload controllers like Deployments and StatefulSets.
+                            type: string
                         type: object
                       iscsi:
                         description: |-
@@ -17205,7 +17500,6 @@ spec:
                               Tip: Ensure that the filesystem type is supported by the host operating system.
                               Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                               More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                              TODO: how do we prevent errors in the filesystem from compromising the machine
                             type: string
                           initiatorName:
                             description: |-
@@ -17217,6 +17511,7 @@ spec:
                             description: iqn is the target iSCSI Qualified Name.
                             type: string
                           iscsiInterface:
+                            default: default
                             description: |-
                               iscsiInterface is the interface Name that uses an iSCSI transport.
                               Defaults to 'default' (tcp).
@@ -17248,9 +17543,7 @@ spec:
                                   This field is effectively required, but due to backwards compatibility is
                                   allowed to be empty. Instances of this type with an empty value here are
                                   almost certainly wrong.
-                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
@@ -17312,7 +17605,9 @@ spec:
                           - claimName
                         type: object
                       photonPersistentDisk:
-                        description: photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine
+                        description: |-
+                          photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine.
+                          Deprecated: PhotonPersistentDisk is deprecated and the in-tree photonPersistentDisk type is no longer supported.
                         properties:
                           fsType:
                             description: |-
@@ -17327,7 +17622,11 @@ spec:
                           - pdID
                         type: object
                       portworxVolume:
-                        description: portworxVolume represents a portworx volume attached and mounted on kubelets host machine
+                        description: |-
+                          portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
+                          Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
+                          are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
+                          is on.
                         properties:
                           fsType:
                             description: |-
@@ -17360,22 +17659,23 @@ spec:
                             format: int32
                             type: integer
                           sources:
-                            description: sources is the list of volume projections
+                            description: |-
+                              sources is the list of volume projections. Each entry in this list
+                              handles one source.
                             items:
-                              description: Projection that may be projected along with other supported volume types
+                              description: |-
+                                Projection that may be projected along with other supported volume types.
+                                Exactly one of these fields must be set.
                               properties:
                                 clusterTrustBundle:
                                   description: |-
                                     ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field
                                     of ClusterTrustBundle objects in an auto-updating file.
 
-
                                     Alpha, gated by the ClusterTrustBundleProjection feature gate.
-
 
                                     ClusterTrustBundle objects can either be selected by name, or by the
                                     combination of signer name and a label selector.
-
 
                                     Kubelet performs aggressive normalization of the PEM contents written
                                     into the pod filesystem.  Esoteric PEM features such as inter-block
@@ -17504,9 +17804,7 @@ spec:
                                         This field is effectively required, but due to backwards compatibility is
                                         allowed to be empty. Instances of this type with an empty value here are
                                         almost certainly wrong.
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                         More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                       type: string
                                     optional:
                                       description: optional specify whether the ConfigMap or its keys must be defined
@@ -17623,9 +17921,7 @@ spec:
                                         This field is effectively required, but due to backwards compatibility is
                                         allowed to be empty. Instances of this type with an empty value here are
                                         almost certainly wrong.
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                         More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                       type: string
                                     optional:
                                       description: optional field specify whether the Secret or its key must be defined
@@ -17665,7 +17961,9 @@ spec:
                             x-kubernetes-list-type: atomic
                         type: object
                       quobyte:
-                        description: quobyte represents a Quobyte mount on the host that shares a pod's lifetime
+                        description: |-
+                          quobyte represents a Quobyte mount on the host that shares a pod's lifetime.
+                          Deprecated: Quobyte is deprecated and the in-tree quobyte type is no longer supported.
                         properties:
                           group:
                             description: |-
@@ -17703,6 +18001,7 @@ spec:
                       rbd:
                         description: |-
                           rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
+                          Deprecated: RBD is deprecated and the in-tree rbd type is no longer supported.
                           More info: https://examples.k8s.io/volumes/rbd/README.md
                         properties:
                           fsType:
@@ -17711,7 +18010,6 @@ spec:
                               Tip: Ensure that the filesystem type is supported by the host operating system.
                               Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                               More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                              TODO: how do we prevent errors in the filesystem from compromising the machine
                             type: string
                           image:
                             description: |-
@@ -17719,6 +18017,7 @@ spec:
                               More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                             type: string
                           keyring:
+                            default: /etc/ceph/keyring
                             description: |-
                               keyring is the path to key ring for RBDUser.
                               Default is /etc/ceph/keyring.
@@ -17733,6 +18032,7 @@ spec:
                             type: array
                             x-kubernetes-list-type: atomic
                           pool:
+                            default: rbd
                             description: |-
                               pool is the rados pool name.
                               Default is rbd.
@@ -17758,13 +18058,12 @@ spec:
                                   This field is effectively required, but due to backwards compatibility is
                                   allowed to be empty. Instances of this type with an empty value here are
                                   almost certainly wrong.
-                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
                           user:
+                            default: admin
                             description: |-
                               user is the rados user name.
                               Default is admin.
@@ -17775,9 +18074,12 @@ spec:
                           - monitors
                         type: object
                       scaleIO:
-                        description: scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
+                        description: |-
+                          scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
+                          Deprecated: ScaleIO is deprecated and the in-tree scaleIO type is no longer supported.
                         properties:
                           fsType:
+                            default: xfs
                             description: |-
                               fsType is the filesystem type to mount.
                               Must be a filesystem type supported by the host operating system.
@@ -17807,9 +18109,7 @@ spec:
                                   This field is effectively required, but due to backwards compatibility is
                                   allowed to be empty. Instances of this type with an empty value here are
                                   almost certainly wrong.
-                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
@@ -17817,6 +18117,7 @@ spec:
                             description: sslEnabled Flag enable/disable SSL communication with Gateway, default false
                             type: boolean
                           storageMode:
+                            default: ThinProvisioned
                             description: |-
                               storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
                               Default is ThinProvisioned.
@@ -17901,7 +18202,9 @@ spec:
                             type: string
                         type: object
                       storageos:
-                        description: storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
+                        description: |-
+                          storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
+                          Deprecated: StorageOS is deprecated and the in-tree storageos type is no longer supported.
                         properties:
                           fsType:
                             description: |-
@@ -17926,9 +18229,7 @@ spec:
                                   This field is effectively required, but due to backwards compatibility is
                                   allowed to be empty. Instances of this type with an empty value here are
                                   almost certainly wrong.
-                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
@@ -17948,7 +18249,10 @@ spec:
                             type: string
                         type: object
                       vsphereVolume:
-                        description: vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine
+                        description: |-
+                          vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine.
+                          Deprecated: VsphereVolume is deprecated. All operations for the in-tree vsphereVolume type
+                          are redirected to the csi.vsphere.vmware.com CSI driver.
                         properties:
                           fsType:
                             description: |-
@@ -17969,6 +18273,7 @@ spec:
                           - volumePath
                         type: object
                     required:
+                      - ""
                       - name
                     type: object
                   type: array
@@ -17979,7 +18284,6 @@ spec:
             status:
               description: |-
                 BuildStatus defines the observed state of Build
-
 
                 NOTICE: This is deprecated and will be removed in a future release.
               properties:
@@ -18006,7 +18310,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: buildstrategies.shipwright.io
 spec:
   conversion:
@@ -18056,6 +18360,7 @@ spec:
               description: BuildStrategySpec defines the desired state of BuildStrategy
               properties:
                 buildSteps:
+                  description: BuildSteps defines the steps of the strategy
                   items:
                     description: |-
                       BuildStep defines a partial step that needs to run in container for building the image.
@@ -18130,9 +18435,7 @@ spec:
                                         This field is effectively required, but due to backwards compatibility is
                                         allowed to be empty. Instances of this type with an empty value here are
                                         almost certainly wrong.
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                         More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                       type: string
                                     optional:
                                       description: Specify whether the ConfigMap or its key must be defined
@@ -18191,9 +18494,7 @@ spec:
                                         This field is effectively required, but due to backwards compatibility is
                                         allowed to be empty. Instances of this type with an empty value here are
                                         almost certainly wrong.
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                         More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                       type: string
                                     optional:
                                       description: Specify whether the Secret or its key must be defined
@@ -18231,9 +18532,7 @@ spec:
                                     This field is effectively required, but due to backwards compatibility is
                                     allowed to be empty. Instances of this type with an empty value here are
                                     almost certainly wrong.
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                   type: string
                                 optional:
                                   description: Specify whether the ConfigMap must be defined
@@ -18253,9 +18552,7 @@ spec:
                                     This field is effectively required, but due to backwards compatibility is
                                     allowed to be empty. Instances of this type with an empty value here are
                                     almost certainly wrong.
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                   type: string
                                 optional:
                                   description: Specify whether the Secret must be defined
@@ -18293,7 +18590,7 @@ spec:
                               More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                             properties:
                               exec:
-                                description: Exec specifies the action to take.
+                                description: Exec specifies a command to execute in the container.
                                 properties:
                                   command:
                                     description: |-
@@ -18308,7 +18605,7 @@ spec:
                                     x-kubernetes-list-type: atomic
                                 type: object
                               httpGet:
-                                description: HTTPGet specifies the http request to perform.
+                                description: HTTPGet specifies an HTTP GET request to perform.
                                 properties:
                                   host:
                                     description: |-
@@ -18355,7 +18652,7 @@ spec:
                                   - port
                                 type: object
                               sleep:
-                                description: Sleep represents the duration that the container should sleep before being terminated.
+                                description: Sleep represents a duration that the container should sleep.
                                 properties:
                                   seconds:
                                     description: Seconds is the number of seconds to sleep.
@@ -18367,8 +18664,8 @@ spec:
                               tcpSocket:
                                 description: |-
                                   Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
-                                  for the backward compatibility. There are no validation of this field and
-                                  lifecycle hooks will fail in runtime when tcp handler is specified.
+                                  for backward compatibility. There is no validation of this field and
+                                  lifecycle hooks will fail at runtime when it is specified.
                                 properties:
                                   host:
                                     description: 'Optional: Host name to connect to, defaults to the pod IP.'
@@ -18399,7 +18696,7 @@ spec:
                               More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                             properties:
                               exec:
-                                description: Exec specifies the action to take.
+                                description: Exec specifies a command to execute in the container.
                                 properties:
                                   command:
                                     description: |-
@@ -18414,7 +18711,7 @@ spec:
                                     x-kubernetes-list-type: atomic
                                 type: object
                               httpGet:
-                                description: HTTPGet specifies the http request to perform.
+                                description: HTTPGet specifies an HTTP GET request to perform.
                                 properties:
                                   host:
                                     description: |-
@@ -18461,7 +18758,7 @@ spec:
                                   - port
                                 type: object
                               sleep:
-                                description: Sleep represents the duration that the container should sleep before being terminated.
+                                description: Sleep represents a duration that the container should sleep.
                                 properties:
                                   seconds:
                                     description: Seconds is the number of seconds to sleep.
@@ -18473,8 +18770,8 @@ spec:
                               tcpSocket:
                                 description: |-
                                   Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
-                                  for the backward compatibility. There are no validation of this field and
-                                  lifecycle hooks will fail in runtime when tcp handler is specified.
+                                  for backward compatibility. There is no validation of this field and
+                                  lifecycle hooks will fail at runtime when it is specified.
                                 properties:
                                   host:
                                     description: 'Optional: Host name to connect to, defaults to the pod IP.'
@@ -18501,7 +18798,7 @@ spec:
                           More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                         properties:
                           exec:
-                            description: Exec specifies the action to take.
+                            description: Exec specifies a command to execute in the container.
                             properties:
                               command:
                                 description: |-
@@ -18522,17 +18819,17 @@ spec:
                             format: int32
                             type: integer
                           grpc:
-                            description: GRPC specifies an action involving a GRPC port.
+                            description: GRPC specifies a GRPC HealthCheckRequest.
                             properties:
                               port:
                                 description: Port number of the gRPC service. Number must be in the range 1 to 65535.
                                 format: int32
                                 type: integer
                               service:
+                                default: ""
                                 description: |-
                                   Service is the name of the service to place in the gRPC HealthCheckRequest
                                   (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-
 
                                   If this is not specified, the default behavior is defined by gRPC.
                                 type: string
@@ -18540,7 +18837,7 @@ spec:
                               - port
                             type: object
                           httpGet:
-                            description: HTTPGet specifies the http request to perform.
+                            description: HTTPGet specifies an HTTP GET request to perform.
                             properties:
                               host:
                                 description: |-
@@ -18605,7 +18902,7 @@ spec:
                             format: int32
                             type: integer
                           tcpSocket:
-                            description: TCPSocket specifies an action involving a TCP port.
+                            description: TCPSocket specifies a connection to a TCP port.
                             properties:
                               host:
                                 description: 'Optional: Host name to connect to, defaults to the pod IP.'
@@ -18707,7 +19004,7 @@ spec:
                           More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                         properties:
                           exec:
-                            description: Exec specifies the action to take.
+                            description: Exec specifies a command to execute in the container.
                             properties:
                               command:
                                 description: |-
@@ -18728,17 +19025,17 @@ spec:
                             format: int32
                             type: integer
                           grpc:
-                            description: GRPC specifies an action involving a GRPC port.
+                            description: GRPC specifies a GRPC HealthCheckRequest.
                             properties:
                               port:
                                 description: Port number of the gRPC service. Number must be in the range 1 to 65535.
                                 format: int32
                                 type: integer
                               service:
+                                default: ""
                                 description: |-
                                   Service is the name of the service to place in the gRPC HealthCheckRequest
                                   (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-
 
                                   If this is not specified, the default behavior is defined by gRPC.
                                 type: string
@@ -18746,7 +19043,7 @@ spec:
                               - port
                             type: object
                           httpGet:
-                            description: HTTPGet specifies the http request to perform.
+                            description: HTTPGet specifies an HTTP GET request to perform.
                             properties:
                               host:
                                 description: |-
@@ -18811,7 +19108,7 @@ spec:
                             format: int32
                             type: integer
                           tcpSocket:
-                            description: TCPSocket specifies an action involving a TCP port.
+                            description: TCPSocket specifies a connection to a TCP port.
                             properties:
                               host:
                                 description: 'Optional: Host name to connect to, defaults to the pod IP.'
@@ -18882,10 +19179,8 @@ spec:
                               Claims lists the names of resources, defined in spec.resourceClaims,
                               that are used by this container.
 
-
                               This is an alpha field and requires enabling the
                               DynamicResourceAllocation feature gate.
-
 
                               This field is immutable. It can only be set for containers.
                             items:
@@ -18896,6 +19191,12 @@ spec:
                                     Name must match the name of one entry in pod.spec.resourceClaims of
                                     the Pod where this field is used. It makes that resource available
                                     inside a container.
+                                  type: string
+                                request:
+                                  description: |-
+                                    Request is the name chosen for a request in the referenced claim.
+                                    If empty, everything from the claim is made available, otherwise
+                                    only the result of this request.
                                   type: string
                               required:
                                 - name
@@ -19018,7 +19319,7 @@ spec:
                           procMount:
                             description: |-
                               procMount denotes the type of proc mount to use for the containers.
-                              The default is DefaultProcMount which uses the container runtime defaults for
+                              The default value is Default which uses the container runtime defaults for
                               readonly paths and masked paths.
                               This requires the ProcMountType feature flag to be enabled.
                               Note that this field cannot be set when spec.os.name is windows.
@@ -19096,7 +19397,6 @@ spec:
                                   type indicates which kind of seccomp profile will be applied.
                                   Valid options are:
 
-
                                   Localhost - a profile defined in a file on the node should be used.
                                   RuntimeDefault - the container runtime default profile should be used.
                                   Unconfined - no profile should be applied.
@@ -19147,7 +19447,7 @@ spec:
                           More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                         properties:
                           exec:
-                            description: Exec specifies the action to take.
+                            description: Exec specifies a command to execute in the container.
                             properties:
                               command:
                                 description: |-
@@ -19168,17 +19468,17 @@ spec:
                             format: int32
                             type: integer
                           grpc:
-                            description: GRPC specifies an action involving a GRPC port.
+                            description: GRPC specifies a GRPC HealthCheckRequest.
                             properties:
                               port:
                                 description: Port number of the gRPC service. Number must be in the range 1 to 65535.
                                 format: int32
                                 type: integer
                               service:
+                                default: ""
                                 description: |-
                                   Service is the name of the service to place in the gRPC HealthCheckRequest
                                   (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-
 
                                   If this is not specified, the default behavior is defined by gRPC.
                                 type: string
@@ -19186,7 +19486,7 @@ spec:
                               - port
                             type: object
                           httpGet:
-                            description: HTTPGet specifies the http request to perform.
+                            description: HTTPGet specifies an HTTP GET request to perform.
                             properties:
                               host:
                                 description: |-
@@ -19251,7 +19551,7 @@ spec:
                             format: int32
                             type: integer
                           tcpSocket:
-                            description: TCPSocket specifies an action involving a TCP port.
+                            description: TCPSocket specifies a connection to a TCP port.
                             properties:
                               host:
                                 description: 'Optional: Host name to connect to, defaults to the pod IP.'
@@ -19384,9 +19684,7 @@ spec:
                                 RecursiveReadOnly specifies whether read-only mounts should be handled
                                 recursively.
 
-
                                 If ReadOnly is false, this field has no meaning and must be unspecified.
-
 
                                 If ReadOnly is true, and this field is set to Disabled, the mount is not made
                                 recursively read-only.  If this field is set to IfPossible, the mount is made
@@ -19395,10 +19693,8 @@ spec:
                                 supported by the container runtime, otherwise the pod will not be started and
                                 an error will be generated to indicate the reason.
 
-
                                 If this field is set to IfPossible or Enabled, MountPropagation must be set to
                                 None (or be unspecified, which defaults to None).
-
 
                                 If this field is not specified, it is treated as an equivalent of Disabled.
                               type: string
@@ -19434,6 +19730,7 @@ spec:
                     type: object
                   type: array
                 parameters:
+                  description: Parameters defines the parameters of the strategy
                   items:
                     description: |-
                       Parameter holds a name-description with a default value
@@ -19466,11 +19763,7 @@ spec:
                     type: object
                   type: array
                 securityContext:
-                  description: |-
-                    BuildStrategySecurityContext defines a UID and GID for the build that is to be used for the build strategy steps as
-                    well as for shipwright-managed steps such as the source retrieval, or the image processing.
-                    The value can be overwritten on the steps for the strategy steps.
-                    If omitted, then UID and GID from the Shipwright configuration will be used for the shipwright-managed steps.
+                  description: SecurityContext defines the default security context of all strategy steps
                   properties:
                     runAsGroup:
                       description: |-
@@ -19491,6 +19784,7 @@ spec:
                     - runAsUser
                   type: object
                 volumes:
+                  description: Volumes defines the volumes of the strategy
                   items:
                     description: |-
                       BuildStrategyVolume is a volume that will be mounted in build pod during build step
@@ -19500,6 +19794,8 @@ spec:
                         description: |-
                           awsElasticBlockStore represents an AWS Disk resource that is attached to a
                           kubelet's host machine and then exposed to the pod.
+                          Deprecated: AWSElasticBlockStore is deprecated. All operations for the in-tree
+                          awsElasticBlockStore type are redirected to the ebs.csi.aws.com CSI driver.
                           More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                         properties:
                           fsType:
@@ -19508,7 +19804,6 @@ spec:
                               Tip: Ensure that the filesystem type is supported by the host operating system.
                               Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                               More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                              TODO: how do we prevent errors in the filesystem from compromising the machine
                             type: string
                           partition:
                             description: |-
@@ -19532,7 +19827,10 @@ spec:
                           - volumeID
                         type: object
                       azureDisk:
-                        description: azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
+                        description: |-
+                          azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
+                          Deprecated: AzureDisk is deprecated. All operations for the in-tree azureDisk type
+                          are redirected to the disk.csi.azure.com CSI driver.
                         properties:
                           cachingMode:
                             description: 'cachingMode is the Host Caching mode: None, Read Only, Read Write.'
@@ -19544,6 +19842,7 @@ spec:
                             description: diskURI is the URI of data disk in the blob storage
                             type: string
                           fsType:
+                            default: ext4
                             description: |-
                               fsType is Filesystem type to mount.
                               Must be a filesystem type supported by the host operating system.
@@ -19553,6 +19852,7 @@ spec:
                             description: 'kind expected values are Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared'
                             type: string
                           readOnly:
+                            default: false
                             description: |-
                               readOnly Defaults to false (read/write). ReadOnly here will force
                               the ReadOnly setting in VolumeMounts.
@@ -19562,7 +19862,10 @@ spec:
                           - diskURI
                         type: object
                       azureFile:
-                        description: azureFile represents an Azure File Service mount on the host and bind mount to the pod.
+                        description: |-
+                          azureFile represents an Azure File Service mount on the host and bind mount to the pod.
+                          Deprecated: AzureFile is deprecated. All operations for the in-tree azureFile type
+                          are redirected to the file.csi.azure.com CSI driver.
                         properties:
                           readOnly:
                             description: |-
@@ -19580,7 +19883,9 @@ spec:
                           - shareName
                         type: object
                       cephfs:
-                        description: cephFS represents a Ceph FS mount on the host that shares a pod's lifetime
+                        description: |-
+                          cephFS represents a Ceph FS mount on the host that shares a pod's lifetime.
+                          Deprecated: CephFS is deprecated and the in-tree cephfs type is no longer supported.
                         properties:
                           monitors:
                             description: |-
@@ -19616,9 +19921,7 @@ spec:
                                   This field is effectively required, but due to backwards compatibility is
                                   allowed to be empty. Instances of this type with an empty value here are
                                   almost certainly wrong.
-                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
@@ -19633,6 +19936,8 @@ spec:
                       cinder:
                         description: |-
                           cinder represents a cinder volume attached and mounted on kubelets host machine.
+                          Deprecated: Cinder is deprecated. All operations for the in-tree cinder type
+                          are redirected to the cinder.csi.openstack.org CSI driver.
                           More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                         properties:
                           fsType:
@@ -19660,9 +19965,7 @@ spec:
                                   This field is effectively required, but due to backwards compatibility is
                                   allowed to be empty. Instances of this type with an empty value here are
                                   almost certainly wrong.
-                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
@@ -19733,9 +20036,7 @@ spec:
                               This field is effectively required, but due to backwards compatibility is
                               allowed to be empty. Instances of this type with an empty value here are
                               almost certainly wrong.
-                              TODO: Add other useful fields. apiVersion, kind, uid?
                               More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                             type: string
                           optional:
                             description: optional specify whether the ConfigMap or its keys must be defined
@@ -19743,7 +20044,7 @@ spec:
                         type: object
                         x-kubernetes-map-type: atomic
                       csi:
-                        description: csi (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers (Beta feature).
+                        description: csi (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers.
                         properties:
                           driver:
                             description: |-
@@ -19771,9 +20072,7 @@ spec:
                                   This field is effectively required, but due to backwards compatibility is
                                   allowed to be empty. Instances of this type with an empty value here are
                                   almost certainly wrong.
-                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
@@ -19901,7 +20200,6 @@ spec:
                           The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,
                           and deleted when the pod is removed.
 
-
                           Use this if:
                           a) the volume is only needed while the pod runs,
                           b) features of normal volumes like restoring from snapshot or capacity
@@ -19912,16 +20210,13 @@ spec:
                              information on the connection between this volume type
                              and PersistentVolumeClaim).
 
-
                           Use PersistentVolumeClaim or one of the vendor-specific
                           APIs for volumes that persist for longer than the lifecycle
                           of an individual pod.
 
-
                           Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to
                           be used that way - see the documentation of the driver for
                           more information.
-
 
                           A pod can use both types of ephemeral volumes and
                           persistent volumes at the same time.
@@ -19936,7 +20231,6 @@ spec:
                               entry. Pod validation will reject the pod if the concatenated name
                               is not valid for a PVC (for example, too long).
 
-
                               An existing PVC with that name that is not owned by the pod
                               will *not* be used for the pod to avoid using an unrelated
                               volume by mistake. Starting the pod is then blocked until
@@ -19946,10 +20240,8 @@ spec:
                               this should not be necessary, but it may be useful when
                               manually reconstructing a broken cluster.
 
-
                               This field is read-only and no changes will be made by Kubernetes
                               to the PVC after it has been created.
-
 
                               Required, must not be nil.
                             properties:
@@ -20145,7 +20437,7 @@ spec:
                                       set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
                                       exists.
                                       More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
-                                      (Alpha) Using this field requires the VolumeAttributesClass feature gate to be enabled.
+                                      (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).
                                     type: string
                                   volumeMode:
                                     description: |-
@@ -20168,7 +20460,6 @@ spec:
                               fsType is the filesystem type to mount.
                               Must be a filesystem type supported by the host operating system.
                               Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                              TODO: how do we prevent errors in the filesystem from compromising the machine
                             type: string
                           lun:
                             description: 'lun is Optional: FC target lun number'
@@ -20198,6 +20489,7 @@ spec:
                         description: |-
                           flexVolume represents a generic volume resource that is
                           provisioned/attached using an exec based plugin.
+                          Deprecated: FlexVolume is deprecated. Consider using a CSIDriver instead.
                         properties:
                           driver:
                             description: driver is the name of the driver to use for this volume.
@@ -20233,9 +20525,7 @@ spec:
                                   This field is effectively required, but due to backwards compatibility is
                                   allowed to be empty. Instances of this type with an empty value here are
                                   almost certainly wrong.
-                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
@@ -20243,7 +20533,9 @@ spec:
                           - driver
                         type: object
                       flocker:
-                        description: flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running
+                        description: |-
+                          flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running.
+                          Deprecated: Flocker is deprecated and the in-tree flocker type is no longer supported.
                         properties:
                           datasetName:
                             description: |-
@@ -20258,6 +20550,8 @@ spec:
                         description: |-
                           gcePersistentDisk represents a GCE Disk resource that is attached to a
                           kubelet's host machine and then exposed to the pod.
+                          Deprecated: GCEPersistentDisk is deprecated. All operations for the in-tree
+                          gcePersistentDisk type are redirected to the pd.csi.storage.gke.io CSI driver.
                           More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                         properties:
                           fsType:
@@ -20266,7 +20560,6 @@ spec:
                               Tip: Ensure that the filesystem type is supported by the host operating system.
                               Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                               More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                              TODO: how do we prevent errors in the filesystem from compromising the machine
                             type: string
                           partition:
                             description: |-
@@ -20294,7 +20587,7 @@ spec:
                       gitRepo:
                         description: |-
                           gitRepo represents a git repository at a particular revision.
-                          DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an
+                          Deprecated: GitRepo is deprecated. To provision a container with a git repo, mount an
                           EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
                           into the Pod's container.
                         properties:
@@ -20317,6 +20610,7 @@ spec:
                       glusterfs:
                         description: |-
                           glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
+                          Deprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported.
                           More info: https://examples.k8s.io/volumes/glusterfs/README.md
                         properties:
                           endpoints:
@@ -20346,9 +20640,6 @@ spec:
                           used for system agents or other privileged things that are allowed
                           to see the host machine. Most containers will NOT need this.
                           More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-                          ---
-                          TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not
-                          mount host directories as read/write.
                         properties:
                           path:
                             description: |-
@@ -20364,6 +20655,41 @@ spec:
                             type: string
                         required:
                           - path
+                        type: object
+                      image:
+                        description: |-
+                          image represents an OCI object (a container image or artifact) pulled and mounted on the kubelet's host machine.
+                          The volume is resolved at pod startup depending on which PullPolicy value is provided:
+
+                          - Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                          - Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                          - IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+
+                          The volume gets re-resolved if the pod gets deleted and recreated, which means that new remote content will become available on pod recreation.
+                          A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
+                          The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
+                          The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
+                          The volume will be mounted read-only (ro) and non-executable files (noexec).
+                          Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath).
+                          The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
+                        properties:
+                          pullPolicy:
+                            description: |-
+                              Policy for pulling OCI objects. Possible values are:
+                              Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                              Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                              IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+                              Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                            type: string
+                          reference:
+                            description: |-
+                              Required: Image or artifact reference to be used.
+                              Behaves in the same way as pod.spec.containers[*].image.
+                              Pull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets.
+                              More info: https://kubernetes.io/docs/concepts/containers/images
+                              This field is optional to allow higher level config management to default or override
+                              container images in workload controllers like Deployments and StatefulSets.
+                            type: string
                         type: object
                       iscsi:
                         description: |-
@@ -20383,7 +20709,6 @@ spec:
                               Tip: Ensure that the filesystem type is supported by the host operating system.
                               Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                               More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                              TODO: how do we prevent errors in the filesystem from compromising the machine
                             type: string
                           initiatorName:
                             description: |-
@@ -20395,6 +20720,7 @@ spec:
                             description: iqn is the target iSCSI Qualified Name.
                             type: string
                           iscsiInterface:
+                            default: default
                             description: |-
                               iscsiInterface is the interface Name that uses an iSCSI transport.
                               Defaults to 'default' (tcp).
@@ -20426,9 +20752,7 @@ spec:
                                   This field is effectively required, but due to backwards compatibility is
                                   allowed to be empty. Instances of this type with an empty value here are
                                   almost certainly wrong.
-                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
@@ -20495,7 +20819,9 @@ spec:
                           - claimName
                         type: object
                       photonPersistentDisk:
-                        description: photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine
+                        description: |-
+                          photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine.
+                          Deprecated: PhotonPersistentDisk is deprecated and the in-tree photonPersistentDisk type is no longer supported.
                         properties:
                           fsType:
                             description: |-
@@ -20510,7 +20836,11 @@ spec:
                           - pdID
                         type: object
                       portworxVolume:
-                        description: portworxVolume represents a portworx volume attached and mounted on kubelets host machine
+                        description: |-
+                          portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
+                          Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
+                          are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
+                          is on.
                         properties:
                           fsType:
                             description: |-
@@ -20543,22 +20873,23 @@ spec:
                             format: int32
                             type: integer
                           sources:
-                            description: sources is the list of volume projections
+                            description: |-
+                              sources is the list of volume projections. Each entry in this list
+                              handles one source.
                             items:
-                              description: Projection that may be projected along with other supported volume types
+                              description: |-
+                                Projection that may be projected along with other supported volume types.
+                                Exactly one of these fields must be set.
                               properties:
                                 clusterTrustBundle:
                                   description: |-
                                     ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field
                                     of ClusterTrustBundle objects in an auto-updating file.
 
-
                                     Alpha, gated by the ClusterTrustBundleProjection feature gate.
-
 
                                     ClusterTrustBundle objects can either be selected by name, or by the
                                     combination of signer name and a label selector.
-
 
                                     Kubelet performs aggressive normalization of the PEM contents written
                                     into the pod filesystem.  Esoteric PEM features such as inter-block
@@ -20687,9 +21018,7 @@ spec:
                                         This field is effectively required, but due to backwards compatibility is
                                         allowed to be empty. Instances of this type with an empty value here are
                                         almost certainly wrong.
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                         More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                       type: string
                                     optional:
                                       description: optional specify whether the ConfigMap or its keys must be defined
@@ -20806,9 +21135,7 @@ spec:
                                         This field is effectively required, but due to backwards compatibility is
                                         allowed to be empty. Instances of this type with an empty value here are
                                         almost certainly wrong.
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                         More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                       type: string
                                     optional:
                                       description: optional field specify whether the Secret or its key must be defined
@@ -20848,7 +21175,9 @@ spec:
                             x-kubernetes-list-type: atomic
                         type: object
                       quobyte:
-                        description: quobyte represents a Quobyte mount on the host that shares a pod's lifetime
+                        description: |-
+                          quobyte represents a Quobyte mount on the host that shares a pod's lifetime.
+                          Deprecated: Quobyte is deprecated and the in-tree quobyte type is no longer supported.
                         properties:
                           group:
                             description: |-
@@ -20886,6 +21215,7 @@ spec:
                       rbd:
                         description: |-
                           rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
+                          Deprecated: RBD is deprecated and the in-tree rbd type is no longer supported.
                           More info: https://examples.k8s.io/volumes/rbd/README.md
                         properties:
                           fsType:
@@ -20894,7 +21224,6 @@ spec:
                               Tip: Ensure that the filesystem type is supported by the host operating system.
                               Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                               More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                              TODO: how do we prevent errors in the filesystem from compromising the machine
                             type: string
                           image:
                             description: |-
@@ -20902,6 +21231,7 @@ spec:
                               More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                             type: string
                           keyring:
+                            default: /etc/ceph/keyring
                             description: |-
                               keyring is the path to key ring for RBDUser.
                               Default is /etc/ceph/keyring.
@@ -20916,6 +21246,7 @@ spec:
                             type: array
                             x-kubernetes-list-type: atomic
                           pool:
+                            default: rbd
                             description: |-
                               pool is the rados pool name.
                               Default is rbd.
@@ -20941,13 +21272,12 @@ spec:
                                   This field is effectively required, but due to backwards compatibility is
                                   allowed to be empty. Instances of this type with an empty value here are
                                   almost certainly wrong.
-                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
                           user:
+                            default: admin
                             description: |-
                               user is the rados user name.
                               Default is admin.
@@ -20958,9 +21288,12 @@ spec:
                           - monitors
                         type: object
                       scaleIO:
-                        description: scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
+                        description: |-
+                          scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
+                          Deprecated: ScaleIO is deprecated and the in-tree scaleIO type is no longer supported.
                         properties:
                           fsType:
+                            default: xfs
                             description: |-
                               fsType is the filesystem type to mount.
                               Must be a filesystem type supported by the host operating system.
@@ -20990,9 +21323,7 @@ spec:
                                   This field is effectively required, but due to backwards compatibility is
                                   allowed to be empty. Instances of this type with an empty value here are
                                   almost certainly wrong.
-                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
@@ -21000,6 +21331,7 @@ spec:
                             description: sslEnabled Flag enable/disable SSL communication with Gateway, default false
                             type: boolean
                           storageMode:
+                            default: ThinProvisioned
                             description: |-
                               storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
                               Default is ThinProvisioned.
@@ -21084,7 +21416,9 @@ spec:
                             type: string
                         type: object
                       storageos:
-                        description: storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
+                        description: |-
+                          storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
+                          Deprecated: StorageOS is deprecated and the in-tree storageos type is no longer supported.
                         properties:
                           fsType:
                             description: |-
@@ -21109,9 +21443,7 @@ spec:
                                   This field is effectively required, but due to backwards compatibility is
                                   allowed to be empty. Instances of this type with an empty value here are
                                   almost certainly wrong.
-                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
@@ -21131,7 +21463,10 @@ spec:
                             type: string
                         type: object
                       vsphereVolume:
-                        description: vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine
+                        description: |-
+                          vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine.
+                          Deprecated: VsphereVolume is deprecated. All operations for the in-tree vsphereVolume type
+                          are redirected to the csi.vsphere.vmware.com CSI driver.
                         properties:
                           fsType:
                             description: |-
@@ -21155,6 +21490,8 @@ spec:
                       - name
                     type: object
                   type: array
+              required:
+                - buildSteps
               type: object
             status:
               description: BuildStrategyStatus defines the observed state of BuildStrategy
@@ -21190,6 +21527,7 @@ spec:
               description: BuildStrategySpec defines the desired state of BuildStrategy
               properties:
                 parameters:
+                  description: Parameters defines the parameters of the strategy
                   items:
                     description: |-
                       Parameter holds a name-description with a default value
@@ -21222,11 +21560,7 @@ spec:
                     type: object
                   type: array
                 securityContext:
-                  description: |-
-                    BuildStrategySecurityContext defines a UID and GID for the build that is to be used for the build strategy steps as
-                    well as for shipwright-managed steps such as the source retrieval, or the image processing.
-                    The value can be overwritten on the steps for the strategy steps.
-                    If omitted, then UID and GID from the Shipwright configuration will be used for the shipwright-managed steps.
+                  description: SecurityContext defines the default security context of all strategy steps
                   properties:
                     runAsGroup:
                       description: |-
@@ -21247,6 +21581,7 @@ spec:
                     - runAsUser
                   type: object
                 steps:
+                  description: Steps defines the steps of the strategy
                   items:
                     description: |-
                       BuildStep defines a partial step that needs to run in container for building the image.
@@ -21319,9 +21654,7 @@ spec:
                                         This field is effectively required, but due to backwards compatibility is
                                         allowed to be empty. Instances of this type with an empty value here are
                                         almost certainly wrong.
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                         More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                       type: string
                                     optional:
                                       description: Specify whether the ConfigMap or its key must be defined
@@ -21380,9 +21713,7 @@ spec:
                                         This field is effectively required, but due to backwards compatibility is
                                         allowed to be empty. Instances of this type with an empty value here are
                                         almost certainly wrong.
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                         More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                       type: string
                                     optional:
                                       description: Specify whether the Secret or its key must be defined
@@ -21428,10 +21759,8 @@ spec:
                               Claims lists the names of resources, defined in spec.resourceClaims,
                               that are used by this container.
 
-
                               This is an alpha field and requires enabling the
                               DynamicResourceAllocation feature gate.
-
 
                               This field is immutable. It can only be set for containers.
                             items:
@@ -21442,6 +21771,12 @@ spec:
                                     Name must match the name of one entry in pod.spec.resourceClaims of
                                     the Pod where this field is used. It makes that resource available
                                     inside a container.
+                                  type: string
+                                request:
+                                  description: |-
+                                    Request is the name chosen for a request in the referenced claim.
+                                    If empty, everything from the claim is made available, otherwise
+                                    only the result of this request.
                                   type: string
                               required:
                                 - name
@@ -21546,7 +21881,7 @@ spec:
                           procMount:
                             description: |-
                               procMount denotes the type of proc mount to use for the containers.
-                              The default is DefaultProcMount which uses the container runtime defaults for
+                              The default value is Default which uses the container runtime defaults for
                               readonly paths and masked paths.
                               This requires the ProcMountType feature flag to be enabled.
                               Note that this field cannot be set when spec.os.name is windows.
@@ -21624,7 +21959,6 @@ spec:
                                   type indicates which kind of seccomp profile will be applied.
                                   Valid options are:
 
-
                                   Localhost - a profile defined in a file on the node should be used.
                                   RuntimeDefault - the container runtime default profile should be used.
                                   Unconfined - no profile should be applied.
@@ -21698,9 +22032,7 @@ spec:
                                 RecursiveReadOnly specifies whether read-only mounts should be handled
                                 recursively.
 
-
                                 If ReadOnly is false, this field has no meaning and must be unspecified.
-
 
                                 If ReadOnly is true, and this field is set to Disabled, the mount is not made
                                 recursively read-only.  If this field is set to IfPossible, the mount is made
@@ -21709,10 +22041,8 @@ spec:
                                 supported by the container runtime, otherwise the pod will not be started and
                                 an error will be generated to indicate the reason.
 
-
                                 If this field is set to IfPossible or Enabled, MountPropagation must be set to
                                 None (or be unspecified, which defaults to None).
-
 
                                 If this field is not specified, it is treated as an equivalent of Disabled.
                               type: string
@@ -21745,6 +22075,7 @@ spec:
                     type: object
                   type: array
                 volumes:
+                  description: Volumes defines the volumes of the strategy
                   items:
                     description: |-
                       BuildStrategyVolume is a volume that will be mounted in build pod during build step
@@ -21754,6 +22085,8 @@ spec:
                         description: |-
                           awsElasticBlockStore represents an AWS Disk resource that is attached to a
                           kubelet's host machine and then exposed to the pod.
+                          Deprecated: AWSElasticBlockStore is deprecated. All operations for the in-tree
+                          awsElasticBlockStore type are redirected to the ebs.csi.aws.com CSI driver.
                           More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                         properties:
                           fsType:
@@ -21762,7 +22095,6 @@ spec:
                               Tip: Ensure that the filesystem type is supported by the host operating system.
                               Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                               More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                              TODO: how do we prevent errors in the filesystem from compromising the machine
                             type: string
                           partition:
                             description: |-
@@ -21786,7 +22118,10 @@ spec:
                           - volumeID
                         type: object
                       azureDisk:
-                        description: azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
+                        description: |-
+                          azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
+                          Deprecated: AzureDisk is deprecated. All operations for the in-tree azureDisk type
+                          are redirected to the disk.csi.azure.com CSI driver.
                         properties:
                           cachingMode:
                             description: 'cachingMode is the Host Caching mode: None, Read Only, Read Write.'
@@ -21798,6 +22133,7 @@ spec:
                             description: diskURI is the URI of data disk in the blob storage
                             type: string
                           fsType:
+                            default: ext4
                             description: |-
                               fsType is Filesystem type to mount.
                               Must be a filesystem type supported by the host operating system.
@@ -21807,6 +22143,7 @@ spec:
                             description: 'kind expected values are Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared'
                             type: string
                           readOnly:
+                            default: false
                             description: |-
                               readOnly Defaults to false (read/write). ReadOnly here will force
                               the ReadOnly setting in VolumeMounts.
@@ -21816,7 +22153,10 @@ spec:
                           - diskURI
                         type: object
                       azureFile:
-                        description: azureFile represents an Azure File Service mount on the host and bind mount to the pod.
+                        description: |-
+                          azureFile represents an Azure File Service mount on the host and bind mount to the pod.
+                          Deprecated: AzureFile is deprecated. All operations for the in-tree azureFile type
+                          are redirected to the file.csi.azure.com CSI driver.
                         properties:
                           readOnly:
                             description: |-
@@ -21834,7 +22174,9 @@ spec:
                           - shareName
                         type: object
                       cephfs:
-                        description: cephFS represents a Ceph FS mount on the host that shares a pod's lifetime
+                        description: |-
+                          cephFS represents a Ceph FS mount on the host that shares a pod's lifetime.
+                          Deprecated: CephFS is deprecated and the in-tree cephfs type is no longer supported.
                         properties:
                           monitors:
                             description: |-
@@ -21870,9 +22212,7 @@ spec:
                                   This field is effectively required, but due to backwards compatibility is
                                   allowed to be empty. Instances of this type with an empty value here are
                                   almost certainly wrong.
-                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
@@ -21887,6 +22227,8 @@ spec:
                       cinder:
                         description: |-
                           cinder represents a cinder volume attached and mounted on kubelets host machine.
+                          Deprecated: Cinder is deprecated. All operations for the in-tree cinder type
+                          are redirected to the cinder.csi.openstack.org CSI driver.
                           More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                         properties:
                           fsType:
@@ -21914,9 +22256,7 @@ spec:
                                   This field is effectively required, but due to backwards compatibility is
                                   allowed to be empty. Instances of this type with an empty value here are
                                   almost certainly wrong.
-                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
@@ -21987,9 +22327,7 @@ spec:
                               This field is effectively required, but due to backwards compatibility is
                               allowed to be empty. Instances of this type with an empty value here are
                               almost certainly wrong.
-                              TODO: Add other useful fields. apiVersion, kind, uid?
                               More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                             type: string
                           optional:
                             description: optional specify whether the ConfigMap or its keys must be defined
@@ -21997,7 +22335,7 @@ spec:
                         type: object
                         x-kubernetes-map-type: atomic
                       csi:
-                        description: csi (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers (Beta feature).
+                        description: csi (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers.
                         properties:
                           driver:
                             description: |-
@@ -22025,9 +22363,7 @@ spec:
                                   This field is effectively required, but due to backwards compatibility is
                                   allowed to be empty. Instances of this type with an empty value here are
                                   almost certainly wrong.
-                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
@@ -22155,7 +22491,6 @@ spec:
                           The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,
                           and deleted when the pod is removed.
 
-
                           Use this if:
                           a) the volume is only needed while the pod runs,
                           b) features of normal volumes like restoring from snapshot or capacity
@@ -22166,16 +22501,13 @@ spec:
                              information on the connection between this volume type
                              and PersistentVolumeClaim).
 
-
                           Use PersistentVolumeClaim or one of the vendor-specific
                           APIs for volumes that persist for longer than the lifecycle
                           of an individual pod.
 
-
                           Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to
                           be used that way - see the documentation of the driver for
                           more information.
-
 
                           A pod can use both types of ephemeral volumes and
                           persistent volumes at the same time.
@@ -22190,7 +22522,6 @@ spec:
                               entry. Pod validation will reject the pod if the concatenated name
                               is not valid for a PVC (for example, too long).
 
-
                               An existing PVC with that name that is not owned by the pod
                               will *not* be used for the pod to avoid using an unrelated
                               volume by mistake. Starting the pod is then blocked until
@@ -22200,10 +22531,8 @@ spec:
                               this should not be necessary, but it may be useful when
                               manually reconstructing a broken cluster.
 
-
                               This field is read-only and no changes will be made by Kubernetes
                               to the PVC after it has been created.
-
 
                               Required, must not be nil.
                             properties:
@@ -22399,7 +22728,7 @@ spec:
                                       set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
                                       exists.
                                       More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
-                                      (Alpha) Using this field requires the VolumeAttributesClass feature gate to be enabled.
+                                      (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).
                                     type: string
                                   volumeMode:
                                     description: |-
@@ -22422,7 +22751,6 @@ spec:
                               fsType is the filesystem type to mount.
                               Must be a filesystem type supported by the host operating system.
                               Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                              TODO: how do we prevent errors in the filesystem from compromising the machine
                             type: string
                           lun:
                             description: 'lun is Optional: FC target lun number'
@@ -22452,6 +22780,7 @@ spec:
                         description: |-
                           flexVolume represents a generic volume resource that is
                           provisioned/attached using an exec based plugin.
+                          Deprecated: FlexVolume is deprecated. Consider using a CSIDriver instead.
                         properties:
                           driver:
                             description: driver is the name of the driver to use for this volume.
@@ -22487,9 +22816,7 @@ spec:
                                   This field is effectively required, but due to backwards compatibility is
                                   allowed to be empty. Instances of this type with an empty value here are
                                   almost certainly wrong.
-                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
@@ -22497,7 +22824,9 @@ spec:
                           - driver
                         type: object
                       flocker:
-                        description: flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running
+                        description: |-
+                          flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running.
+                          Deprecated: Flocker is deprecated and the in-tree flocker type is no longer supported.
                         properties:
                           datasetName:
                             description: |-
@@ -22512,6 +22841,8 @@ spec:
                         description: |-
                           gcePersistentDisk represents a GCE Disk resource that is attached to a
                           kubelet's host machine and then exposed to the pod.
+                          Deprecated: GCEPersistentDisk is deprecated. All operations for the in-tree
+                          gcePersistentDisk type are redirected to the pd.csi.storage.gke.io CSI driver.
                           More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                         properties:
                           fsType:
@@ -22520,7 +22851,6 @@ spec:
                               Tip: Ensure that the filesystem type is supported by the host operating system.
                               Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                               More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                              TODO: how do we prevent errors in the filesystem from compromising the machine
                             type: string
                           partition:
                             description: |-
@@ -22548,7 +22878,7 @@ spec:
                       gitRepo:
                         description: |-
                           gitRepo represents a git repository at a particular revision.
-                          DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an
+                          Deprecated: GitRepo is deprecated. To provision a container with a git repo, mount an
                           EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
                           into the Pod's container.
                         properties:
@@ -22571,6 +22901,7 @@ spec:
                       glusterfs:
                         description: |-
                           glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
+                          Deprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported.
                           More info: https://examples.k8s.io/volumes/glusterfs/README.md
                         properties:
                           endpoints:
@@ -22600,9 +22931,6 @@ spec:
                           used for system agents or other privileged things that are allowed
                           to see the host machine. Most containers will NOT need this.
                           More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-                          ---
-                          TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not
-                          mount host directories as read/write.
                         properties:
                           path:
                             description: |-
@@ -22618,6 +22946,41 @@ spec:
                             type: string
                         required:
                           - path
+                        type: object
+                      image:
+                        description: |-
+                          image represents an OCI object (a container image or artifact) pulled and mounted on the kubelet's host machine.
+                          The volume is resolved at pod startup depending on which PullPolicy value is provided:
+
+                          - Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                          - Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                          - IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+
+                          The volume gets re-resolved if the pod gets deleted and recreated, which means that new remote content will become available on pod recreation.
+                          A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
+                          The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
+                          The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
+                          The volume will be mounted read-only (ro) and non-executable files (noexec).
+                          Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath).
+                          The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
+                        properties:
+                          pullPolicy:
+                            description: |-
+                              Policy for pulling OCI objects. Possible values are:
+                              Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                              Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                              IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+                              Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                            type: string
+                          reference:
+                            description: |-
+                              Required: Image or artifact reference to be used.
+                              Behaves in the same way as pod.spec.containers[*].image.
+                              Pull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets.
+                              More info: https://kubernetes.io/docs/concepts/containers/images
+                              This field is optional to allow higher level config management to default or override
+                              container images in workload controllers like Deployments and StatefulSets.
+                            type: string
                         type: object
                       iscsi:
                         description: |-
@@ -22637,7 +23000,6 @@ spec:
                               Tip: Ensure that the filesystem type is supported by the host operating system.
                               Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                               More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                              TODO: how do we prevent errors in the filesystem from compromising the machine
                             type: string
                           initiatorName:
                             description: |-
@@ -22649,6 +23011,7 @@ spec:
                             description: iqn is the target iSCSI Qualified Name.
                             type: string
                           iscsiInterface:
+                            default: default
                             description: |-
                               iscsiInterface is the interface Name that uses an iSCSI transport.
                               Defaults to 'default' (tcp).
@@ -22680,9 +23043,7 @@ spec:
                                   This field is effectively required, but due to backwards compatibility is
                                   allowed to be empty. Instances of this type with an empty value here are
                                   almost certainly wrong.
-                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
@@ -22749,7 +23110,9 @@ spec:
                           - claimName
                         type: object
                       photonPersistentDisk:
-                        description: photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine
+                        description: |-
+                          photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine.
+                          Deprecated: PhotonPersistentDisk is deprecated and the in-tree photonPersistentDisk type is no longer supported.
                         properties:
                           fsType:
                             description: |-
@@ -22764,7 +23127,11 @@ spec:
                           - pdID
                         type: object
                       portworxVolume:
-                        description: portworxVolume represents a portworx volume attached and mounted on kubelets host machine
+                        description: |-
+                          portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
+                          Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
+                          are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
+                          is on.
                         properties:
                           fsType:
                             description: |-
@@ -22797,22 +23164,23 @@ spec:
                             format: int32
                             type: integer
                           sources:
-                            description: sources is the list of volume projections
+                            description: |-
+                              sources is the list of volume projections. Each entry in this list
+                              handles one source.
                             items:
-                              description: Projection that may be projected along with other supported volume types
+                              description: |-
+                                Projection that may be projected along with other supported volume types.
+                                Exactly one of these fields must be set.
                               properties:
                                 clusterTrustBundle:
                                   description: |-
                                     ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field
                                     of ClusterTrustBundle objects in an auto-updating file.
 
-
                                     Alpha, gated by the ClusterTrustBundleProjection feature gate.
-
 
                                     ClusterTrustBundle objects can either be selected by name, or by the
                                     combination of signer name and a label selector.
-
 
                                     Kubelet performs aggressive normalization of the PEM contents written
                                     into the pod filesystem.  Esoteric PEM features such as inter-block
@@ -22941,9 +23309,7 @@ spec:
                                         This field is effectively required, but due to backwards compatibility is
                                         allowed to be empty. Instances of this type with an empty value here are
                                         almost certainly wrong.
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                         More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                       type: string
                                     optional:
                                       description: optional specify whether the ConfigMap or its keys must be defined
@@ -23060,9 +23426,7 @@ spec:
                                         This field is effectively required, but due to backwards compatibility is
                                         allowed to be empty. Instances of this type with an empty value here are
                                         almost certainly wrong.
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                         More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                       type: string
                                     optional:
                                       description: optional field specify whether the Secret or its key must be defined
@@ -23102,7 +23466,9 @@ spec:
                             x-kubernetes-list-type: atomic
                         type: object
                       quobyte:
-                        description: quobyte represents a Quobyte mount on the host that shares a pod's lifetime
+                        description: |-
+                          quobyte represents a Quobyte mount on the host that shares a pod's lifetime.
+                          Deprecated: Quobyte is deprecated and the in-tree quobyte type is no longer supported.
                         properties:
                           group:
                             description: |-
@@ -23140,6 +23506,7 @@ spec:
                       rbd:
                         description: |-
                           rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
+                          Deprecated: RBD is deprecated and the in-tree rbd type is no longer supported.
                           More info: https://examples.k8s.io/volumes/rbd/README.md
                         properties:
                           fsType:
@@ -23148,7 +23515,6 @@ spec:
                               Tip: Ensure that the filesystem type is supported by the host operating system.
                               Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                               More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                              TODO: how do we prevent errors in the filesystem from compromising the machine
                             type: string
                           image:
                             description: |-
@@ -23156,6 +23522,7 @@ spec:
                               More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                             type: string
                           keyring:
+                            default: /etc/ceph/keyring
                             description: |-
                               keyring is the path to key ring for RBDUser.
                               Default is /etc/ceph/keyring.
@@ -23170,6 +23537,7 @@ spec:
                             type: array
                             x-kubernetes-list-type: atomic
                           pool:
+                            default: rbd
                             description: |-
                               pool is the rados pool name.
                               Default is rbd.
@@ -23195,13 +23563,12 @@ spec:
                                   This field is effectively required, but due to backwards compatibility is
                                   allowed to be empty. Instances of this type with an empty value here are
                                   almost certainly wrong.
-                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
                           user:
+                            default: admin
                             description: |-
                               user is the rados user name.
                               Default is admin.
@@ -23212,9 +23579,12 @@ spec:
                           - monitors
                         type: object
                       scaleIO:
-                        description: scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
+                        description: |-
+                          scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
+                          Deprecated: ScaleIO is deprecated and the in-tree scaleIO type is no longer supported.
                         properties:
                           fsType:
+                            default: xfs
                             description: |-
                               fsType is the filesystem type to mount.
                               Must be a filesystem type supported by the host operating system.
@@ -23244,9 +23614,7 @@ spec:
                                   This field is effectively required, but due to backwards compatibility is
                                   allowed to be empty. Instances of this type with an empty value here are
                                   almost certainly wrong.
-                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
@@ -23254,6 +23622,7 @@ spec:
                             description: sslEnabled Flag enable/disable SSL communication with Gateway, default false
                             type: boolean
                           storageMode:
+                            default: ThinProvisioned
                             description: |-
                               storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
                               Default is ThinProvisioned.
@@ -23338,7 +23707,9 @@ spec:
                             type: string
                         type: object
                       storageos:
-                        description: storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
+                        description: |-
+                          storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
+                          Deprecated: StorageOS is deprecated and the in-tree storageos type is no longer supported.
                         properties:
                           fsType:
                             description: |-
@@ -23363,9 +23734,7 @@ spec:
                                   This field is effectively required, but due to backwards compatibility is
                                   allowed to be empty. Instances of this type with an empty value here are
                                   almost certainly wrong.
-                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
@@ -23385,7 +23754,10 @@ spec:
                             type: string
                         type: object
                       vsphereVolume:
-                        description: vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine
+                        description: |-
+                          vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine.
+                          Deprecated: VsphereVolume is deprecated. All operations for the in-tree vsphereVolume type
+                          are redirected to the csi.vsphere.vmware.com CSI driver.
                         properties:
                           fsType:
                             description: |-
@@ -23409,6 +23781,8 @@ spec:
                       - name
                     type: object
                   type: array
+              required:
+                - steps
               type: object
             status:
               description: BuildStrategyStatus defines the observed state of BuildStrategy
@@ -23424,7 +23798,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: clusterbuildstrategies.shipwright.io
 spec:
   conversion:
@@ -23474,6 +23848,7 @@ spec:
               description: BuildStrategySpec defines the desired state of BuildStrategy
               properties:
                 buildSteps:
+                  description: BuildSteps defines the steps of the strategy
                   items:
                     description: |-
                       BuildStep defines a partial step that needs to run in container for building the image.
@@ -23548,9 +23923,7 @@ spec:
                                         This field is effectively required, but due to backwards compatibility is
                                         allowed to be empty. Instances of this type with an empty value here are
                                         almost certainly wrong.
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                         More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                       type: string
                                     optional:
                                       description: Specify whether the ConfigMap or its key must be defined
@@ -23609,9 +23982,7 @@ spec:
                                         This field is effectively required, but due to backwards compatibility is
                                         allowed to be empty. Instances of this type with an empty value here are
                                         almost certainly wrong.
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                         More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                       type: string
                                     optional:
                                       description: Specify whether the Secret or its key must be defined
@@ -23649,9 +24020,7 @@ spec:
                                     This field is effectively required, but due to backwards compatibility is
                                     allowed to be empty. Instances of this type with an empty value here are
                                     almost certainly wrong.
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                   type: string
                                 optional:
                                   description: Specify whether the ConfigMap must be defined
@@ -23671,9 +24040,7 @@ spec:
                                     This field is effectively required, but due to backwards compatibility is
                                     allowed to be empty. Instances of this type with an empty value here are
                                     almost certainly wrong.
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                   type: string
                                 optional:
                                   description: Specify whether the Secret must be defined
@@ -23711,7 +24078,7 @@ spec:
                               More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                             properties:
                               exec:
-                                description: Exec specifies the action to take.
+                                description: Exec specifies a command to execute in the container.
                                 properties:
                                   command:
                                     description: |-
@@ -23726,7 +24093,7 @@ spec:
                                     x-kubernetes-list-type: atomic
                                 type: object
                               httpGet:
-                                description: HTTPGet specifies the http request to perform.
+                                description: HTTPGet specifies an HTTP GET request to perform.
                                 properties:
                                   host:
                                     description: |-
@@ -23773,7 +24140,7 @@ spec:
                                   - port
                                 type: object
                               sleep:
-                                description: Sleep represents the duration that the container should sleep before being terminated.
+                                description: Sleep represents a duration that the container should sleep.
                                 properties:
                                   seconds:
                                     description: Seconds is the number of seconds to sleep.
@@ -23785,8 +24152,8 @@ spec:
                               tcpSocket:
                                 description: |-
                                   Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
-                                  for the backward compatibility. There are no validation of this field and
-                                  lifecycle hooks will fail in runtime when tcp handler is specified.
+                                  for backward compatibility. There is no validation of this field and
+                                  lifecycle hooks will fail at runtime when it is specified.
                                 properties:
                                   host:
                                     description: 'Optional: Host name to connect to, defaults to the pod IP.'
@@ -23817,7 +24184,7 @@ spec:
                               More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                             properties:
                               exec:
-                                description: Exec specifies the action to take.
+                                description: Exec specifies a command to execute in the container.
                                 properties:
                                   command:
                                     description: |-
@@ -23832,7 +24199,7 @@ spec:
                                     x-kubernetes-list-type: atomic
                                 type: object
                               httpGet:
-                                description: HTTPGet specifies the http request to perform.
+                                description: HTTPGet specifies an HTTP GET request to perform.
                                 properties:
                                   host:
                                     description: |-
@@ -23879,7 +24246,7 @@ spec:
                                   - port
                                 type: object
                               sleep:
-                                description: Sleep represents the duration that the container should sleep before being terminated.
+                                description: Sleep represents a duration that the container should sleep.
                                 properties:
                                   seconds:
                                     description: Seconds is the number of seconds to sleep.
@@ -23891,8 +24258,8 @@ spec:
                               tcpSocket:
                                 description: |-
                                   Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
-                                  for the backward compatibility. There are no validation of this field and
-                                  lifecycle hooks will fail in runtime when tcp handler is specified.
+                                  for backward compatibility. There is no validation of this field and
+                                  lifecycle hooks will fail at runtime when it is specified.
                                 properties:
                                   host:
                                     description: 'Optional: Host name to connect to, defaults to the pod IP.'
@@ -23919,7 +24286,7 @@ spec:
                           More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                         properties:
                           exec:
-                            description: Exec specifies the action to take.
+                            description: Exec specifies a command to execute in the container.
                             properties:
                               command:
                                 description: |-
@@ -23940,17 +24307,17 @@ spec:
                             format: int32
                             type: integer
                           grpc:
-                            description: GRPC specifies an action involving a GRPC port.
+                            description: GRPC specifies a GRPC HealthCheckRequest.
                             properties:
                               port:
                                 description: Port number of the gRPC service. Number must be in the range 1 to 65535.
                                 format: int32
                                 type: integer
                               service:
+                                default: ""
                                 description: |-
                                   Service is the name of the service to place in the gRPC HealthCheckRequest
                                   (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-
 
                                   If this is not specified, the default behavior is defined by gRPC.
                                 type: string
@@ -23958,7 +24325,7 @@ spec:
                               - port
                             type: object
                           httpGet:
-                            description: HTTPGet specifies the http request to perform.
+                            description: HTTPGet specifies an HTTP GET request to perform.
                             properties:
                               host:
                                 description: |-
@@ -24023,7 +24390,7 @@ spec:
                             format: int32
                             type: integer
                           tcpSocket:
-                            description: TCPSocket specifies an action involving a TCP port.
+                            description: TCPSocket specifies a connection to a TCP port.
                             properties:
                               host:
                                 description: 'Optional: Host name to connect to, defaults to the pod IP.'
@@ -24125,7 +24492,7 @@ spec:
                           More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                         properties:
                           exec:
-                            description: Exec specifies the action to take.
+                            description: Exec specifies a command to execute in the container.
                             properties:
                               command:
                                 description: |-
@@ -24146,17 +24513,17 @@ spec:
                             format: int32
                             type: integer
                           grpc:
-                            description: GRPC specifies an action involving a GRPC port.
+                            description: GRPC specifies a GRPC HealthCheckRequest.
                             properties:
                               port:
                                 description: Port number of the gRPC service. Number must be in the range 1 to 65535.
                                 format: int32
                                 type: integer
                               service:
+                                default: ""
                                 description: |-
                                   Service is the name of the service to place in the gRPC HealthCheckRequest
                                   (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-
 
                                   If this is not specified, the default behavior is defined by gRPC.
                                 type: string
@@ -24164,7 +24531,7 @@ spec:
                               - port
                             type: object
                           httpGet:
-                            description: HTTPGet specifies the http request to perform.
+                            description: HTTPGet specifies an HTTP GET request to perform.
                             properties:
                               host:
                                 description: |-
@@ -24229,7 +24596,7 @@ spec:
                             format: int32
                             type: integer
                           tcpSocket:
-                            description: TCPSocket specifies an action involving a TCP port.
+                            description: TCPSocket specifies a connection to a TCP port.
                             properties:
                               host:
                                 description: 'Optional: Host name to connect to, defaults to the pod IP.'
@@ -24300,10 +24667,8 @@ spec:
                               Claims lists the names of resources, defined in spec.resourceClaims,
                               that are used by this container.
 
-
                               This is an alpha field and requires enabling the
                               DynamicResourceAllocation feature gate.
-
 
                               This field is immutable. It can only be set for containers.
                             items:
@@ -24314,6 +24679,12 @@ spec:
                                     Name must match the name of one entry in pod.spec.resourceClaims of
                                     the Pod where this field is used. It makes that resource available
                                     inside a container.
+                                  type: string
+                                request:
+                                  description: |-
+                                    Request is the name chosen for a request in the referenced claim.
+                                    If empty, everything from the claim is made available, otherwise
+                                    only the result of this request.
                                   type: string
                               required:
                                 - name
@@ -24436,7 +24807,7 @@ spec:
                           procMount:
                             description: |-
                               procMount denotes the type of proc mount to use for the containers.
-                              The default is DefaultProcMount which uses the container runtime defaults for
+                              The default value is Default which uses the container runtime defaults for
                               readonly paths and masked paths.
                               This requires the ProcMountType feature flag to be enabled.
                               Note that this field cannot be set when spec.os.name is windows.
@@ -24514,7 +24885,6 @@ spec:
                                   type indicates which kind of seccomp profile will be applied.
                                   Valid options are:
 
-
                                   Localhost - a profile defined in a file on the node should be used.
                                   RuntimeDefault - the container runtime default profile should be used.
                                   Unconfined - no profile should be applied.
@@ -24565,7 +24935,7 @@ spec:
                           More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                         properties:
                           exec:
-                            description: Exec specifies the action to take.
+                            description: Exec specifies a command to execute in the container.
                             properties:
                               command:
                                 description: |-
@@ -24586,17 +24956,17 @@ spec:
                             format: int32
                             type: integer
                           grpc:
-                            description: GRPC specifies an action involving a GRPC port.
+                            description: GRPC specifies a GRPC HealthCheckRequest.
                             properties:
                               port:
                                 description: Port number of the gRPC service. Number must be in the range 1 to 65535.
                                 format: int32
                                 type: integer
                               service:
+                                default: ""
                                 description: |-
                                   Service is the name of the service to place in the gRPC HealthCheckRequest
                                   (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-
 
                                   If this is not specified, the default behavior is defined by gRPC.
                                 type: string
@@ -24604,7 +24974,7 @@ spec:
                               - port
                             type: object
                           httpGet:
-                            description: HTTPGet specifies the http request to perform.
+                            description: HTTPGet specifies an HTTP GET request to perform.
                             properties:
                               host:
                                 description: |-
@@ -24669,7 +25039,7 @@ spec:
                             format: int32
                             type: integer
                           tcpSocket:
-                            description: TCPSocket specifies an action involving a TCP port.
+                            description: TCPSocket specifies a connection to a TCP port.
                             properties:
                               host:
                                 description: 'Optional: Host name to connect to, defaults to the pod IP.'
@@ -24802,9 +25172,7 @@ spec:
                                 RecursiveReadOnly specifies whether read-only mounts should be handled
                                 recursively.
 
-
                                 If ReadOnly is false, this field has no meaning and must be unspecified.
-
 
                                 If ReadOnly is true, and this field is set to Disabled, the mount is not made
                                 recursively read-only.  If this field is set to IfPossible, the mount is made
@@ -24813,10 +25181,8 @@ spec:
                                 supported by the container runtime, otherwise the pod will not be started and
                                 an error will be generated to indicate the reason.
 
-
                                 If this field is set to IfPossible or Enabled, MountPropagation must be set to
                                 None (or be unspecified, which defaults to None).
-
 
                                 If this field is not specified, it is treated as an equivalent of Disabled.
                               type: string
@@ -24852,6 +25218,7 @@ spec:
                     type: object
                   type: array
                 parameters:
+                  description: Parameters defines the parameters of the strategy
                   items:
                     description: |-
                       Parameter holds a name-description with a default value
@@ -24884,11 +25251,7 @@ spec:
                     type: object
                   type: array
                 securityContext:
-                  description: |-
-                    BuildStrategySecurityContext defines a UID and GID for the build that is to be used for the build strategy steps as
-                    well as for shipwright-managed steps such as the source retrieval, or the image processing.
-                    The value can be overwritten on the steps for the strategy steps.
-                    If omitted, then UID and GID from the Shipwright configuration will be used for the shipwright-managed steps.
+                  description: SecurityContext defines the default security context of all strategy steps
                   properties:
                     runAsGroup:
                       description: |-
@@ -24909,6 +25272,7 @@ spec:
                     - runAsUser
                   type: object
                 volumes:
+                  description: Volumes defines the volumes of the strategy
                   items:
                     description: |-
                       BuildStrategyVolume is a volume that will be mounted in build pod during build step
@@ -24918,6 +25282,8 @@ spec:
                         description: |-
                           awsElasticBlockStore represents an AWS Disk resource that is attached to a
                           kubelet's host machine and then exposed to the pod.
+                          Deprecated: AWSElasticBlockStore is deprecated. All operations for the in-tree
+                          awsElasticBlockStore type are redirected to the ebs.csi.aws.com CSI driver.
                           More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                         properties:
                           fsType:
@@ -24926,7 +25292,6 @@ spec:
                               Tip: Ensure that the filesystem type is supported by the host operating system.
                               Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                               More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                              TODO: how do we prevent errors in the filesystem from compromising the machine
                             type: string
                           partition:
                             description: |-
@@ -24950,7 +25315,10 @@ spec:
                           - volumeID
                         type: object
                       azureDisk:
-                        description: azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
+                        description: |-
+                          azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
+                          Deprecated: AzureDisk is deprecated. All operations for the in-tree azureDisk type
+                          are redirected to the disk.csi.azure.com CSI driver.
                         properties:
                           cachingMode:
                             description: 'cachingMode is the Host Caching mode: None, Read Only, Read Write.'
@@ -24962,6 +25330,7 @@ spec:
                             description: diskURI is the URI of data disk in the blob storage
                             type: string
                           fsType:
+                            default: ext4
                             description: |-
                               fsType is Filesystem type to mount.
                               Must be a filesystem type supported by the host operating system.
@@ -24971,6 +25340,7 @@ spec:
                             description: 'kind expected values are Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared'
                             type: string
                           readOnly:
+                            default: false
                             description: |-
                               readOnly Defaults to false (read/write). ReadOnly here will force
                               the ReadOnly setting in VolumeMounts.
@@ -24980,7 +25350,10 @@ spec:
                           - diskURI
                         type: object
                       azureFile:
-                        description: azureFile represents an Azure File Service mount on the host and bind mount to the pod.
+                        description: |-
+                          azureFile represents an Azure File Service mount on the host and bind mount to the pod.
+                          Deprecated: AzureFile is deprecated. All operations for the in-tree azureFile type
+                          are redirected to the file.csi.azure.com CSI driver.
                         properties:
                           readOnly:
                             description: |-
@@ -24998,7 +25371,9 @@ spec:
                           - shareName
                         type: object
                       cephfs:
-                        description: cephFS represents a Ceph FS mount on the host that shares a pod's lifetime
+                        description: |-
+                          cephFS represents a Ceph FS mount on the host that shares a pod's lifetime.
+                          Deprecated: CephFS is deprecated and the in-tree cephfs type is no longer supported.
                         properties:
                           monitors:
                             description: |-
@@ -25034,9 +25409,7 @@ spec:
                                   This field is effectively required, but due to backwards compatibility is
                                   allowed to be empty. Instances of this type with an empty value here are
                                   almost certainly wrong.
-                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
@@ -25051,6 +25424,8 @@ spec:
                       cinder:
                         description: |-
                           cinder represents a cinder volume attached and mounted on kubelets host machine.
+                          Deprecated: Cinder is deprecated. All operations for the in-tree cinder type
+                          are redirected to the cinder.csi.openstack.org CSI driver.
                           More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                         properties:
                           fsType:
@@ -25078,9 +25453,7 @@ spec:
                                   This field is effectively required, but due to backwards compatibility is
                                   allowed to be empty. Instances of this type with an empty value here are
                                   almost certainly wrong.
-                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
@@ -25151,9 +25524,7 @@ spec:
                               This field is effectively required, but due to backwards compatibility is
                               allowed to be empty. Instances of this type with an empty value here are
                               almost certainly wrong.
-                              TODO: Add other useful fields. apiVersion, kind, uid?
                               More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                             type: string
                           optional:
                             description: optional specify whether the ConfigMap or its keys must be defined
@@ -25161,7 +25532,7 @@ spec:
                         type: object
                         x-kubernetes-map-type: atomic
                       csi:
-                        description: csi (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers (Beta feature).
+                        description: csi (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers.
                         properties:
                           driver:
                             description: |-
@@ -25189,9 +25560,7 @@ spec:
                                   This field is effectively required, but due to backwards compatibility is
                                   allowed to be empty. Instances of this type with an empty value here are
                                   almost certainly wrong.
-                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
@@ -25319,7 +25688,6 @@ spec:
                           The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,
                           and deleted when the pod is removed.
 
-
                           Use this if:
                           a) the volume is only needed while the pod runs,
                           b) features of normal volumes like restoring from snapshot or capacity
@@ -25330,16 +25698,13 @@ spec:
                              information on the connection between this volume type
                              and PersistentVolumeClaim).
 
-
                           Use PersistentVolumeClaim or one of the vendor-specific
                           APIs for volumes that persist for longer than the lifecycle
                           of an individual pod.
 
-
                           Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to
                           be used that way - see the documentation of the driver for
                           more information.
-
 
                           A pod can use both types of ephemeral volumes and
                           persistent volumes at the same time.
@@ -25354,7 +25719,6 @@ spec:
                               entry. Pod validation will reject the pod if the concatenated name
                               is not valid for a PVC (for example, too long).
 
-
                               An existing PVC with that name that is not owned by the pod
                               will *not* be used for the pod to avoid using an unrelated
                               volume by mistake. Starting the pod is then blocked until
@@ -25364,10 +25728,8 @@ spec:
                               this should not be necessary, but it may be useful when
                               manually reconstructing a broken cluster.
 
-
                               This field is read-only and no changes will be made by Kubernetes
                               to the PVC after it has been created.
-
 
                               Required, must not be nil.
                             properties:
@@ -25563,7 +25925,7 @@ spec:
                                       set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
                                       exists.
                                       More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
-                                      (Alpha) Using this field requires the VolumeAttributesClass feature gate to be enabled.
+                                      (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).
                                     type: string
                                   volumeMode:
                                     description: |-
@@ -25586,7 +25948,6 @@ spec:
                               fsType is the filesystem type to mount.
                               Must be a filesystem type supported by the host operating system.
                               Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                              TODO: how do we prevent errors in the filesystem from compromising the machine
                             type: string
                           lun:
                             description: 'lun is Optional: FC target lun number'
@@ -25616,6 +25977,7 @@ spec:
                         description: |-
                           flexVolume represents a generic volume resource that is
                           provisioned/attached using an exec based plugin.
+                          Deprecated: FlexVolume is deprecated. Consider using a CSIDriver instead.
                         properties:
                           driver:
                             description: driver is the name of the driver to use for this volume.
@@ -25651,9 +26013,7 @@ spec:
                                   This field is effectively required, but due to backwards compatibility is
                                   allowed to be empty. Instances of this type with an empty value here are
                                   almost certainly wrong.
-                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
@@ -25661,7 +26021,9 @@ spec:
                           - driver
                         type: object
                       flocker:
-                        description: flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running
+                        description: |-
+                          flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running.
+                          Deprecated: Flocker is deprecated and the in-tree flocker type is no longer supported.
                         properties:
                           datasetName:
                             description: |-
@@ -25676,6 +26038,8 @@ spec:
                         description: |-
                           gcePersistentDisk represents a GCE Disk resource that is attached to a
                           kubelet's host machine and then exposed to the pod.
+                          Deprecated: GCEPersistentDisk is deprecated. All operations for the in-tree
+                          gcePersistentDisk type are redirected to the pd.csi.storage.gke.io CSI driver.
                           More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                         properties:
                           fsType:
@@ -25684,7 +26048,6 @@ spec:
                               Tip: Ensure that the filesystem type is supported by the host operating system.
                               Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                               More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                              TODO: how do we prevent errors in the filesystem from compromising the machine
                             type: string
                           partition:
                             description: |-
@@ -25712,7 +26075,7 @@ spec:
                       gitRepo:
                         description: |-
                           gitRepo represents a git repository at a particular revision.
-                          DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an
+                          Deprecated: GitRepo is deprecated. To provision a container with a git repo, mount an
                           EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
                           into the Pod's container.
                         properties:
@@ -25735,6 +26098,7 @@ spec:
                       glusterfs:
                         description: |-
                           glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
+                          Deprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported.
                           More info: https://examples.k8s.io/volumes/glusterfs/README.md
                         properties:
                           endpoints:
@@ -25764,9 +26128,6 @@ spec:
                           used for system agents or other privileged things that are allowed
                           to see the host machine. Most containers will NOT need this.
                           More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-                          ---
-                          TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not
-                          mount host directories as read/write.
                         properties:
                           path:
                             description: |-
@@ -25782,6 +26143,41 @@ spec:
                             type: string
                         required:
                           - path
+                        type: object
+                      image:
+                        description: |-
+                          image represents an OCI object (a container image or artifact) pulled and mounted on the kubelet's host machine.
+                          The volume is resolved at pod startup depending on which PullPolicy value is provided:
+
+                          - Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                          - Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                          - IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+
+                          The volume gets re-resolved if the pod gets deleted and recreated, which means that new remote content will become available on pod recreation.
+                          A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
+                          The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
+                          The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
+                          The volume will be mounted read-only (ro) and non-executable files (noexec).
+                          Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath).
+                          The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
+                        properties:
+                          pullPolicy:
+                            description: |-
+                              Policy for pulling OCI objects. Possible values are:
+                              Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                              Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                              IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+                              Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                            type: string
+                          reference:
+                            description: |-
+                              Required: Image or artifact reference to be used.
+                              Behaves in the same way as pod.spec.containers[*].image.
+                              Pull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets.
+                              More info: https://kubernetes.io/docs/concepts/containers/images
+                              This field is optional to allow higher level config management to default or override
+                              container images in workload controllers like Deployments and StatefulSets.
+                            type: string
                         type: object
                       iscsi:
                         description: |-
@@ -25801,7 +26197,6 @@ spec:
                               Tip: Ensure that the filesystem type is supported by the host operating system.
                               Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                               More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                              TODO: how do we prevent errors in the filesystem from compromising the machine
                             type: string
                           initiatorName:
                             description: |-
@@ -25813,6 +26208,7 @@ spec:
                             description: iqn is the target iSCSI Qualified Name.
                             type: string
                           iscsiInterface:
+                            default: default
                             description: |-
                               iscsiInterface is the interface Name that uses an iSCSI transport.
                               Defaults to 'default' (tcp).
@@ -25844,9 +26240,7 @@ spec:
                                   This field is effectively required, but due to backwards compatibility is
                                   allowed to be empty. Instances of this type with an empty value here are
                                   almost certainly wrong.
-                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
@@ -25913,7 +26307,9 @@ spec:
                           - claimName
                         type: object
                       photonPersistentDisk:
-                        description: photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine
+                        description: |-
+                          photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine.
+                          Deprecated: PhotonPersistentDisk is deprecated and the in-tree photonPersistentDisk type is no longer supported.
                         properties:
                           fsType:
                             description: |-
@@ -25928,7 +26324,11 @@ spec:
                           - pdID
                         type: object
                       portworxVolume:
-                        description: portworxVolume represents a portworx volume attached and mounted on kubelets host machine
+                        description: |-
+                          portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
+                          Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
+                          are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
+                          is on.
                         properties:
                           fsType:
                             description: |-
@@ -25961,22 +26361,23 @@ spec:
                             format: int32
                             type: integer
                           sources:
-                            description: sources is the list of volume projections
+                            description: |-
+                              sources is the list of volume projections. Each entry in this list
+                              handles one source.
                             items:
-                              description: Projection that may be projected along with other supported volume types
+                              description: |-
+                                Projection that may be projected along with other supported volume types.
+                                Exactly one of these fields must be set.
                               properties:
                                 clusterTrustBundle:
                                   description: |-
                                     ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field
                                     of ClusterTrustBundle objects in an auto-updating file.
 
-
                                     Alpha, gated by the ClusterTrustBundleProjection feature gate.
-
 
                                     ClusterTrustBundle objects can either be selected by name, or by the
                                     combination of signer name and a label selector.
-
 
                                     Kubelet performs aggressive normalization of the PEM contents written
                                     into the pod filesystem.  Esoteric PEM features such as inter-block
@@ -26105,9 +26506,7 @@ spec:
                                         This field is effectively required, but due to backwards compatibility is
                                         allowed to be empty. Instances of this type with an empty value here are
                                         almost certainly wrong.
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                         More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                       type: string
                                     optional:
                                       description: optional specify whether the ConfigMap or its keys must be defined
@@ -26224,9 +26623,7 @@ spec:
                                         This field is effectively required, but due to backwards compatibility is
                                         allowed to be empty. Instances of this type with an empty value here are
                                         almost certainly wrong.
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                         More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                       type: string
                                     optional:
                                       description: optional field specify whether the Secret or its key must be defined
@@ -26266,7 +26663,9 @@ spec:
                             x-kubernetes-list-type: atomic
                         type: object
                       quobyte:
-                        description: quobyte represents a Quobyte mount on the host that shares a pod's lifetime
+                        description: |-
+                          quobyte represents a Quobyte mount on the host that shares a pod's lifetime.
+                          Deprecated: Quobyte is deprecated and the in-tree quobyte type is no longer supported.
                         properties:
                           group:
                             description: |-
@@ -26304,6 +26703,7 @@ spec:
                       rbd:
                         description: |-
                           rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
+                          Deprecated: RBD is deprecated and the in-tree rbd type is no longer supported.
                           More info: https://examples.k8s.io/volumes/rbd/README.md
                         properties:
                           fsType:
@@ -26312,7 +26712,6 @@ spec:
                               Tip: Ensure that the filesystem type is supported by the host operating system.
                               Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                               More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                              TODO: how do we prevent errors in the filesystem from compromising the machine
                             type: string
                           image:
                             description: |-
@@ -26320,6 +26719,7 @@ spec:
                               More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                             type: string
                           keyring:
+                            default: /etc/ceph/keyring
                             description: |-
                               keyring is the path to key ring for RBDUser.
                               Default is /etc/ceph/keyring.
@@ -26334,6 +26734,7 @@ spec:
                             type: array
                             x-kubernetes-list-type: atomic
                           pool:
+                            default: rbd
                             description: |-
                               pool is the rados pool name.
                               Default is rbd.
@@ -26359,13 +26760,12 @@ spec:
                                   This field is effectively required, but due to backwards compatibility is
                                   allowed to be empty. Instances of this type with an empty value here are
                                   almost certainly wrong.
-                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
                           user:
+                            default: admin
                             description: |-
                               user is the rados user name.
                               Default is admin.
@@ -26376,9 +26776,12 @@ spec:
                           - monitors
                         type: object
                       scaleIO:
-                        description: scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
+                        description: |-
+                          scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
+                          Deprecated: ScaleIO is deprecated and the in-tree scaleIO type is no longer supported.
                         properties:
                           fsType:
+                            default: xfs
                             description: |-
                               fsType is the filesystem type to mount.
                               Must be a filesystem type supported by the host operating system.
@@ -26408,9 +26811,7 @@ spec:
                                   This field is effectively required, but due to backwards compatibility is
                                   allowed to be empty. Instances of this type with an empty value here are
                                   almost certainly wrong.
-                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
@@ -26418,6 +26819,7 @@ spec:
                             description: sslEnabled Flag enable/disable SSL communication with Gateway, default false
                             type: boolean
                           storageMode:
+                            default: ThinProvisioned
                             description: |-
                               storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
                               Default is ThinProvisioned.
@@ -26502,7 +26904,9 @@ spec:
                             type: string
                         type: object
                       storageos:
-                        description: storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
+                        description: |-
+                          storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
+                          Deprecated: StorageOS is deprecated and the in-tree storageos type is no longer supported.
                         properties:
                           fsType:
                             description: |-
@@ -26527,9 +26931,7 @@ spec:
                                   This field is effectively required, but due to backwards compatibility is
                                   allowed to be empty. Instances of this type with an empty value here are
                                   almost certainly wrong.
-                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
@@ -26549,7 +26951,10 @@ spec:
                             type: string
                         type: object
                       vsphereVolume:
-                        description: vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine
+                        description: |-
+                          vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine.
+                          Deprecated: VsphereVolume is deprecated. All operations for the in-tree vsphereVolume type
+                          are redirected to the csi.vsphere.vmware.com CSI driver.
                         properties:
                           fsType:
                             description: |-
@@ -26573,6 +26978,8 @@ spec:
                       - name
                     type: object
                   type: array
+              required:
+                - buildSteps
               type: object
             status:
               description: BuildStrategyStatus defines the observed state of BuildStrategy
@@ -26608,6 +27015,7 @@ spec:
               description: BuildStrategySpec defines the desired state of BuildStrategy
               properties:
                 parameters:
+                  description: Parameters defines the parameters of the strategy
                   items:
                     description: |-
                       Parameter holds a name-description with a default value
@@ -26640,11 +27048,7 @@ spec:
                     type: object
                   type: array
                 securityContext:
-                  description: |-
-                    BuildStrategySecurityContext defines a UID and GID for the build that is to be used for the build strategy steps as
-                    well as for shipwright-managed steps such as the source retrieval, or the image processing.
-                    The value can be overwritten on the steps for the strategy steps.
-                    If omitted, then UID and GID from the Shipwright configuration will be used for the shipwright-managed steps.
+                  description: SecurityContext defines the default security context of all strategy steps
                   properties:
                     runAsGroup:
                       description: |-
@@ -26665,6 +27069,7 @@ spec:
                     - runAsUser
                   type: object
                 steps:
+                  description: Steps defines the steps of the strategy
                   items:
                     description: |-
                       BuildStep defines a partial step that needs to run in container for building the image.
@@ -26737,9 +27142,7 @@ spec:
                                         This field is effectively required, but due to backwards compatibility is
                                         allowed to be empty. Instances of this type with an empty value here are
                                         almost certainly wrong.
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                         More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                       type: string
                                     optional:
                                       description: Specify whether the ConfigMap or its key must be defined
@@ -26798,9 +27201,7 @@ spec:
                                         This field is effectively required, but due to backwards compatibility is
                                         allowed to be empty. Instances of this type with an empty value here are
                                         almost certainly wrong.
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                         More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                       type: string
                                     optional:
                                       description: Specify whether the Secret or its key must be defined
@@ -26846,10 +27247,8 @@ spec:
                               Claims lists the names of resources, defined in spec.resourceClaims,
                               that are used by this container.
 
-
                               This is an alpha field and requires enabling the
                               DynamicResourceAllocation feature gate.
-
 
                               This field is immutable. It can only be set for containers.
                             items:
@@ -26860,6 +27259,12 @@ spec:
                                     Name must match the name of one entry in pod.spec.resourceClaims of
                                     the Pod where this field is used. It makes that resource available
                                     inside a container.
+                                  type: string
+                                request:
+                                  description: |-
+                                    Request is the name chosen for a request in the referenced claim.
+                                    If empty, everything from the claim is made available, otherwise
+                                    only the result of this request.
                                   type: string
                               required:
                                 - name
@@ -26964,7 +27369,7 @@ spec:
                           procMount:
                             description: |-
                               procMount denotes the type of proc mount to use for the containers.
-                              The default is DefaultProcMount which uses the container runtime defaults for
+                              The default value is Default which uses the container runtime defaults for
                               readonly paths and masked paths.
                               This requires the ProcMountType feature flag to be enabled.
                               Note that this field cannot be set when spec.os.name is windows.
@@ -27042,7 +27447,6 @@ spec:
                                   type indicates which kind of seccomp profile will be applied.
                                   Valid options are:
 
-
                                   Localhost - a profile defined in a file on the node should be used.
                                   RuntimeDefault - the container runtime default profile should be used.
                                   Unconfined - no profile should be applied.
@@ -27116,9 +27520,7 @@ spec:
                                 RecursiveReadOnly specifies whether read-only mounts should be handled
                                 recursively.
 
-
                                 If ReadOnly is false, this field has no meaning and must be unspecified.
-
 
                                 If ReadOnly is true, and this field is set to Disabled, the mount is not made
                                 recursively read-only.  If this field is set to IfPossible, the mount is made
@@ -27127,10 +27529,8 @@ spec:
                                 supported by the container runtime, otherwise the pod will not be started and
                                 an error will be generated to indicate the reason.
 
-
                                 If this field is set to IfPossible or Enabled, MountPropagation must be set to
                                 None (or be unspecified, which defaults to None).
-
 
                                 If this field is not specified, it is treated as an equivalent of Disabled.
                               type: string
@@ -27163,6 +27563,7 @@ spec:
                     type: object
                   type: array
                 volumes:
+                  description: Volumes defines the volumes of the strategy
                   items:
                     description: |-
                       BuildStrategyVolume is a volume that will be mounted in build pod during build step
@@ -27172,6 +27573,8 @@ spec:
                         description: |-
                           awsElasticBlockStore represents an AWS Disk resource that is attached to a
                           kubelet's host machine and then exposed to the pod.
+                          Deprecated: AWSElasticBlockStore is deprecated. All operations for the in-tree
+                          awsElasticBlockStore type are redirected to the ebs.csi.aws.com CSI driver.
                           More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                         properties:
                           fsType:
@@ -27180,7 +27583,6 @@ spec:
                               Tip: Ensure that the filesystem type is supported by the host operating system.
                               Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                               More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                              TODO: how do we prevent errors in the filesystem from compromising the machine
                             type: string
                           partition:
                             description: |-
@@ -27204,7 +27606,10 @@ spec:
                           - volumeID
                         type: object
                       azureDisk:
-                        description: azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
+                        description: |-
+                          azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
+                          Deprecated: AzureDisk is deprecated. All operations for the in-tree azureDisk type
+                          are redirected to the disk.csi.azure.com CSI driver.
                         properties:
                           cachingMode:
                             description: 'cachingMode is the Host Caching mode: None, Read Only, Read Write.'
@@ -27216,6 +27621,7 @@ spec:
                             description: diskURI is the URI of data disk in the blob storage
                             type: string
                           fsType:
+                            default: ext4
                             description: |-
                               fsType is Filesystem type to mount.
                               Must be a filesystem type supported by the host operating system.
@@ -27225,6 +27631,7 @@ spec:
                             description: 'kind expected values are Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared'
                             type: string
                           readOnly:
+                            default: false
                             description: |-
                               readOnly Defaults to false (read/write). ReadOnly here will force
                               the ReadOnly setting in VolumeMounts.
@@ -27234,7 +27641,10 @@ spec:
                           - diskURI
                         type: object
                       azureFile:
-                        description: azureFile represents an Azure File Service mount on the host and bind mount to the pod.
+                        description: |-
+                          azureFile represents an Azure File Service mount on the host and bind mount to the pod.
+                          Deprecated: AzureFile is deprecated. All operations for the in-tree azureFile type
+                          are redirected to the file.csi.azure.com CSI driver.
                         properties:
                           readOnly:
                             description: |-
@@ -27252,7 +27662,9 @@ spec:
                           - shareName
                         type: object
                       cephfs:
-                        description: cephFS represents a Ceph FS mount on the host that shares a pod's lifetime
+                        description: |-
+                          cephFS represents a Ceph FS mount on the host that shares a pod's lifetime.
+                          Deprecated: CephFS is deprecated and the in-tree cephfs type is no longer supported.
                         properties:
                           monitors:
                             description: |-
@@ -27288,9 +27700,7 @@ spec:
                                   This field is effectively required, but due to backwards compatibility is
                                   allowed to be empty. Instances of this type with an empty value here are
                                   almost certainly wrong.
-                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
@@ -27305,6 +27715,8 @@ spec:
                       cinder:
                         description: |-
                           cinder represents a cinder volume attached and mounted on kubelets host machine.
+                          Deprecated: Cinder is deprecated. All operations for the in-tree cinder type
+                          are redirected to the cinder.csi.openstack.org CSI driver.
                           More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                         properties:
                           fsType:
@@ -27332,9 +27744,7 @@ spec:
                                   This field is effectively required, but due to backwards compatibility is
                                   allowed to be empty. Instances of this type with an empty value here are
                                   almost certainly wrong.
-                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
@@ -27405,9 +27815,7 @@ spec:
                               This field is effectively required, but due to backwards compatibility is
                               allowed to be empty. Instances of this type with an empty value here are
                               almost certainly wrong.
-                              TODO: Add other useful fields. apiVersion, kind, uid?
                               More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                             type: string
                           optional:
                             description: optional specify whether the ConfigMap or its keys must be defined
@@ -27415,7 +27823,7 @@ spec:
                         type: object
                         x-kubernetes-map-type: atomic
                       csi:
-                        description: csi (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers (Beta feature).
+                        description: csi (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers.
                         properties:
                           driver:
                             description: |-
@@ -27443,9 +27851,7 @@ spec:
                                   This field is effectively required, but due to backwards compatibility is
                                   allowed to be empty. Instances of this type with an empty value here are
                                   almost certainly wrong.
-                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
@@ -27573,7 +27979,6 @@ spec:
                           The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,
                           and deleted when the pod is removed.
 
-
                           Use this if:
                           a) the volume is only needed while the pod runs,
                           b) features of normal volumes like restoring from snapshot or capacity
@@ -27584,16 +27989,13 @@ spec:
                              information on the connection between this volume type
                              and PersistentVolumeClaim).
 
-
                           Use PersistentVolumeClaim or one of the vendor-specific
                           APIs for volumes that persist for longer than the lifecycle
                           of an individual pod.
 
-
                           Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to
                           be used that way - see the documentation of the driver for
                           more information.
-
 
                           A pod can use both types of ephemeral volumes and
                           persistent volumes at the same time.
@@ -27608,7 +28010,6 @@ spec:
                               entry. Pod validation will reject the pod if the concatenated name
                               is not valid for a PVC (for example, too long).
 
-
                               An existing PVC with that name that is not owned by the pod
                               will *not* be used for the pod to avoid using an unrelated
                               volume by mistake. Starting the pod is then blocked until
@@ -27618,10 +28019,8 @@ spec:
                               this should not be necessary, but it may be useful when
                               manually reconstructing a broken cluster.
 
-
                               This field is read-only and no changes will be made by Kubernetes
                               to the PVC after it has been created.
-
 
                               Required, must not be nil.
                             properties:
@@ -27817,7 +28216,7 @@ spec:
                                       set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
                                       exists.
                                       More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
-                                      (Alpha) Using this field requires the VolumeAttributesClass feature gate to be enabled.
+                                      (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).
                                     type: string
                                   volumeMode:
                                     description: |-
@@ -27840,7 +28239,6 @@ spec:
                               fsType is the filesystem type to mount.
                               Must be a filesystem type supported by the host operating system.
                               Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                              TODO: how do we prevent errors in the filesystem from compromising the machine
                             type: string
                           lun:
                             description: 'lun is Optional: FC target lun number'
@@ -27870,6 +28268,7 @@ spec:
                         description: |-
                           flexVolume represents a generic volume resource that is
                           provisioned/attached using an exec based plugin.
+                          Deprecated: FlexVolume is deprecated. Consider using a CSIDriver instead.
                         properties:
                           driver:
                             description: driver is the name of the driver to use for this volume.
@@ -27905,9 +28304,7 @@ spec:
                                   This field is effectively required, but due to backwards compatibility is
                                   allowed to be empty. Instances of this type with an empty value here are
                                   almost certainly wrong.
-                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
@@ -27915,7 +28312,9 @@ spec:
                           - driver
                         type: object
                       flocker:
-                        description: flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running
+                        description: |-
+                          flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running.
+                          Deprecated: Flocker is deprecated and the in-tree flocker type is no longer supported.
                         properties:
                           datasetName:
                             description: |-
@@ -27930,6 +28329,8 @@ spec:
                         description: |-
                           gcePersistentDisk represents a GCE Disk resource that is attached to a
                           kubelet's host machine and then exposed to the pod.
+                          Deprecated: GCEPersistentDisk is deprecated. All operations for the in-tree
+                          gcePersistentDisk type are redirected to the pd.csi.storage.gke.io CSI driver.
                           More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                         properties:
                           fsType:
@@ -27938,7 +28339,6 @@ spec:
                               Tip: Ensure that the filesystem type is supported by the host operating system.
                               Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                               More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                              TODO: how do we prevent errors in the filesystem from compromising the machine
                             type: string
                           partition:
                             description: |-
@@ -27966,7 +28366,7 @@ spec:
                       gitRepo:
                         description: |-
                           gitRepo represents a git repository at a particular revision.
-                          DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an
+                          Deprecated: GitRepo is deprecated. To provision a container with a git repo, mount an
                           EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
                           into the Pod's container.
                         properties:
@@ -27989,6 +28389,7 @@ spec:
                       glusterfs:
                         description: |-
                           glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
+                          Deprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported.
                           More info: https://examples.k8s.io/volumes/glusterfs/README.md
                         properties:
                           endpoints:
@@ -28018,9 +28419,6 @@ spec:
                           used for system agents or other privileged things that are allowed
                           to see the host machine. Most containers will NOT need this.
                           More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-                          ---
-                          TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not
-                          mount host directories as read/write.
                         properties:
                           path:
                             description: |-
@@ -28036,6 +28434,41 @@ spec:
                             type: string
                         required:
                           - path
+                        type: object
+                      image:
+                        description: |-
+                          image represents an OCI object (a container image or artifact) pulled and mounted on the kubelet's host machine.
+                          The volume is resolved at pod startup depending on which PullPolicy value is provided:
+
+                          - Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                          - Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                          - IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+
+                          The volume gets re-resolved if the pod gets deleted and recreated, which means that new remote content will become available on pod recreation.
+                          A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
+                          The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
+                          The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
+                          The volume will be mounted read-only (ro) and non-executable files (noexec).
+                          Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath).
+                          The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
+                        properties:
+                          pullPolicy:
+                            description: |-
+                              Policy for pulling OCI objects. Possible values are:
+                              Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                              Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                              IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+                              Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                            type: string
+                          reference:
+                            description: |-
+                              Required: Image or artifact reference to be used.
+                              Behaves in the same way as pod.spec.containers[*].image.
+                              Pull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets.
+                              More info: https://kubernetes.io/docs/concepts/containers/images
+                              This field is optional to allow higher level config management to default or override
+                              container images in workload controllers like Deployments and StatefulSets.
+                            type: string
                         type: object
                       iscsi:
                         description: |-
@@ -28055,7 +28488,6 @@ spec:
                               Tip: Ensure that the filesystem type is supported by the host operating system.
                               Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                               More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                              TODO: how do we prevent errors in the filesystem from compromising the machine
                             type: string
                           initiatorName:
                             description: |-
@@ -28067,6 +28499,7 @@ spec:
                             description: iqn is the target iSCSI Qualified Name.
                             type: string
                           iscsiInterface:
+                            default: default
                             description: |-
                               iscsiInterface is the interface Name that uses an iSCSI transport.
                               Defaults to 'default' (tcp).
@@ -28098,9 +28531,7 @@ spec:
                                   This field is effectively required, but due to backwards compatibility is
                                   allowed to be empty. Instances of this type with an empty value here are
                                   almost certainly wrong.
-                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
@@ -28167,7 +28598,9 @@ spec:
                           - claimName
                         type: object
                       photonPersistentDisk:
-                        description: photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine
+                        description: |-
+                          photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine.
+                          Deprecated: PhotonPersistentDisk is deprecated and the in-tree photonPersistentDisk type is no longer supported.
                         properties:
                           fsType:
                             description: |-
@@ -28182,7 +28615,11 @@ spec:
                           - pdID
                         type: object
                       portworxVolume:
-                        description: portworxVolume represents a portworx volume attached and mounted on kubelets host machine
+                        description: |-
+                          portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
+                          Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
+                          are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
+                          is on.
                         properties:
                           fsType:
                             description: |-
@@ -28215,22 +28652,23 @@ spec:
                             format: int32
                             type: integer
                           sources:
-                            description: sources is the list of volume projections
+                            description: |-
+                              sources is the list of volume projections. Each entry in this list
+                              handles one source.
                             items:
-                              description: Projection that may be projected along with other supported volume types
+                              description: |-
+                                Projection that may be projected along with other supported volume types.
+                                Exactly one of these fields must be set.
                               properties:
                                 clusterTrustBundle:
                                   description: |-
                                     ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field
                                     of ClusterTrustBundle objects in an auto-updating file.
 
-
                                     Alpha, gated by the ClusterTrustBundleProjection feature gate.
-
 
                                     ClusterTrustBundle objects can either be selected by name, or by the
                                     combination of signer name and a label selector.
-
 
                                     Kubelet performs aggressive normalization of the PEM contents written
                                     into the pod filesystem.  Esoteric PEM features such as inter-block
@@ -28359,9 +28797,7 @@ spec:
                                         This field is effectively required, but due to backwards compatibility is
                                         allowed to be empty. Instances of this type with an empty value here are
                                         almost certainly wrong.
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                         More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                       type: string
                                     optional:
                                       description: optional specify whether the ConfigMap or its keys must be defined
@@ -28478,9 +28914,7 @@ spec:
                                         This field is effectively required, but due to backwards compatibility is
                                         allowed to be empty. Instances of this type with an empty value here are
                                         almost certainly wrong.
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                         More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                       type: string
                                     optional:
                                       description: optional field specify whether the Secret or its key must be defined
@@ -28520,7 +28954,9 @@ spec:
                             x-kubernetes-list-type: atomic
                         type: object
                       quobyte:
-                        description: quobyte represents a Quobyte mount on the host that shares a pod's lifetime
+                        description: |-
+                          quobyte represents a Quobyte mount on the host that shares a pod's lifetime.
+                          Deprecated: Quobyte is deprecated and the in-tree quobyte type is no longer supported.
                         properties:
                           group:
                             description: |-
@@ -28558,6 +28994,7 @@ spec:
                       rbd:
                         description: |-
                           rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
+                          Deprecated: RBD is deprecated and the in-tree rbd type is no longer supported.
                           More info: https://examples.k8s.io/volumes/rbd/README.md
                         properties:
                           fsType:
@@ -28566,7 +29003,6 @@ spec:
                               Tip: Ensure that the filesystem type is supported by the host operating system.
                               Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                               More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                              TODO: how do we prevent errors in the filesystem from compromising the machine
                             type: string
                           image:
                             description: |-
@@ -28574,6 +29010,7 @@ spec:
                               More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                             type: string
                           keyring:
+                            default: /etc/ceph/keyring
                             description: |-
                               keyring is the path to key ring for RBDUser.
                               Default is /etc/ceph/keyring.
@@ -28588,6 +29025,7 @@ spec:
                             type: array
                             x-kubernetes-list-type: atomic
                           pool:
+                            default: rbd
                             description: |-
                               pool is the rados pool name.
                               Default is rbd.
@@ -28613,13 +29051,12 @@ spec:
                                   This field is effectively required, but due to backwards compatibility is
                                   allowed to be empty. Instances of this type with an empty value here are
                                   almost certainly wrong.
-                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
                           user:
+                            default: admin
                             description: |-
                               user is the rados user name.
                               Default is admin.
@@ -28630,9 +29067,12 @@ spec:
                           - monitors
                         type: object
                       scaleIO:
-                        description: scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
+                        description: |-
+                          scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
+                          Deprecated: ScaleIO is deprecated and the in-tree scaleIO type is no longer supported.
                         properties:
                           fsType:
+                            default: xfs
                             description: |-
                               fsType is the filesystem type to mount.
                               Must be a filesystem type supported by the host operating system.
@@ -28662,9 +29102,7 @@ spec:
                                   This field is effectively required, but due to backwards compatibility is
                                   allowed to be empty. Instances of this type with an empty value here are
                                   almost certainly wrong.
-                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
@@ -28672,6 +29110,7 @@ spec:
                             description: sslEnabled Flag enable/disable SSL communication with Gateway, default false
                             type: boolean
                           storageMode:
+                            default: ThinProvisioned
                             description: |-
                               storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
                               Default is ThinProvisioned.
@@ -28756,7 +29195,9 @@ spec:
                             type: string
                         type: object
                       storageos:
-                        description: storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
+                        description: |-
+                          storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
+                          Deprecated: StorageOS is deprecated and the in-tree storageos type is no longer supported.
                         properties:
                           fsType:
                             description: |-
@@ -28781,9 +29222,7 @@ spec:
                                   This field is effectively required, but due to backwards compatibility is
                                   allowed to be empty. Instances of this type with an empty value here are
                                   almost certainly wrong.
-                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
@@ -28803,7 +29242,10 @@ spec:
                             type: string
                         type: object
                       vsphereVolume:
-                        description: vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine
+                        description: |-
+                          vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine.
+                          Deprecated: VsphereVolume is deprecated. All operations for the in-tree vsphereVolume type
+                          are redirected to the csi.vsphere.vmware.com CSI driver.
                         properties:
                           fsType:
                             description: |-
@@ -28827,6 +29269,8 @@ spec:
                       - name
                     type: object
                   type: array
+              required:
+                - steps
               type: object
             status:
               description: BuildStrategyStatus defines the observed state of BuildStrategy


### PR DESCRIPTION
## Changes

- update shiperight release
- use latest available operator image
- bump operator-sdk version
- update bundle manifests

Signed-off-by: Avinal Kumar <avinal@redhat.com>

