### PR TITLE
[BUILD-1905, BUILD-1891] builds-1.6: fix(deps): update operator digest

### DIFF
--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -15,6 +15,7 @@ LABEL operators.operatorframework.io.test.config.v1=tests/scorecard/
 
 LABEL com.redhat.openshift.versions="v4.16-v4." \
     com.redhat.component="openshift-builds-operator-bundle-container" \
+    cpe="cpe:/a:redhat:openshift_builds:1.6::el9" \
     description="Red Hat OpenShift Builds Operator Bundle" \
     distribution-scope="public" \
     io.k8s.description="Red Hat OpenShift Builds Operator Bundle" \

--- a/bundle/manifests/openshift-builds-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/openshift-builds-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -4,7 +4,7 @@ metadata:
   creationTimestamp: null
   labels:
     app.kubernetes.io/part-of: openshift-builds
-    app.kubernetes.io/version: 1.6.0
+    app.kubernetes.io/version: 1.6.5
   name: openshift-builds-metrics-reader
 rules:
 - nonResourceURLs:

--- a/bundle/manifests/openshift-builds-operator-metrics_v1_service.yaml
+++ b/bundle/manifests/openshift-builds-operator-metrics_v1_service.yaml
@@ -4,7 +4,7 @@ metadata:
   creationTimestamp: null
   labels:
     app.kubernetes.io/part-of: openshift-builds
-    app.kubernetes.io/version: 1.6.0
+    app.kubernetes.io/version: 1.6.5
   name: openshift-builds-operator-metrics
 spec:
   ports:

--- a/bundle/manifests/openshift-builds-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/openshift-builds-operator.clusterserviceversion.yaml
@@ -36,7 +36,7 @@ metadata:
     categories: Developer Tools, Integration & Delivery
     certified: "true"
     containerImage: registry.redhat.io/openshift-builds/openshift-builds-rhel9-operator
-    createdAt: "2026-02-02T10:25:33Z"
+    createdAt: "2026-04-22T11:31:28Z"
     description: Builds for Red Hat OpenShift is a framework for building container images on Kubernetes.
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
@@ -809,7 +809,7 @@ spec:
         - label:
             app: openshift-builds-operator
             app.kubernetes.io/part-of: openshift-builds
-            app.kubernetes.io/version: 1.6.0
+            app.kubernetes.io/version: 1.6.5
             control-plane: controller-manager
           name: openshift-builds-operator
           spec:
@@ -872,7 +872,7 @@ spec:
                         value: registry.redhat.io/openshift-builds/openshift-builds-waiters-rhel9@sha256:9463393cf84d7af4b7c7ce866ed99f5c2d6ccd361d7297f9bf6e1da2a4f73981
                       - name: IMAGE_SHIPWRIGHT_SHIPWRIGHT_BUILD_WEBHOOK
                         value: registry.redhat.io/openshift-builds/openshift-builds-webhook-rhel9@sha256:6bd51f6317c71ec3a409af86cb3524affe5b4538ba563a475f953c3e53edd49d
-                    image: registry.redhat.io/openshift-builds/openshift-builds-rhel9-operator@sha256:723b3b3f88d5e8ccd51b03e7c5049d6b06cbc6ebd4fce7e39d102f7b72ad6ca0
+                    image: registry.redhat.io/openshift-builds/openshift-builds-rhel9-operator@sha256:9de266888f795c0f532c335474dd6d71bb14906d4472cce0e362814683423976
                     imagePullPolicy: Always
                     livenessProbe:
                       httpGet:
@@ -967,7 +967,7 @@ spec:
     name: Red Hat
     url: https://www.redhat.com
   relatedImages:
-    - image: registry.redhat.io/openshift-builds/openshift-builds-rhel9-operator@sha256:723b3b3f88d5e8ccd51b03e7c5049d6b06cbc6ebd4fce7e39d102f7b72ad6ca0
+    - image: registry.redhat.io/openshift-builds/openshift-builds-rhel9-operator@sha256:9de266888f795c0f532c335474dd6d71bb14906d4472cce0e362814683423976
       name: OPENSHIFT_BUILDS_OPERATOR
     - image: registry.redhat.io/openshift-builds/openshift-builds-controller-rhel9@sha256:fbe2d63520b188d3e29dee041b054637ce023cef209a917f80b74c3c1238c8e4
       name: OPENSHIFT_BUILDS_CONTROLLER

