### PR TITLE
[BUILD-1914, BUILD-1898] builds-1.7: fix(deps): update operator digest

### DIFF
--- a/bundle/manifests/openshift-builds-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/openshift-builds-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -4,7 +4,7 @@ metadata:
   creationTimestamp: null
   labels:
     app.kubernetes.io/part-of: openshift-builds
-    app.kubernetes.io/version: 1.7.0
+    app.kubernetes.io/version: 1.7.2
   name: openshift-builds-metrics-reader
 rules:
 - nonResourceURLs:

--- a/bundle/manifests/openshift-builds-operator-metrics_v1_service.yaml
+++ b/bundle/manifests/openshift-builds-operator-metrics_v1_service.yaml
@@ -4,7 +4,7 @@ metadata:
   creationTimestamp: null
   labels:
     app.kubernetes.io/part-of: openshift-builds
-    app.kubernetes.io/version: 1.7.0
+    app.kubernetes.io/version: 1.7.2
   name: openshift-builds-operator-metrics
 spec:
   ports:

--- a/bundle/manifests/openshift-builds-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/openshift-builds-operator.clusterserviceversion.yaml
@@ -36,7 +36,7 @@ metadata:
     categories: Developer Tools, Integration & Delivery
     certified: "true"
     containerImage: registry.redhat.io/openshift-builds/openshift-builds-operator-rhel9
-    createdAt: "2026-02-25T14:43:02Z"
+    createdAt: "2026-04-22T11:23:34Z"
     description: Builds for Red Hat OpenShift is a framework for building container images on Kubernetes.
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
@@ -286,12 +286,15 @@ spec:
             - apiGroups:
                 - ""
               resources:
-                - configmaps
+                - endpoints
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - ""
+              resources:
                 - events
-                - limitranges
-                - namespaces
-                - pods
-                - secrets
                 - services
               verbs:
                 - create
@@ -302,44 +305,18 @@ spec:
                 - update
                 - watch
             - apiGroups:
-                - ""
+                - admissionregistration.k8s.io
               resources:
-                - endpoints
-              verbs:
-                - get
-                - list
-                - watch
-            - apiGroups:
-                - ""
-              resources:
-                - serviceaccounts
+                - validatingwebhookconfigurations
               verbs:
                 - create
+                - delete
                 - get
                 - list
+                - patch
+                - update
                 - watch
             - apiGroups:
-                - ""
-              resourceNames:
-                - shipwright-build-controller
-              resources:
-                - serviceaccounts
-              verbs:
-                - delete
-                - patch
-                - update
-            - apiGroups:
-                - ""
-              resourceNames:
-                - shipwright-build-webhook
-              resources:
-                - serviceaccounts
-              verbs:
-                - delete
-                - patch
-                - update
-            - apiGroups:
-                - admissionregistration.k8s.io
                 - admissionregistration.k8s.io/v1beta1
               resources:
                 - validatingwebhookconfigurations
@@ -392,6 +369,16 @@ spec:
                 - apps
               resources:
                 - daemonsets
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - update
+                - watch
+            - apiGroups:
+                - apps
+              resources:
                 - deployments
               verbs:
                 - create
@@ -436,6 +423,15 @@ spec:
                 - deployments/finalizers
               verbs:
                 - update
+            - apiGroups:
+                - cert-manager.io
+              resources:
+                - certificates
+              verbs:
+                - create
+                - get
+                - list
+                - watch
             - apiGroups:
                 - cert-manager.io
               resourceNames:
@@ -449,7 +445,6 @@ spec:
             - apiGroups:
                 - cert-manager.io
               resources:
-                - certificates
                 - issuers
               verbs:
                 - create
@@ -462,6 +457,65 @@ spec:
                 - selfsigned-issuer
               resources:
                 - issuers
+              verbs:
+                - delete
+                - patch
+                - update
+            - apiGroups:
+                - ""
+              resources:
+                - configmaps
+                - events
+                - limitranges
+                - namespaces
+                - pods
+                - secrets
+                - services
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - ""
+              resources:
+                - namespaces
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - ""
+              resources:
+                - serviceaccounts
+              verbs:
+                - create
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - ""
+              resourceNames:
+                - shipwright-build-controller
+              resources:
+                - serviceaccounts
+              verbs:
+                - delete
+                - patch
+                - update
+            - apiGroups:
+                - ""
+              resourceNames:
+                - shipwright-build-webhook
+              resources:
+                - serviceaccounts
               verbs:
                 - delete
                 - patch
