### PR TITLE
[BUILD-2055] chore: prepare main for 1.8 release - update versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ ENTRYPOINT ["/operator"]
 
 LABEL \
     com.redhat.component="openshift-builds-operator" \
-    cpe="cpe:/a:redhat:openshift_builds:1.7::el9" \
+    cpe="cpe:/a:redhat:openshift_builds:1.8::el9" \
     description="Red Hat OpenShift Builds Operator" \
     distribution-scope="public" \
     io.k8s.description="Red Hat OpenShift Builds Operator" \
@@ -43,4 +43,4 @@ LABEL \
     summary="Red Hat OpenShift Builds Operator" \
     url="https://github.com/redhat-openshift-builds/operator" \
     vendor="Red Hat, Inc." \
-    version="v1.7.1"
+    version="v1.8.0"

--- a/Makefile
+++ b/Makefile
@@ -3,14 +3,14 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 1.7.1
+VERSION ?= 1.8.0
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")
 # To re-generate a bundle for other specific channels without changing the standard setup, you can:
 # - use the CHANNELS as arg of the bundle target (e.g make bundle CHANNELS=candidate,fast,stable)
 # - use environment variables to overwrite this value (e.g export CHANNELS="candidate,fast,stable")
-CHANNELS ?= "latest,openshift-builds-1.7"
+CHANNELS ?= "latest,openshift-builds-1.8"
 ifneq ($(origin CHANNELS), undefined)
 BUNDLE_CHANNELS := --channels=$(CHANNELS)
 endif

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -16,7 +16,7 @@ LABEL operators.operatorframework.io.test.config.v1=tests/scorecard/
 LABEL \
     com.redhat.openshift.versions="v4.16-v4.21" \
     com.redhat.component="openshift-builds-operator-bundle" \
-    cpe="cpe:/a:redhat:openshift_builds:1.7::el9" \
+    cpe="cpe:/a:redhat:openshift_builds:1.8::el9" \
     description="Red Hat OpenShift Builds Operator Bundle" \
     distribution-scope="public" \
     io.k8s.description="Red Hat OpenShift Builds Operator Bundle" \
@@ -28,7 +28,7 @@ LABEL \
     summary="Red Hat OpenShift Builds Operator Bundle" \
     url="https://github.com/redhat-openshift-builds/operator" \
     vendor="Red Hat, Inc." \
-    version="v1.7.1"
+    version="v1.8.0"
 
 COPY bundle/ /
 COPY LICENSE /licenses/


### PR DESCRIPTION
## Summary
- Updated Makefile VERSION to 1.8.0
- Updated Makefile CHANNELS to openshift-builds-1.8
- Updated Dockerfile and bundle.Dockerfile version/cpe labels

Assisted-By: Claude Code