### PR TITLE
[BUILD-1677]: Implement Network Policies for operand components

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ COPY --from=builder /opt/app-root/src /opt/app-root/src
 COPY --from=builder /opt/app-root/src/operator .
 COPY config/shipwright/ config/shipwright/
 COPY config/sharedresource/ config/sharedresource/
+COPY config/networkpolicies/ config/networkpolicies/
 COPY LICENSE /licenses/
 
 USER 65532:65532

--- a/config/networkpolicies/ingress-policies.yaml
+++ b/config/networkpolicies/ingress-policies.yaml
@@ -1,0 +1,92 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-ingress
+  namespace: openshift-builds
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: csidriver-webhook-ingress
+  namespace: openshift-builds
+spec:
+  podSelector:
+    matchLabels:
+      name: shared-resource-csi-driver-webhook
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: openshift-kube-apiserver
+    ports:
+    - protocol: TCP
+      port: 8443
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: shipwright-webhook-ingress
+  namespace: openshift-builds
+spec:
+  podSelector:
+    matchLabels:
+      name: shp-build-webhook
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: openshift-kube-apiserver
+    ports:
+    - protocol: TCP
+      port: 8443
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: monitoring-metrics-ingress-csi
+  namespace: openshift-builds
+spec:
+  podSelector:
+    matchLabels:
+      app: shared-resource-csi-driver-node
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          network.openshift.io/policy-group: monitoring
+    ports:
+    - protocol: TCP
+      port: 6000  # provisioner-m metrics port
+    - protocol: TCP
+      port: 9898  # healthz port
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: monitoring-metrics-ingress-shipwright
+  namespace: openshift-builds
+spec:
+  podSelector:
+    matchLabels:
+      name: shipwright-build
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          network.openshift.io/policy-group: monitoring
+    ports:
+    - protocol: TCP
+      port: 8383

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -253,6 +253,18 @@ rules:
   - update
   - watch
 - apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - operator.openshift.io
   resources:
   - openshiftbuilds

--- a/internal/common/constant.go
+++ b/internal/common/constant.go
@@ -33,5 +33,9 @@ var (
 )
 
 var (
+	NetworkPolicyManifestPath = filepath.Join("config", "networkpolicies")
+)
+
+var (
 	CurrentNamespaceName string
 )