@@ -552,6 +606,35 @@ spec:
                 - rbac.authorization.k8s.io
               resources:
                 - clusterrolebindings
+              verbs:
+                - create
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - rbac.authorization.k8s.io
+              resourceNames:
+                - shipwright-build-controller
+              resources:
+                - clusterrolebindings
+              verbs:
+                - delete
+                - patch
+                - update
+            - apiGroups:
+                - rbac.authorization.k8s.io
+              resourceNames:
+                - shipwright-build-webhook
+              resources:
+                - clusterrolebindings
+              verbs:
+                - delete
+                - patch
+                - update
+            - apiGroups:
+                - rbac.authorization.k8s.io
+              resources:
+                - clusterrolebindings
                 - clusterroles
                 - rolebindings
                 - roles
@@ -564,30 +647,13 @@ spec:
                 - watch
             - apiGroups:
                 - rbac.authorization.k8s.io
-              resourceNames:
-                - shipwright-build-controller
               resources:
-                - clusterrolebindings
                 - clusterroles
-                - rolebindings
-                - roles
               verbs:
-                - delete
-                - patch
-                - update
-            - apiGroups:
-                - rbac.authorization.k8s.io
-              resourceNames:
-                - shipwright-build-webhook
-              resources:
-                - clusterrolebindings
-                - clusterroles
-                - rolebindings
-                - roles
-              verbs:
-                - delete
-                - patch
-                - update
+                - create
+                - get
+                - list
+                - watch
             - apiGroups:
                 - rbac.authorization.k8s.io
               resourceNames:
@@ -604,6 +670,84 @@ spec:
                 - shipwright-build-aggregate-view
               resources:
                 - clusterroles
+              verbs:
+                - delete
+                - patch
+                - update
+            - apiGroups:
+                - rbac.authorization.k8s.io
+              resourceNames:
+                - shipwright-build-controller
+              resources:
+                - clusterroles
+              verbs:
+                - delete
+                - patch
+                - update
+            - apiGroups:
+                - rbac.authorization.k8s.io
+              resourceNames:
+                - shipwright-build-webhook
+              resources:
+                - clusterroles
+              verbs:
+                - delete
+                - patch
+                - update
+            - apiGroups:
+                - rbac.authorization.k8s.io
+              resources:
+                - rolebindings
+              verbs:
+                - create
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - rbac.authorization.k8s.io
+              resourceNames:
+                - shipwright-build-controller
+              resources:
+                - rolebindings
+              verbs:
+                - delete
+                - patch
+                - update
+            - apiGroups:
+                - rbac.authorization.k8s.io
+              resourceNames:
+                - shipwright-build-webhook
+              resources:
+                - rolebindings
+              verbs:
+                - delete
+                - patch
+                - update
+            - apiGroups:
+                - rbac.authorization.k8s.io
+              resources:
+                - roles
+              verbs:
+                - create
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - rbac.authorization.k8s.io
+              resourceNames:
+                - shipwright-build-controller
+              resources:
+                - roles
+              verbs:
+                - delete
+                - patch
+                - update
+            - apiGroups:
+                - rbac.authorization.k8s.io
+              resourceNames:
+                - shipwright-build-webhook
+              resources:
+                - roles
               verbs:
                 - delete
                 - patch
@@ -666,7 +810,7 @@ spec:
         - label:
             app: openshift-builds-operator
             app.kubernetes.io/part-of: openshift-builds
-            app.kubernetes.io/version: 1.7.1
+            app.kubernetes.io/version: 1.7.2
             control-plane: controller-manager
           name: openshift-builds-operator
           spec:
@@ -729,7 +873,7 @@ spec:
                         value: registry.redhat.io/openshift-builds/openshift-builds-waiters-rhel9@sha256:06d0ae4b03f25380a484b0fa4379422115227c3aa70ab31e483f2da0c210bdb0
                       - name: IMAGE_SHIPWRIGHT_SHIPWRIGHT_BUILD_WEBHOOK
                         value: registry.redhat.io/openshift-builds/openshift-builds-webhook-rhel9@sha256:e01be356c0fc6ec7035a489bb5d8f0c6aaf386ae7a7655fe9e4bdc03a7f822ad
-                    image: registry.redhat.io/openshift-builds/openshift-builds-rhel9-operator@sha256:1c49758610cfe99b37072dca97a79051992cf191875f45928d688f3f5691c18b
+                    image: registry.redhat.io/openshift-builds/openshift-builds-rhel9-operator@sha256:2f45dd946fd8fe76be14e9f998b588b9dd89718464e97ee44748edda9e74fccd
                     imagePullPolicy: Always
                     livenessProbe:
                       httpGet:
