### PR TITLE
Add automated cherry-pick workflow

### DIFF
--- a/.github/workflows/cherrypick.yaml
+++ b/.github/workflows/cherrypick.yaml
@@ -1,0 +1,29 @@
+name: Cherry pick merged pull request
+on:
+  pull_request_target:
+    types: [labeled, closed]
+permissions:
+  contents: write
+  pull-requests: write
+jobs:
+  backport:
+    name: Cherry pick pull request
+    runs-on: ubuntu-latest
+    if: >
+      github.event.pull_request.merged == true &&
+      (
+        (github.event.action == 'closed') ||
+        (github.event.action == 'labeled' && startsWith(github.event.label.name, 'builds-'))
+      )
+    steps:
+      - uses: actions/checkout@v4
+      - name: Create cherry pick pull requests
+        uses: korthout/backport-action@v4
+        with:
+          label_pattern: (builds-[\w.]+)
+          branch_name: cherrypick-${pull_number}-to-${target_branch}
+          pull_title: >
+            Automated cherry pick of #${pull_number}: ${pull_title}
+          pull_description: |
+            # Description
+            Automated cherry pick of #${pull_number}.


### PR DESCRIPTION
# Changes
- Add automated cherry-pick workflow in GitHub action.
- Workflow triggers when a label with builds release branch name is added
- Update the result of action in the origin PR