### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for openshift-builds-operator-1-4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,11 +21,12 @@ ENTRYPOINT ["/operator"]
 
 LABEL \
     com.redhat.component="openshift-builds-operator-container" \
-    name="openshift-builds/operator" \
+    name="openshift-builds/openshift-builds-rhel9-operator" \
     version="v1.4.1" \
     summary="Red Hat OpenShift Builds Operator" \
     maintainer="openshift-builds@redhat.com" \
     description="Red Hat OpenShift Builds Operator" \
     io.k8s.description="Red Hat OpenShift Builds Operator" \
     io.k8s.display-name="Red Hat OpenShift Builds Operator" \
-    io.openshift.tags="builds,operator"
+    io.openshift.tags="builds,operator" \
+    cpe="cpe:/a:redhat:openshift_builds:1.4::el9"


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