@@ -824,7 +968,7 @@ spec:
     name: Red Hat
     url: https://www.redhat.com
   relatedImages:
-    - image: registry.redhat.io/openshift-builds/openshift-builds-rhel9-operator@sha256:1c49758610cfe99b37072dca97a79051992cf191875f45928d688f3f5691c18b
+    - image: registry.redhat.io/openshift-builds/openshift-builds-rhel9-operator@sha256:2f45dd946fd8fe76be14e9f998b588b9dd89718464e97ee44748edda9e74fccd
       name: OPENSHIFT_BUILDS_OPERATOR
     - image: registry.redhat.io/openshift-builds/openshift-builds-controller-rhel9@sha256:475929d87df047d4d85b0f5fa0da61dccc8b76682f22dca0baded665f1ea1ed0
       name: OPENSHIFT_BUILDS_CONTROLLER

--- a/bundle/manifests/openshift-builds-shared-resource-node-privileged-binding_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
+++ b/bundle/manifests/openshift-builds-shared-resource-node-privileged-binding_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
@@ -4,7 +4,7 @@ metadata:
   creationTimestamp: null
   labels:
     app.kubernetes.io/part-of: openshift-builds
-    app.kubernetes.io/version: 1.7.0
+    app.kubernetes.io/version: 1.7.2
   name: openshift-builds-shared-resource-node-privileged-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/bundle/manifests/openshift-builds-shared-resource-privileged-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/openshift-builds-shared-resource-privileged-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -4,7 +4,7 @@ metadata:
   creationTimestamp: null
   labels:
     app.kubernetes.io/part-of: openshift-builds
-    app.kubernetes.io/version: 1.7.0
+    app.kubernetes.io/version: 1.7.2
   name: openshift-builds-shared-resource-privileged-role
 rules:
 - apiGroups:

--- a/bundle/manifests/openshift-builds-shared-resource-prometheus_rbac.authorization.k8s.io_v1_role.yaml
+++ b/bundle/manifests/openshift-builds-shared-resource-prometheus_rbac.authorization.k8s.io_v1_role.yaml
@@ -4,7 +4,7 @@ metadata:
   creationTimestamp: null
   labels:
     app.kubernetes.io/part-of: openshift-builds
-    app.kubernetes.io/version: 1.7.0
+    app.kubernetes.io/version: 1.7.2
   name: openshift-builds-shared-resource-prometheus
 rules:
 - apiGroups:

--- a/bundle/manifests/openshift-builds-shared-resource-prometheus_rbac.authorization.k8s.io_v1_rolebinding.yaml
+++ b/bundle/manifests/openshift-builds-shared-resource-prometheus_rbac.authorization.k8s.io_v1_rolebinding.yaml
@@ -4,7 +4,7 @@ metadata:
   creationTimestamp: null
   labels:
     app.kubernetes.io/part-of: openshift-builds
-    app.kubernetes.io/version: 1.7.0
+    app.kubernetes.io/version: 1.7.2
   name: openshift-builds-shared-resource-prometheus
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/bundle/manifests/operator.openshift.io_openshiftbuilds.yaml
+++ b/bundle/manifests/operator.openshift.io_openshiftbuilds.yaml
@@ -2,11 +2,11 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.14.0
   creationTimestamp: null
   labels:
     app.kubernetes.io/part-of: openshift-builds
-    app.kubernetes.io/version: 1.7.0
+    app.kubernetes.io/version: 1.7.2
   name: openshiftbuilds.operator.openshift.io
 spec:
   group: operator.openshift.io
@@ -89,8 +89,16 @@ spec:
                 description: Conditions holds the latest available observations of
                   a resource's current state.
                 items:
-                  description: Condition contains details for one aspect of the current
-                    state of this API Resource.
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
                   properties:
                     lastTransitionTime:
                       description: |-
@@ -131,7 +139,12 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string

--- a/bundle/manifests/operator.shipwright.io_shipwrightbuilds.yaml
+++ b/bundle/manifests/operator.shipwright.io_shipwrightbuilds.yaml
@@ -6,7 +6,7 @@ metadata:
   creationTimestamp: null
   labels:
     app.kubernetes.io/part-of: openshift-builds
-    app.kubernetes.io/version: 1.7.0
+    app.kubernetes.io/version: 1.7.2
   name: shipwrightbuilds.operator.shipwright.io
 spec:
   group: operator.shipwright.io