--- a/bundle/manifests/openshift-builds-shared-resource-node-privileged-binding_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
+++ b/bundle/manifests/openshift-builds-shared-resource-node-privileged-binding_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
@@ -4,7 +4,7 @@ metadata:
   creationTimestamp: null
   labels:
     app.kubernetes.io/part-of: openshift-builds
-    app.kubernetes.io/version: 1.6.0
+    app.kubernetes.io/version: 1.6.5
   name: openshift-builds-shared-resource-node-privileged-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/bundle/manifests/openshift-builds-shared-resource-privileged-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/openshift-builds-shared-resource-privileged-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -4,7 +4,7 @@ metadata:
   creationTimestamp: null
   labels:
     app.kubernetes.io/part-of: openshift-builds
-    app.kubernetes.io/version: 1.6.0
+    app.kubernetes.io/version: 1.6.5
   name: openshift-builds-shared-resource-privileged-role
 rules:
 - apiGroups:

--- a/bundle/manifests/openshift-builds-shared-resource-prometheus_rbac.authorization.k8s.io_v1_role.yaml
+++ b/bundle/manifests/openshift-builds-shared-resource-prometheus_rbac.authorization.k8s.io_v1_role.yaml
@@ -4,7 +4,7 @@ metadata:
   creationTimestamp: null
   labels:
     app.kubernetes.io/part-of: openshift-builds
-    app.kubernetes.io/version: 1.6.0
+    app.kubernetes.io/version: 1.6.5
   name: openshift-builds-shared-resource-prometheus
 rules:
 - apiGroups:

--- a/bundle/manifests/openshift-builds-shared-resource-prometheus_rbac.authorization.k8s.io_v1_rolebinding.yaml
+++ b/bundle/manifests/openshift-builds-shared-resource-prometheus_rbac.authorization.k8s.io_v1_rolebinding.yaml
@@ -4,7 +4,7 @@ metadata:
   creationTimestamp: null
   labels:
     app.kubernetes.io/part-of: openshift-builds
-    app.kubernetes.io/version: 1.6.0
+    app.kubernetes.io/version: 1.6.5
   name: openshift-builds-shared-resource-prometheus
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/bundle/manifests/operator.openshift.io_openshiftbuilds.yaml
+++ b/bundle/manifests/operator.openshift.io_openshiftbuilds.yaml
@@ -6,7 +6,7 @@ metadata:
   creationTimestamp: null
   labels:
     app.kubernetes.io/part-of: openshift-builds
-    app.kubernetes.io/version: 1.6.0
+    app.kubernetes.io/version: 1.6.5
   name: openshiftbuilds.operator.openshift.io
 spec:
   group: operator.openshift.io

--- a/bundle/manifests/operator.shipwright.io_shipwrightbuilds.yaml
+++ b/bundle/manifests/operator.shipwright.io_shipwrightbuilds.yaml
@@ -6,7 +6,7 @@ metadata:
   creationTimestamp: null
   labels:
     app.kubernetes.io/part-of: openshift-builds
-    app.kubernetes.io/version: 1.6.0
+    app.kubernetes.io/version: 1.6.5
   name: shipwrightbuilds.operator.shipwright.io
 spec:
   group: operator.shipwright.io

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -14,7 +14,7 @@ namePrefix: openshift-builds-
 labels:
   - pairs:
       app.kubernetes.io/part-of: openshift-builds
-      app.kubernetes.io/version: 1.6.4
+      app.kubernetes.io/version: 1.6.5
 
 resources:
 - ../crd

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -3,6 +3,6 @@ resources:
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
-- digest: sha256:723b3b3f88d5e8ccd51b03e7c5049d6b06cbc6ebd4fce7e39d102f7b72ad6ca0
+- digest: sha256:9de266888f795c0f532c335474dd6d71bb14906d4472cce0e362814683423976
   name: operator
   newName: registry.redhat.io/openshift-builds/openshift-builds-rhel9-operator

