### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for openshift-builds-operator-bundle-1-2

### DIFF
--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -15,13 +15,14 @@ LABEL operators.operatorframework.io.test.config.v1=tests/scorecard/
 
 LABEL com.redhat.openshift.versions="v4.12-v4.17" \
     com.redhat.component="openshift-builds-operator-bundle-container" \
+    cpe="cpe:/a:redhat:openshift_builds:1.2::el9" \
     description="Red Hat OpenShift Builds Operator Bundle" \
     distribution-scope="public" \
     io.k8s.description="Red Hat OpenShift Builds Operator Bundle" \
     io.k8s.display-name="Red Hat OpenShift Builds Operator Bundle" \
     io.openshift.tags="builds,operator,bundle" \
     maintainer="openshift-builds@redhat.com" \
-    name="openshift-builds/operator-bundle" \
+    name="openshift-builds/openshift-builds-operator-bundle" \
     release="0" \
     summary="Red Hat OpenShift Builds Operator Bundle" \
     url="https://catalog.redhat.com/software/containers/openshift-builds/openshift-builds-operator-bundle" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