--- a/config/crd/bases/operator.openshift.io_openshiftbuilds.yaml
+++ b/config/crd/bases/operator.openshift.io_openshiftbuilds.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: openshiftbuilds.operator.openshift.io
 spec:
   group: operator.openshift.io
@@ -86,8 +86,16 @@ spec:
                 description: Conditions holds the latest available observations of
                   a resource's current state.
                 items:
-                  description: Condition contains details for one aspect of the current
-                    state of this API Resource.
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
                   properties:
                     lastTransitionTime:
                       description: |-
@@ -128,7 +136,12 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -14,7 +14,7 @@ namePrefix: openshift-builds-
 labels:
   - pairs:
       app.kubernetes.io/part-of: openshift-builds
-      app.kubernetes.io/version: 1.7.0
+      app.kubernetes.io/version: 1.7.2
 
 resources:
 - ../crd

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,8 +1,8 @@
 resources:
-  - manager.yaml
+- manager.yaml
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
-  - digest: sha256:1c49758610cfe99b37072dca97a79051992cf191875f45928d688f3f5691c18b
-    name: operator
-    newName: registry.redhat.io/openshift-builds/openshift-builds-rhel9-operator
+- digest: sha256:2f45dd946fd8fe76be14e9f998b588b9dd89718464e97ee44748edda9e74fccd
+  name: operator
+  newName: registry.redhat.io/openshift-builds/openshift-builds-rhel9-operator

--- a/config/manifests/bases/openshift-builds-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/openshift-builds-operator.clusterserviceversion.yaml
@@ -83,7 +83,7 @@ spec:
     name: Red Hat
     url: https://www.redhat.com
   relatedImages:
-    - image: registry.redhat.io/openshift-builds/openshift-builds-rhel9-operator@sha256:1c49758610cfe99b37072dca97a79051992cf191875f45928d688f3f5691c18b
+    - image: registry.redhat.io/openshift-builds/openshift-builds-rhel9-operator@sha256:2f45dd946fd8fe76be14e9f998b588b9dd89718464e97ee44748edda9e74fccd
       name: OPENSHIFT_BUILDS_OPERATOR
     - image: registry.redhat.io/openshift-builds/openshift-builds-controller-rhel9@sha256:475929d87df047d4d85b0f5fa0da61dccc8b76682f22dca0baded665f1ea1ed0
       name: OPENSHIFT_BUILDS_CONTROLLER
@@ -109,4 +109,4 @@ spec:
       name: OPENSHIFT_BUILDS_BUILDAH
     - image: registry.redhat.io/source-to-image/source-to-image-rhel9@sha256:70293cb8a80aa548933ff5f502bac89945a5cd08801c4ca3aac08a10dd01f62f
       name: OPENSHIFT_BUILDS_SOURCE_TO_IMAGE
-  version: 1.7.1
+  version: 1.7.2

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -7,12 +7,15 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - configmaps
+  - endpoints
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - events
-  - limitranges
-  - namespaces
-  - pods
-  - secrets
   - services
   verbs:
   - create
@@ -23,44 +26,18 @@ rules:
   - update
   - watch
 - apiGroups:
-  - ""
+  - admissionregistration.k8s.io
   resources:
-  - endpoints
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - serviceaccounts
+  - validatingwebhookconfigurations
   verbs:
   - create
+  - delete
   - get
   - list
+  - patch
+  - update
   - watch
 - apiGroups:
-  - ""
-  resourceNames:
-  - shipwright-build-controller
-  resources:
-  - serviceaccounts
-  verbs:
-  - delete
-  - patch
-  - update
-- apiGroups:
-  - ""
-  resourceNames:
-  - shipwright-build-webhook
-  resources:
-  - serviceaccounts
-  verbs:
-  - delete
-  - patch
-  - update
-- apiGroups:
-  - admissionregistration.k8s.io
   - admissionregistration.k8s.io/v1beta1
   resources:
   - validatingwebhookconfigurations
@@ -113,6 +90,16 @@ rules:
   - apps
   resources:
   - daemonsets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
   - deployments
   verbs:
   - create
@@ -157,6 +144,15 @@ rules:
   - deployments/finalizers
   verbs:
   - update
+- apiGroups:
+  - cert-manager.io
+  resources:
+  - certificates
+  verbs:
+  - create
+  - get
+  - list
+  - watch
 - apiGroups:
   - cert-manager.io
   resourceNames:
@@ -170,7 +166,6 @@ rules:
 - apiGroups:
   - cert-manager.io
   resources:
-  - certificates
   - issuers
   verbs:
   - create
@@ -183,6 +178,65 @@ rules:
   - selfsigned-issuer
   resources:
   - issuers
+  verbs:
+  - delete
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - events
+  - limitranges
+  - namespaces
+  - pods
+  - secrets
+  - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resourceNames:
+  - shipwright-build-controller
+  resources:
+  - serviceaccounts
+  verbs:
+  - delete
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resourceNames:
+  - shipwright-build-webhook
+  resources:
+  - serviceaccounts
   verbs:
   - delete
   - patch
@@ -273,6 +327,35 @@ rules:
   - rbac.authorization.k8s.io
   resources:
   - clusterrolebindings
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resourceNames:
+  - shipwright-build-controller
+  resources:
+  - clusterrolebindings
+  verbs:
+  - delete
+  - patch
+  - update
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resourceNames:
+  - shipwright-build-webhook
+  resources:
+  - clusterrolebindings
+  verbs:
+  - delete
+  - patch
+  - update
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
   - clusterroles
   - rolebindings
   - roles
@@ -285,30 +368,13 @@ rules:
   - watch
 - apiGroups:
   - rbac.authorization.k8s.io
-  resourceNames:
-  - shipwright-build-controller
   resources:
-  - clusterrolebindings
   - clusterroles
-  - rolebindings
-  - roles
   verbs:
-  - delete
-  - patch
-  - update
-- apiGroups:
-  - rbac.authorization.k8s.io
-  resourceNames:
-  - shipwright-build-webhook
-  resources:
-  - clusterrolebindings
-  - clusterroles
-  - rolebindings
-  - roles
-  verbs:
-  - delete
-  - patch
-  - update
+  - create
+  - get
+  - list
+  - watch
 - apiGroups:
   - rbac.authorization.k8s.io
   resourceNames:
@@ -325,6 +391,84 @@ rules:
   - shipwright-build-aggregate-view
   resources:
   - clusterroles
+  verbs:
+  - delete
+  - patch
+  - update
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resourceNames:
+  - shipwright-build-controller
+  resources:
+  - clusterroles
+  verbs:
+  - delete
+  - patch
+  - update
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resourceNames:
+  - shipwright-build-webhook
+  resources:
+  - clusterroles
+  verbs:
+  - delete
+  - patch
+  - update
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resourceNames:
+  - shipwright-build-controller
+  resources:
+  - rolebindings
+  verbs:
+  - delete
+  - patch
+  - update
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resourceNames:
+  - shipwright-build-webhook
+  resources:
+  - rolebindings
+  verbs:
+  - delete
+  - patch
+  - update
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resourceNames:
+  - shipwright-build-controller
+  resources:
+  - roles
+  verbs:
+  - delete
+  - patch
+  - update
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resourceNames:
+  - shipwright-build-webhook
+  resources:
+  - roles
   verbs:
   - delete
   - patch

--- a/config/shipwright/build/strategy/buildah.yaml
+++ b/config/shipwright/build/strategy/buildah.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   steps:
     - name: build-and-push
-      image: registry.redhat.io/ubi9/buildah@sha256:4a267751427aa3a4df3e66a789f034446b3fb274b882572f22ad99106f87fdb7
+      image: registry.redhat.io/ubi9/buildah@sha256:2b1f0c98e7527341df4b3caa7228c53228e5594e75ba38721f21719d84a24282
       imagePullPolicy: Always
       workingDir: $(params.shp-source-root)
       securityContext:

--- a/config/shipwright/build/strategy/buildpacks-extender.yaml
+++ b/config/shipwright/build/strategy/buildpacks-extender.yaml
@@ -15,13 +15,13 @@ spec:
   parameters:
     - name: cnb-platform-api
       description: Platform API Version supported
-      default: "0.12"
+      default: "0.14"
     - name: cnb-builder-image
       description: Builder image containing the buildpacks. This is also the image the extender will use if kind=build.
       default: ""
     - name: cnb-lifecycle-image
       description: The image to use when executing Lifecycle phases.
-      default: "buildpacksio/lifecycle:0.20.8"
+      default: "buildpacksio/lifecycle:0.21.5"
     - name: cnb-log-level
       description: Logging level
       default: "debug"
@@ -65,7 +65,7 @@ spec:
       default: "/layers/extended"
   steps:
     - name: prepare