--- a/config/manifests/bases/openshift-builds-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/openshift-builds-operator.clusterserviceversion.yaml
@@ -40,9 +40,7 @@ spec:
         kind: ShipwrightBuild
         name: shipwrightbuilds.operator.shipwright.io
         version: v1alpha1
-      - description: |-
-          OpenShiftBuild describes the desired state of Builds for OpenShift, and the status of
-          all deployed components.
+      - description: OpenShiftBuild describes the desired state of Builds for OpenShift, and the status of all deployed components.
         displayName: Open Shift Build
         kind: OpenShiftBuild
         name: openshiftbuilds.operator.openshift.io
@@ -85,7 +83,7 @@ spec:
     name: Red Hat
     url: https://www.redhat.com
   relatedImages:
-    - image: registry.redhat.io/openshift-builds/openshift-builds-rhel9-operator@sha256:723b3b3f88d5e8ccd51b03e7c5049d6b06cbc6ebd4fce7e39d102f7b72ad6ca0
+    - image: registry.redhat.io/openshift-builds/openshift-builds-rhel9-operator@sha256:9de266888f795c0f532c335474dd6d71bb14906d4472cce0e362814683423976
       name: OPENSHIFT_BUILDS_OPERATOR
     - image: registry.redhat.io/openshift-builds/openshift-builds-controller-rhel9@sha256:fbe2d63520b188d3e29dee041b054637ce023cef209a917f80b74c3c1238c8e4
       name: OPENSHIFT_BUILDS_CONTROLLER
@@ -111,4 +109,4 @@ spec:
       name: OPENSHIFT_BUILDS_BUILDAH
     - image: registry.redhat.io/source-to-image/source-to-image-rhel9@sha256:70293cb8a80aa548933ff5f502bac89945a5cd08801c4ca3aac08a10dd01f62f
       name: OPENSHIFT_BUILDS_SOURCE_TO_IMAGE
-  version: 1.6.4
+  version: 1.6.5

--- a/config/shipwright/build/strategy/buildah.yaml
+++ b/config/shipwright/build/strategy/buildah.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   steps:
     - name: build-and-push
-      image: registry.redhat.io/ubi9/buildah@sha256:4a267751427aa3a4df3e66a789f034446b3fb274b882572f22ad99106f87fdb7
+      image: registry.redhat.io/ubi9/buildah@sha256:2b1f0c98e7527341df4b3caa7228c53228e5594e75ba38721f21719d84a24282
       imagePullPolicy: Always
       workingDir: $(params.shp-source-root)
       securityContext:

--- a/config/shipwright/build/strategy/buildpacks-extender.yaml
+++ b/config/shipwright/build/strategy/buildpacks-extender.yaml
@@ -15,13 +15,13 @@ spec:
   parameters:
     - name: cnb-platform-api
       description: Platform API Version supported
-      default: "0.12"
+      default: "0.14"
     - name: cnb-builder-image
       description: Builder image containing the buildpacks. This is also the image the extender will use if kind=build.
       default: ""
     - name: cnb-lifecycle-image
       description: The image to use when executing Lifecycle phases.
-      default: "buildpacksio/lifecycle:0.20.8"
+      default: "buildpacksio/lifecycle:0.21.5"
     - name: cnb-log-level
       description: Logging level
       default: "debug"
@@ -65,7 +65,7 @@ spec:
       default: "/layers/extended"
   steps:
     - name: prepare
-      image: registry.access.redhat.com/ubi9/ubi@sha256:2e4eebec441e8bbc3459fcc83ddee0f7d3cfd219097b4110a37d7ff4fe0ff2e9
+      image: registry.access.redhat.com/ubi9/ubi@sha256:cecb1cde7bda7c8165ae27841c2335667f8a3665a349c0d051329c61660a496c
       args:
         - -c
         - |
@@ -308,7 +308,7 @@ spec:
         - name: empty-dir
           mountPath: /platform
     - name: results
