### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for openshift-builds-operator-bundle-1-5

### DIFF
--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -21,12 +21,13 @@ LABEL com.redhat.openshift.versions="v4.16-v4.19" \
     io.k8s.display-name="Red Hat OpenShift Builds Operator Bundle" \
     io.openshift.tags="builds,operator,bundle" \
     maintainer="openshift-builds@redhat.com" \
-    name="openshift-builds/operator-bundle" \
+    name="openshift-builds/openshift-builds-operator-bundle" \
     summary="Red Hat OpenShift Builds Operator Bundle" \
     url="https://catalog.redhat.com/software/containers/openshift-builds/openshift-builds-operator-bundle" \
     vendor="Red Hat, Inc." \
     version="1.5.1" \
-    release="1.5.1"
+    release="1.5.1" \
+    cpe="cpe:/a:redhat:openshift_builds:1.5::el9"
 
 COPY bundle/ /
 COPY LICENSE /licenses/


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