-      image: registry.access.redhat.com/ubi9/ubi@sha256:2e4eebec441e8bbc3459fcc83ddee0f7d3cfd219097b4110a37d7ff4fe0ff2e9
+      image: registry.access.redhat.com/ubi9/ubi@sha256:cecb1cde7bda7c8165ae27841c2335667f8a3665a349c0d051329c61660a496c
       args:
         - -c
         - |
@@ -308,7 +308,7 @@ spec:
         - name: empty-dir
           mountPath: /platform
     - name: results
-      image: registry.access.redhat.com/ubi9/ubi@sha256:2e4eebec441e8bbc3459fcc83ddee0f7d3cfd219097b4110a37d7ff4fe0ff2e9
+      image: registry.access.redhat.com/ubi9/ubi@sha256:cecb1cde7bda7c8165ae27841c2335667f8a3665a349c0d051329c61660a496c
       args:
         - -c
         - |

--- a/config/shipwright/build/strategy/buildpacks.yaml
+++ b/config/shipwright/build/strategy/buildpacks.yaml
@@ -15,13 +15,13 @@ spec:
   parameters:
     - name: cnb-platform-api
       description: Platform API Version supported
-      default: "0.12"
+      default: "0.14"
     - name: cnb-builder-image
       description: Builder image containing the buildpacks. This is also the image the extender will use if kind=build.
       default: ""
     - name: cnb-lifecycle-image
       description: The image to use when executing Lifecycle phases.
-      default: "buildpacksio/lifecycle:0.20.8"
+      default: "buildpacksio/lifecycle:0.21.5"
     - name: cnb-log-level
       description: Logging level
       default: "debug"
@@ -65,7 +65,7 @@ spec:
       default: "/layers/extended"
   steps:
     - name: prepare
-      image: registry.access.redhat.com/ubi9/ubi@sha256:2e4eebec441e8bbc3459fcc83ddee0f7d3cfd219097b4110a37d7ff4fe0ff2e9
+      image: registry.access.redhat.com/ubi9/ubi@sha256:cecb1cde7bda7c8165ae27841c2335667f8a3665a349c0d051329c61660a496c
       args:
         - -c
         - |
@@ -278,7 +278,7 @@ spec:
         - name: empty-dir
           mountPath: /platform
     - name: results
-      image: registry.access.redhat.com/ubi9/ubi@sha256:2e4eebec441e8bbc3459fcc83ddee0f7d3cfd219097b4110a37d7ff4fe0ff2e9
+      image: registry.access.redhat.com/ubi9/ubi@sha256:cecb1cde7bda7c8165ae27841c2335667f8a3665a349c0d051329c61660a496c
       args:
         - -c
         - |

--- a/config/shipwright/build/strategy/source-to-image.yaml
+++ b/config/shipwright/build/strategy/source-to-image.yaml
@@ -12,7 +12,7 @@ spec:
       overridable: true
   buildSteps:
     - name: s2i-generate
-      image: registry.redhat.io/source-to-image/source-to-image-rhel9@sha256:70293cb8a80aa548933ff5f502bac89945a5cd08801c4ca3aac08a10dd01f62f
+      image: registry.redhat.io/source-to-image/source-to-image-rhel9@sha256:0e4e2bfcdc07ff0edfdba792acab8afeaf697c8d9048ea3fee0de63ba8678f69
       workingDir: $(params.shp-source-root)
       command: 
         - /usr/local/bin/s2i
@@ -28,7 +28,7 @@ spec:
         - name: etc-pki-entitlement
           mountPath: /etc/pki/entitlement
     - name: buildah
-      image: registry.redhat.io/ubi9/buildah@sha256:4a267751427aa3a4df3e66a789f034446b3fb274b882572f22ad99106f87fdb7
+      image: registry.redhat.io/ubi9/buildah@sha256:2b1f0c98e7527341df4b3caa7228c53228e5594e75ba38721f21719d84a24282
       workingDir: /s2i
       securityContext:
         capabilities:


### PR DESCRIPTION
## CVE Fix

Fixes CVE-2026-33186, CVE-2026-33211.

### Changes
- Updated operator image digest from Konflux snapshot `openshift-builds-1-7-20260422-103819-000`
- Fixed stale version labels (1.7.0/1.7.1 → 1.7.2) in `config/default/kustomization.yaml` and `config/manifests/bases/` CSV
- Regenerated bundle manifests via `make bundle`

### Jira Issues
Resolves: BUILD-1914, BUILD-1898

Co-Authored-By: Claude Opus 4.6 <noreply>