### PR TITLE
fix: stop gomod updates via renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json"
+  "extends": [
+    "github>konflux-ci/mintmaker//config/renovate/renovate.json"
+  ],
+  "gomod": {
+    "enabled": false
+  }
+}


### PR DESCRIPTION
- go mod updates will be part of code changes or bug fixes
- mintmaker update spams the repo and we only require
pipeline updates and Containerfile updates