-      image: registry.access.redhat.com/ubi9/ubi@sha256:2e4eebec441e8bbc3459fcc83ddee0f7d3cfd219097b4110a37d7ff4fe0ff2e9
+      image: registry.access.redhat.com/ubi9/ubi@sha256:cecb1cde7bda7c8165ae27841c2335667f8a3665a349c0d051329c61660a496c
       args:
         - -c
         - |

--- a/config/shipwright/build/strategy/buildpacks.yaml
+++ b/config/shipwright/build/strategy/buildpacks.yaml
@@ -15,13 +15,13 @@ spec:
   parameters:
     - name: cnb-platform-api
       description: Platform API Version supported
-      default: "0.12"
+      default: "0.14"
     - name: cnb-builder-image
       description: Builder image containing the buildpacks. This is also the image the extender will use if kind=build.
       default: ""
     - name: cnb-lifecycle-image
       description: The image to use when executing Lifecycle phases.
-      default: "buildpacksio/lifecycle:0.20.8"
+      default: "buildpacksio/lifecycle:0.21.5"
     - name: cnb-log-level
       description: Logging level
       default: "debug"
@@ -65,7 +65,7 @@ spec:
       default: "/layers/extended"
   steps:
     - name: prepare
-      image: registry.access.redhat.com/ubi9/ubi@sha256:2e4eebec441e8bbc3459fcc83ddee0f7d3cfd219097b4110a37d7ff4fe0ff2e9
+      image: registry.access.redhat.com/ubi9/ubi@sha256:cecb1cde7bda7c8165ae27841c2335667f8a3665a349c0d051329c61660a496c
       args:
         - -c
         - |
@@ -278,7 +278,7 @@ spec:
         - name: empty-dir
           mountPath: /platform
     - name: results
-      image: registry.access.redhat.com/ubi9/ubi@sha256:2e4eebec441e8bbc3459fcc83ddee0f7d3cfd219097b4110a37d7ff4fe0ff2e9
+      image: registry.access.redhat.com/ubi9/ubi@sha256:cecb1cde7bda7c8165ae27841c2335667f8a3665a349c0d051329c61660a496c
       args:
         - -c
         - |

--- a/config/shipwright/build/strategy/source-to-image.yaml
+++ b/config/shipwright/build/strategy/source-to-image.yaml
@@ -12,7 +12,7 @@ spec:
       overridable: true
   buildSteps:
     - name: s2i-generate
-      image: registry.redhat.io/source-to-image/source-to-image-rhel9@sha256:70293cb8a80aa548933ff5f502bac89945a5cd08801c4ca3aac08a10dd01f62f
+      image: registry.redhat.io/source-to-image/source-to-image-rhel9@sha256:0e4e2bfcdc07ff0edfdba792acab8afeaf697c8d9048ea3fee0de63ba8678f69
       workingDir: $(params.shp-source-root)
       command: 
         - /usr/local/bin/s2i
@@ -28,7 +28,7 @@ spec:
         - name: etc-pki-entitlement
           mountPath: /etc/pki/entitlement
     - name: buildah
-      image: registry.redhat.io/ubi9/buildah@sha256:4a267751427aa3a4df3e66a789f034446b3fb274b882572f22ad99106f87fdb7
+      image: registry.redhat.io/ubi9/buildah@sha256:2b1f0c98e7527341df4b3caa7228c53228e5594e75ba38721f21719d84a24282
       workingDir: /s2i
       securityContext:
         capabilities:


### PR DESCRIPTION
## CVE Fix

Fixes CVE-2026-33186, CVE-2026-33211.

### Changes
- Updated operator image digest from Konflux snapshot `openshift-builds-1-6-20260422-102246-000`
- Fixed stale version labels (1.6.4 → 1.6.5) in `config/default/kustomization.yaml` and `config/manifests/bases/` CSV
- Added missing `cpe` label to `bundle.Dockerfile` to fix EC required labels warning
- Regenerated bundle manifests via `make bundle`

### Jira Issues
Resolves: BUILD-1905, BUILD-1891

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>