--- a/internal/controller/openshiftbuild_controller.go
+++ b/internal/controller/openshiftbuild_controller.go
@@ -26,6 +26,7 @@ import (
 	"github.com/go-logr/logr"
 	manifestivalclient "github.com/manifestival/controller-runtime-client"
 	"github.com/manifestival/manifestival"
+	"github.com/redhat-openshift-builds/operator/internal/networkpolicy"
 	"github.com/redhat-openshift-builds/operator/internal/sharedresource"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
@@ -52,6 +53,7 @@ type OpenShiftBuildReconciler struct {
 	Logger         logr.Logger
 	SharedResource *sharedresource.SharedResource
 	Shipwright     *shipwrightbuild.ShipwrightBuild
+	NetworkPolicy  *networkpolicy.NetworkPolicy
 }
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
@@ -125,6 +127,23 @@ func (r *OpenShiftBuildReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		return ctrl.Result{}, fmt.Errorf("SharedResources reconciliation failed : %v", sharedResourcesErr)
 	}
 
+	// Reconcile NetworkPolicies
+	if networkPolicyErr := r.ReconcileNetworkPolicy(ctx, openShiftBuild); networkPolicyErr != nil {
+		logger.Error(networkPolicyErr, "Failed to reconcile NetworkPolicy")
+		apimeta.SetStatusCondition(&openShiftBuild.Status.Conditions, metav1.Condition{
+			Type:    openshiftv1alpha1.ConditionReady,
+			Status:  metav1.ConditionFalse,
+			Reason:  "NetworkPolicyReconcileFailed",
+			Message: fmt.Sprintf("Failed to reconcile NetworkPolicy: %v", networkPolicyErr),
+		})
+
+		if statusUpdateErr := r.Client.Status().Update(ctx, openShiftBuild); statusUpdateErr != nil {
+			logger.Error(statusUpdateErr, "Failed to update status after NetworkPolicyReconcileFailed", networkPolicyErr)
+		}
+
+		return ctrl.Result{}, fmt.Errorf("NetworkPolicy reconciliation failed : %v", networkPolicyErr)
+	}
+
 	// Update status
 	apimeta.SetStatusCondition(&openShiftBuild.Status.Conditions, metav1.Condition{
 		Type:    openshiftv1alpha1.ConditionReady,
@@ -195,6 +214,19 @@ func (r *OpenShiftBuildReconciler) ReconcileSharedResource(ctx context.Context, 
 	return nil
 }
 
+// ReconcileNetworkPolicy reconciles NetworkPolicy resources
+func (r *OpenShiftBuildReconciler) ReconcileNetworkPolicy(ctx context.Context, openshiftBuild *openshiftv1alpha1.OpenShiftBuild) error {
+	logger := log.FromContext(ctx).WithValues("name", openshiftBuild.ObjectMeta.Name)
+
+	logger.Info("Reconciling NetworkPolicy...")
+	if err := r.NetworkPolicy.Reconcile(ctx, openshiftBuild); err != nil {
+		logger.Error(err, "Failed reconciling NetworkPolicy...")
+		return err
+	}
+
+	return nil
+}
+
 // BootStrapSharedResource initializes the manifestival to apply Shared Resources
 func (r *OpenShiftBuildReconciler) setupSharedResource(mgr ctrl.Manager) error {
 	// Initialize Manifestival
@@ -218,6 +250,29 @@ func (r *OpenShiftBuildReconciler) setupSharedResource(mgr ctrl.Manager) error {
 	return nil
 }
 
+// setupNetworkPolicy initializes the manifestival to apply NetworkPolicy resources
+func (r *OpenShiftBuildReconciler) setupNetworkPolicy(mgr ctrl.Manager) error {
+	// Initialize Manifestival
+	manifestivalOptions := []manifestival.Option{
+		manifestival.UseLogger(r.Logger),
+		manifestival.UseClient(manifestivalclient.NewClient(mgr.GetClient())),
+	}
+
+	// NetworkPolicy manifests
+	networkPolicyManifestPath := common.NetworkPolicyManifestPath
+	if path, ok := os.LookupEnv("NETWORKPOLICY_MANIFEST_PATH"); ok {
+		networkPolicyManifestPath = path
+	}
+	networkPolicyManifest, err := manifestival.NewManifest(networkPolicyManifestPath, manifestivalOptions...)
+	if err != nil {
+		return err
+	}
+
+	// Initialize NetworkPolicy
+	r.NetworkPolicy = networkpolicy.New(mgr.GetClient(), networkPolicyManifest, r.Logger)
+	return nil
+}
+
 // HandleDeletion deletes objects created by the controller
 func (r *OpenShiftBuildReconciler) HandleDeletion(ctx context.Context, owner *openshiftv1alpha1.OpenShiftBuild) error {
 	logger := log.FromContext(ctx).WithValues("name", owner.Name)
@@ -227,6 +282,10 @@ func (r *OpenShiftBuildReconciler) HandleDeletion(ctx context.Context, owner *op
 	}
 	if err := r.SharedResource.Reconcile(ctx, owner); err != nil {
 		logger.Error(err, "Failed to delete SharedResource")
+		return err
+	}
+	if err := r.NetworkPolicy.Reconcile(ctx, owner); err != nil {
+		logger.Error(err, "Failed to delete NetworkPolicy")
 		return err
 	}
 	if controllerutil.ContainsFinalizer(owner, common.OpenShiftBuildFinalizerName) {
@@ -287,6 +346,11 @@ func (r *OpenShiftBuildReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 	// bootstrap Shared Resources
 	if err := r.setupSharedResource(mgr); err != nil {
+		return err
+	}
+
+	// bootstrap NetworkPolicy
+	if err := r.setupNetworkPolicy(mgr); err != nil {
 		return err
 	}
 

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -112,6 +112,7 @@ var _ = BeforeSuite(func(ctx SpecContext) {
 	// Override the global shared resource path to the correct location.
 	// TODO: Make manifest paths a field on the respective reconciler.
 	common.SharedResourceManifestPath = filepath.Join("..", "..", "config", "sharedresource")
+	common.NetworkPolicyManifestPath = filepath.Join("..", "..", "config", "networkpolicies")
 	Expect(opBuildReconciler.SetupWithManager(mgr)).To(Succeed())
 
 	// Create namespace where operands are deployed. Manifestival does a check for existence.

--- a/internal/networkpolicy/networkpolicy.go
+++ b/internal/networkpolicy/networkpolicy.go
@@ -1,0 +1,79 @@
+package networkpolicy
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	"github.com/manifestival/manifestival"
+	openshiftv1alpha1 "github.com/redhat-openshift-builds/operator/api/v1alpha1"
+	"github.com/redhat-openshift-builds/operator/internal/common"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type NetworkPolicy struct {
+	Client   client.Client
+	Logger   logr.Logger
+	Manifest manifestival.Manifest
+}
+
+func New(client client.Client, manifest manifestival.Manifest, logger logr.Logger) *NetworkPolicy {
+	return &NetworkPolicy{
+		Client:   client,
+		Manifest: manifest,
+		Logger:   logger,
+	}
+}
+
+func (np *NetworkPolicy) Reconcile(ctx context.Context, owner *openshiftv1alpha1.OpenShiftBuild) error {
+	logger := np.Logger.WithValues("name", owner.Name)
+
+	transformerfuncs := []manifestival.Transformer{
+		manifestival.InjectOwner(owner),
+		manifestival.InjectNamespace(common.OpenShiftBuildNamespaceName),
+	}
+
+	if owner.DeletionTimestamp.IsZero() {
+		transformerfuncs = append(transformerfuncs, common.InjectFinalizer(common.OpenShiftBuildFinalizerName))
+	}
+
+	manifest, err := np.Manifest.Transform(transformerfuncs...)
+	if err != nil {
+		logger.Error(err, "Failed to transform NetworkPolicy manifests")
+		return err
+	}
+
+	if !owner.DeletionTimestamp.IsZero() {
+		logger.Info("OpenShiftBuild is being deleted, cleaning up NetworkPolicy resources")
+		return np.deleteManifests(&manifest)
+	}
+
+	logger.Info("Applying NetworkPolicy manifests for zero-trust security")
+	return manifest.Apply()
+}
+
+func (np *NetworkPolicy) deleteManifests(manifest *manifestival.Manifest) error {
+	mfc := np.Manifest.Client
+	for _, res := range manifest.Resources() {
+		obj, err := mfc.Get(&res)
+		if err != nil {
+			if errors.IsNotFound(err) {
+				continue 
+			}
+			return err
+		}
+
+		if len(obj.GetFinalizers()) > 0 {
+			obj.SetFinalizers([]string{})
+			if err := mfc.Update(obj); err != nil {
+				return err
+			}
+		}
+
+		np.Logger.Info("Deleting NetworkPolicy resource", "name", res.GetName())
+		if err := mfc.Delete(&res); err != nil && !errors.IsNotFound(err) {
+			return err
+		}
+	}
+	return nil
+}

--- a/test/e2e/e2e_networkpolicy_test.go
+++ b/test/e2e/e2e_networkpolicy_test.go
@@ -1,0 +1,372 @@
+/*
+Copyright 2024 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	buildv1beta1 "github.com/shipwright-io/build/pkg/apis/build/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	openshiftBuildsNS  = "openshift-builds"
+	netpolMonitoringNS = "netpol-test-monitoring"
+	netpolMonPodName   = "netpol-mon-probe"
+	netpolDenyPodName  = "netpol-deny-probe"
+
+	// tcpProbeTimeout is the max seconds to wait for a TCP connection attempt.
+	// OVN-Kubernetes DROPs blocked packets, so an allowed connection gets a fast
+	// response (exit 0 or 1, < 1 s), while a blocked one hangs until timeout (exit 124).
+	tcpProbeTimeout = 4
+)
+
+var _ = Describe("NetworkPolicy enforcement test", Ordered, Label("e2e"), Label("networkpolicy"), func() {
+
+	BeforeAll(func(ctx SpecContext) {
+		By("Creating a namespace labeled as monitoring so the allow-side of monitoring NetworkPolicies can be tested")
+		monNS := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: netpolMonitoringNS,
+				Labels: map[string]string{
+					"network.openshift.io/policy-group": "monitoring",
+				},
+			},
+		}
+		if err := kubeClient.Create(ctx, monNS); client.IgnoreAlreadyExists(err) != nil {
+			Fail(fmt.Sprintf("failed to create monitoring test namespace: %v", err))
+		}
+
+		By("Creating probe pods for enforcement tests")
+		pods := []struct {
+			pod  *corev1.Pod
+			desc string
+		}{
+			{netpolProbePod(netpolMonPodName, netpolMonitoringNS), "monitoring-namespace probe"},
+			{netpolProbePod(netpolDenyPodName, testNamespace), "deny-namespace probe"},
+		}
+		for _, p := range pods {
+			if err := kubeClient.Create(ctx, p.pod); client.IgnoreAlreadyExists(err) != nil {
+				Fail(fmt.Sprintf("failed to create %s: %v", p.desc, err))
+			}
+		}
+
+		By("Waiting for probe pods to be Running")
+		for _, p := range pods {
+			Eventually(func() bool {
+				pod := &corev1.Pod{}
+				if err := kubeClient.Get(ctx, client.ObjectKey{Name: p.pod.Name, Namespace: p.pod.Namespace}, pod); err != nil {
+					return false
+				}
+				return pod.Status.Phase == corev1.PodRunning
+			}, 3*time.Minute, 5*time.Second).Should(BeTrue(), "%s should be Running", p.desc)
+		}
+	})
+
+	AfterAll(func(ctx SpecContext) {
+		By("Cleaning up probe pods and monitoring namespace")
+		_ = kubeClient.Delete(ctx, &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: netpolMonPodName, Namespace: netpolMonitoringNS}})
+		_ = kubeClient.Delete(ctx, &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: netpolDenyPodName, Namespace: testNamespace}})
+		_ = kubeClient.Delete(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: netpolMonitoringNS}})
+	})
+
+	Context("NetworkPolicy deployment", func() {
+		It("should have all 5 ingress policies deployed in openshift-builds", func(ctx SpecContext) {
+			for _, policyName := range []string{
+				"default-deny-ingress",
+				"csidriver-webhook-ingress",
+				"shipwright-webhook-ingress",
+				"monitoring-metrics-ingress-csi",
+				"monitoring-metrics-ingress-shipwright",
+			} {
+				np := &networkingv1.NetworkPolicy{}
+				Expect(kubeClient.Get(ctx, types.NamespacedName{Name: policyName, Namespace: openshiftBuildsNS}, np)).
+					To(Succeed(), "NetworkPolicy %s should exist", policyName)
+			}
+		})
+
+		It("should have default-deny-ingress covering all pods with no allow rules", func(ctx SpecContext) {
+			np := &networkingv1.NetworkPolicy{}
+			Expect(kubeClient.Get(ctx, types.NamespacedName{Name: "default-deny-ingress", Namespace: openshiftBuildsNS}, np)).To(Succeed())
+			Expect(np.Spec.PodSelector.MatchLabels).To(BeEmpty(), "must apply to all pods (empty podSelector)")
+			Expect(np.Spec.PodSelector.MatchExpressions).To(BeEmpty(), "must apply to all pods (empty podSelector)")
+			Expect(np.Spec.Ingress).To(BeEmpty(), "deny-all means no ingress rules")
+			Expect(np.Spec.PolicyTypes).To(ContainElement(networkingv1.PolicyTypeIngress))
+		})
+
+		It("should restrict webhook ingress to kube-apiserver namespace on port 8443", func(ctx SpecContext) {
+			for _, policyName := range []string{"csidriver-webhook-ingress", "shipwright-webhook-ingress"} {
+				np := &networkingv1.NetworkPolicy{}
+				Expect(kubeClient.Get(ctx, types.NamespacedName{Name: policyName, Namespace: openshiftBuildsNS}, np)).To(Succeed())
+				Expect(np.Spec.Ingress).To(HaveLen(1), "%s: expected one ingress rule", policyName)
+				Expect(np.Spec.Ingress[0].From[0].NamespaceSelector.MatchLabels).To(
+					HaveKeyWithValue("kubernetes.io/metadata.name", "openshift-kube-apiserver"),
+					"%s: wrong source namespace", policyName)
+				Expect(np.Spec.Ingress[0].Ports[0].Port.IntValue()).To(Equal(8443),
+					"%s: wrong port", policyName)
+			}
+		})
+
+		It("should restrict monitoring ingress to monitoring-labeled namespaces", func(ctx SpecContext) {
+			for _, policyName := range []string{"monitoring-metrics-ingress-csi", "monitoring-metrics-ingress-shipwright"} {
+				np := &networkingv1.NetworkPolicy{}
+				Expect(kubeClient.Get(ctx, types.NamespacedName{Name: policyName, Namespace: openshiftBuildsNS}, np)).To(Succeed())
+				Expect(np.Spec.Ingress[0].From[0].NamespaceSelector.MatchLabels).To(
+					HaveKeyWithValue("network.openshift.io/policy-group", "monitoring"),
+					"%s: wrong source namespace selector", policyName)
+			}
+		})
+
+		It("should have monitoring-metrics-ingress-csi targeting CSI pods on ports 6000 and 9898", func(ctx SpecContext) {
+			np := &networkingv1.NetworkPolicy{}
+			Expect(kubeClient.Get(ctx, types.NamespacedName{Name: "monitoring-metrics-ingress-csi", Namespace: openshiftBuildsNS}, np)).To(Succeed())
+			Expect(np.Spec.PodSelector.MatchLabels).To(HaveKeyWithValue("app", "shared-resource-csi-driver-node"))
+			ports := make([]int, 0, len(np.Spec.Ingress[0].Ports))
+			for _, p := range np.Spec.Ingress[0].Ports {
+				ports = append(ports, p.Port.IntValue())
+			}
+			Expect(ports).To(ConsistOf(6000, 9898), "CSI metrics policy should allow ports 6000 (provisioner) and 9898 (healthz)")
+		})
+
+		It("should have monitoring-metrics-ingress-shipwright targeting Shipwright pods on port 8383", func(ctx SpecContext) {
+			np := &networkingv1.NetworkPolicy{}
+			Expect(kubeClient.Get(ctx, types.NamespacedName{Name: "monitoring-metrics-ingress-shipwright", Namespace: openshiftBuildsNS}, np)).To(Succeed())
+			Expect(np.Spec.PodSelector.MatchLabels).To(HaveKeyWithValue("name", "shipwright-build"))
+			ports := make([]int, 0, len(np.Spec.Ingress[0].Ports))
+			for _, p := range np.Spec.Ingress[0].Ports {
+				ports = append(ports, p.Port.IntValue())
+			}
+			Expect(ports).To(ConsistOf(8383), "Shipwright metrics policy should allow exactly port 8383")
+		})
+
+		It("should have webhook policies targeting the correct pod labels", func(ctx SpecContext) {
+			for policyName, expectedLabel := range map[string]map[string]string{
+				"csidriver-webhook-ingress":  {"name": "shared-resource-csi-driver-webhook"},
+				"shipwright-webhook-ingress": {"name": "shp-build-webhook"},
+			} {
+				np := &networkingv1.NetworkPolicy{}
+				Expect(kubeClient.Get(ctx, types.NamespacedName{Name: policyName, Namespace: openshiftBuildsNS}, np)).To(Succeed())
+				for k, v := range expectedLabel {
+					Expect(np.Spec.PodSelector.MatchLabels).To(HaveKeyWithValue(k, v),
+						"%s should target pods with %s=%s", policyName, k, v)
+				}
+			}
+		})
+	})
+
+	Context("default-deny-ingress", func() {
+		It("should BLOCK arbitrary traffic from an external namespace to openshift-builds pods", func(ctx SpecContext) {
+			operatorPods := &corev1.PodList{}
+			Expect(kubeClient.List(ctx, operatorPods, client.InNamespace(openshiftBuildsNS),
+				client.MatchingLabels{"control-plane": "controller-manager"})).To(Succeed())
+			Expect(operatorPods.Items).NotTo(BeEmpty(), "operator pod must exist")
+			ip := operatorPods.Items[0].Status.PodIP
+			Expect(ip).NotTo(BeEmpty(), "operator pod must have an IP")
+
+			By(fmt.Sprintf("Probing operator pod %s:8443 from builds-test (expect BLOCKED)", ip))
+			Expect(netpolIsAllowed(testNamespace, netpolDenyPodName, ip, 8443)).To(
+				BeFalse(),
+				"default-deny-ingress should DROP traffic from builds-test to operator pod (no specific allow policy covers it)")
+		})
+	})
+
+	Context("monitoring-metrics-ingress-csi", func() {
+		var csiPodIP string
+
+		BeforeEach(func(ctx SpecContext) {
+			pods := &corev1.PodList{}
+			Expect(kubeClient.List(ctx, pods, client.InNamespace(openshiftBuildsNS),
+				client.MatchingLabels{"app": "shared-resource-csi-driver-node"})).To(Succeed())
+			if len(pods.Items) == 0 || pods.Items[0].Status.PodIP == "" {
+				Skip("CSI DaemonSet pod has no IP yet — skipping enforcement test")
+			}
+			csiPodIP = pods.Items[0].Status.PodIP
+		})
+
+		It("should ALLOW a monitoring-labeled namespace to reach CSI metrics port 9898", func(ctx SpecContext) {
+			By(fmt.Sprintf("Probing CSI pod %s:9898 from monitoring namespace (expect ALLOWED)", csiPodIP))
+			Expect(netpolIsAllowed(netpolMonitoringNS, netpolMonPodName, csiPodIP, 9898)).To(
+				BeTrue(),
+				"monitoring-metrics-ingress-csi should ALLOW monitoring namespace → CSI pod port 9898")
+		})
+
+		It("should ALLOW a monitoring-labeled namespace to reach CSI metrics port 6000", func(ctx SpecContext) {
+			By(fmt.Sprintf("Probing CSI pod %s:6000 from monitoring namespace (expect ALLOWED)", csiPodIP))
+			Expect(netpolIsAllowed(netpolMonitoringNS, netpolMonPodName, csiPodIP, 6000)).To(
+				BeTrue(),
+				"monitoring-metrics-ingress-csi should ALLOW monitoring namespace → CSI pod port 6000")
+		})
+
+		It("should BLOCK a non-monitoring namespace from reaching CSI metrics port 9898", func(ctx SpecContext) {
+			By(fmt.Sprintf("Probing CSI pod %s:9898 from builds-test (expect BLOCKED)", csiPodIP))
+			Expect(netpolIsAllowed(testNamespace, netpolDenyPodName, csiPodIP, 9898)).To(
+				BeFalse(),
+				"default-deny-ingress should DROP traffic from non-monitoring namespace → CSI pod port 9898")
+		})
+
+		It("should BLOCK a non-monitoring namespace from reaching CSI metrics port 6000", func(ctx SpecContext) {
+			By(fmt.Sprintf("Probing CSI pod %s:6000 from builds-test (expect BLOCKED)", csiPodIP))
+			Expect(netpolIsAllowed(testNamespace, netpolDenyPodName, csiPodIP, 6000)).To(
+				BeFalse(),
+				"default-deny-ingress should DROP traffic from non-monitoring namespace → CSI pod port 6000")
+		})
+	})
+
+	Context("monitoring-metrics-ingress-shipwright", func() {
+		var shipwrightPodIP string
+
+		BeforeEach(func(ctx SpecContext) {
+			pods := &corev1.PodList{}
+			Expect(kubeClient.List(ctx, pods, client.InNamespace(openshiftBuildsNS),
+				client.MatchingLabels{"name": "shipwright-build"})).To(Succeed())
+			if len(pods.Items) == 0 || pods.Items[0].Status.PodIP == "" {
+				Skip("Shipwright build pod has no IP yet — skipping enforcement test")
+			}
+			shipwrightPodIP = pods.Items[0].Status.PodIP
+		})
+
+		It("should ALLOW a monitoring-labeled namespace to reach Shipwright metrics port 8383", func(ctx SpecContext) {
+			By(fmt.Sprintf("Probing Shipwright pod %s:8383 from monitoring namespace (expect ALLOWED)", shipwrightPodIP))
+			Expect(netpolIsAllowed(netpolMonitoringNS, netpolMonPodName, shipwrightPodIP, 8383)).To(
+				BeTrue(),
+				"monitoring-metrics-ingress-shipwright should ALLOW monitoring namespace → Shipwright pod port 8383")
+		})
+
+		It("should BLOCK a non-monitoring namespace from reaching Shipwright metrics port 8383", func(ctx SpecContext) {
+			By(fmt.Sprintf("Probing Shipwright pod %s:8383 from builds-test (expect BLOCKED)", shipwrightPodIP))
+			Expect(netpolIsAllowed(testNamespace, netpolDenyPodName, shipwrightPodIP, 8383)).To(
+				BeFalse(),
+				"default-deny-ingress should DROP traffic from non-monitoring namespace → Shipwright pod port 8383")
+		})
+	})
+
+	Context("webhook ingress policies", func() {
+		It("should BLOCK non-kube-apiserver namespace from reaching CSI webhook port 8443", func(ctx SpecContext) {
+			pods := &corev1.PodList{}
+			Expect(kubeClient.List(ctx, pods, client.InNamespace(openshiftBuildsNS),
+				client.MatchingLabels{"name": "shared-resource-csi-driver-webhook"})).To(Succeed())
+			if len(pods.Items) == 0 || pods.Items[0].Status.PodIP == "" {
+				Skip("CSI webhook pod has no IP yet — skipping enforcement test")
+			}
+			ip := pods.Items[0].Status.PodIP
+
+			By(fmt.Sprintf("Probing CSI webhook pod %s:8443 from builds-test (expect BLOCKED)", ip))
+			Expect(netpolIsAllowed(testNamespace, netpolDenyPodName, ip, 8443)).To(
+				BeFalse(),
+				"csidriver-webhook-ingress should only allow kube-apiserver; builds-test traffic must be DROPPED")
+		})
+
+		It("should BLOCK non-kube-apiserver namespace from reaching Shipwright webhook port 8443", func(ctx SpecContext) {
+			pods := &corev1.PodList{}
+			Expect(kubeClient.List(ctx, pods, client.InNamespace(openshiftBuildsNS),
+				client.MatchingLabels{"name": "shp-build-webhook"})).To(Succeed())
+			if len(pods.Items) == 0 || pods.Items[0].Status.PodIP == "" {
+				Skip("Shipwright webhook pod has no IP yet — skipping enforcement test")
+			}
+			ip := pods.Items[0].Status.PodIP
+
+			By(fmt.Sprintf("Probing Shipwright webhook pod %s:8443 from builds-test (expect BLOCKED)", ip))
+			Expect(netpolIsAllowed(testNamespace, netpolDenyPodName, ip, 8443)).To(
+				BeFalse(),
+				"shipwright-webhook-ingress should only allow kube-apiserver; builds-test traffic must be DROPPED")
+		})
+	})
+
+	Context("kube-apiserver to Shipwright webhook", func() {
+		It("should allow kube-apiserver to reach the Shipwright admission webhook", func(ctx SpecContext) {
+			build := &buildv1beta1.Build{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "netpol-webhook-probe-",
+					Namespace:    testNamespace,
+				},
+				Spec: buildv1beta1.BuildSpec{
+					Source: &buildv1beta1.Source{
+						Type: buildv1beta1.GitType,
+						Git:  &buildv1beta1.Git{URL: "https://github.com/example/nonexistent"},
+					},
+					Strategy: buildv1beta1.Strategy{Name: "buildpacks-extender"},
+					Output:   buildv1beta1.Image{Image: "example.com/nonexistent:latest"},
+				},
+			}
+			err := kubeClient.Create(ctx, build)
+			defer func() { _ = kubeClient.Delete(ctx, build) }()
+
+			if err != nil {
+				Expect(err.Error()).NotTo(MatchRegexp("(context deadline exceeded|i/o timeout)"),
+					"webhook timed out — shipwright-webhook-ingress may be blocking kube-apiserver → shp-build-webhook")
+			}
+		})
+	})
+})
+
+// netpolProbePod returns a minimal pod that sleeps indefinitely, used as a source for TCP probes.
+// The security context satisfies OpenShift's restricted PodSecurity profile.
+func netpolProbePod(name, namespace string) *corev1.Pod {
+	allowPrivEsc := false
+	runAsNonRoot := true
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    map[string]string{"app": "netpol-probe"},
+		},
+		Spec: corev1.PodSpec{
+			SecurityContext: &corev1.PodSecurityContext{
+				RunAsNonRoot:   &runAsNonRoot,
+				SeccompProfile: &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
+			},
+			Containers: []corev1.Container{{
+				Name:    "probe",
+				Image:   "registry.access.redhat.com/ubi9/ubi:latest",
+				Command: []string{"sh", "-c", "sleep infinity"},
+				SecurityContext: &corev1.SecurityContext{
+					AllowPrivilegeEscalation: &allowPrivEsc,
+					Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
+				},
+			}},
+			RestartPolicy: corev1.RestartPolicyAlways,
+		},
+	}
+}
+
+// netpolIsAllowed attempts a TCP connection from podName in namespace to targetIP:targetPort
+// and returns true if it completes within tcpProbeTimeout seconds 
+func netpolIsAllowed(namespace, podName, targetIP string, targetPort int) bool {
+	cmd := exec.Command("kubectl", "exec",
+		"-n", namespace, podName,
+		"-c", "probe", "--",
+		"bash", "-c",
+		fmt.Sprintf(
+			"timeout %d bash -c 'echo > /dev/tcp/%s/%d' 2>/dev/null; code=$?; [ $code -ne 124 ]",
+			tcpProbeTimeout, targetIP, targetPort,
+		),
+	)
+	output, err := cmd.CombinedOutput()
+	GinkgoWriter.Printf("netpolIsAllowed %s/%s → %s:%d err=%v out=%q\n",
+		namespace, podName, targetIP, targetPort, err, strings.TrimSpace(string(output)))
+	return err == nil
+}


### PR DESCRIPTION
Implement NetworkPolicies for operand components in the openshift-builds namespace to prevent lateral movement and data exfiltration. Added default-deny-all with explicit allow rules for K8s API egress, webhook ingress from openshift-kube-apiserver, and metrics ingress from openshift-monitoring. Includes an e2e test verifying both YAML deployment and actual network connectivity.