### PR TITLE
fix(deps): bump tekton/pipeline to v1.6.1, update go-toolset base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/ubi9/go-toolset@sha256:1e1c89558f8bf86db3d88e5d5de0b6bd396ef948749a2c5d6a752ea46f35d4db AS builder
+FROM registry.redhat.io/ubi9/go-toolset@sha256:d637b9dfccb16623f19b95c43fe5a65b20b722e62753c4445c5d02f9e40b807d AS builder
 
 USER 1001
 

--- a/go.mod
+++ b/go.mod
@@ -92,7 +92,7 @@ require (
 	github.com/spf13/afero v1.15.0 // indirect
 	github.com/spf13/cobra v1.10.1 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
-	github.com/tektoncd/pipeline v1.6.0 // indirect
+	github.com/tektoncd/pipeline v1.6.1 // indirect
 	github.com/tektoncd/triggers v0.33.0 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	github.com/xlab/treeprint v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -714,8 +714,8 @@ github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD
 github.com/stvp/go-udp-testing v0.0.0-20201019212854-469649b16807/go.mod h1:7jxmlfBCDBXRzr0eAQJ48XC1hBu1np4CS5+cHEYfwpc=
 github.com/tektoncd/operator v0.77.0 h1:GaNvJnjMOhvUyAarBK+h31zTHgjSQjhIXP2oY7iPAxk=
 github.com/tektoncd/operator v0.77.0/go.mod h1:dBgVRdA8uQYoCMXda5l11u5yNmQzvMkgRjMJE7EgWpI=
-github.com/tektoncd/pipeline v1.6.0 h1:A+D+jzOVl2QNl/yiNT7csVgBUy2wpz6K6+/D4q5lfss=
-github.com/tektoncd/pipeline v1.6.0/go.mod h1:5SNoYgRYPQopkv7ApVq5GO3JqPk2AjV+VMMjwBsbJOg=
+github.com/tektoncd/pipeline v1.6.1 h1:DLeA6gVQrDHw9hy7eI48rOp2MO+Fwawj1+AcgSpJysk=
+github.com/tektoncd/pipeline v1.6.1/go.mod h1:5SNoYgRYPQopkv7ApVq5GO3JqPk2AjV+VMMjwBsbJOg=
 github.com/tektoncd/triggers v0.33.0 h1:pG2Kz/2FHjysGG4GGhiGp9hHdwA8BLZI3H7m9U9sj4M=
 github.com/tektoncd/triggers v0.33.0/go.mod h1:V2CTUxZB6zwymfeUnsZqFEwtkN6ClT+chtxr03N3L7c=
 github.com/tidwall/gjson v1.18.0 h1:FIDeeyB800efLX89e5a8Y0BNH+LOngJyGrIWxG2FKQY=

--- a/vendor/github.com/tektoncd/pipeline/pkg/apis/pipeline/pod/template.go
+++ b/vendor/github.com/tektoncd/pipeline/pkg/apis/pipeline/pod/template.go
@@ -132,6 +132,18 @@ type Template struct {
 	// +optional
 	HostNetwork bool `json:"hostNetwork,omitempty"`
 
+	// HostUsers indicates whether the pod will use the host's user namespace.
+	// Optional: Default to true.
+	// If set to true or not present, the pod will be run in the host user namespace, useful
+	// for when the pod needs a feature only available to the host user namespace, such as
+	// loading a kernel module with CAP_SYS_MODULE.
+	// When set to false, a new user namespace is created for the pod. Setting false
+	// is useful to mitigating container breakout vulnerabilities such as allowing
+	// containers to run as root without their user having root privileges on the host.
+	// This field depends on the kubernetes feature gate UserNamespacesSupport being enabled.
+	// +optional
+	HostUsers *bool `json:"hostUsers,omitempty"`
+
 	// TopologySpreadConstraints controls how Pods are spread across your cluster among
 	// failure-domains such as regions, zones, nodes, and other user-defined topology domains.
 	// +optional
@@ -228,6 +240,9 @@ func MergePodTemplateWithDefault(tpl, defaultTpl *PodTemplate) *PodTemplate {
 		}
 		if !tpl.HostNetwork && defaultTpl.HostNetwork {
 			tpl.HostNetwork = true
+		}
+		if tpl.HostUsers == nil {
+			tpl.HostUsers = defaultTpl.HostUsers
 		}
 		if tpl.TopologySpreadConstraints == nil {
 			tpl.TopologySpreadConstraints = defaultTpl.TopologySpreadConstraints

--- a/vendor/github.com/tektoncd/pipeline/pkg/apis/pipeline/pod/zz_generated.deepcopy.go
+++ b/vendor/github.com/tektoncd/pipeline/pkg/apis/pipeline/pod/zz_generated.deepcopy.go
@@ -153,6 +153,11 @@ func (in *Template) DeepCopyInto(out *Template) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.HostUsers != nil {
+		in, out := &in.HostUsers, &out.HostUsers
+		*out = new(bool)
+		**out = **in
+	}
 	if in.TopologySpreadConstraints != nil {
 		in, out := &in.TopologySpreadConstraints, &out.TopologySpreadConstraints
 		*out = make([]v1.TopologySpreadConstraint, len(*in))

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -317,7 +317,7 @@ github.com/tektoncd/operator/pkg/client/clientset/versioned/scheme
 github.com/tektoncd/operator/pkg/client/clientset/versioned/typed/operator/v1alpha1
 github.com/tektoncd/operator/pkg/common
 github.com/tektoncd/operator/pkg/reconciler/openshift
-# github.com/tektoncd/pipeline v1.6.0
+# github.com/tektoncd/pipeline v1.6.1
 ## explicit; go 1.24.0
 github.com/tektoncd/pipeline/pkg/apis/config
 github.com/tektoncd/pipeline/pkg/apis/pipeline/pod


### PR DESCRIPTION
## CVE Fix

Fixes CVE-2026-33211, CVE-2026-33186.

### Changes
- Bumped `github.com/tektoncd/pipeline` from v1.6.0 to v1.6.1 (fixes CVE-2026-33211)
- Updated `go-toolset` base image SHA in Dockerfile (picks up latest go1.25.8 image)

### Notes
- `google.golang.org/grpc` is already at v1.80.0 on main (above fix version v1.79.3), so no bump needed for CVE-2026-33186
- This PR contains only dependency bumps — no version/release label changes
- Cherry-picks to `builds-1.6` and `builds-1.7` will follow after merge

Co-Authored-By: Claude Opus 4.6 <noreply>