### PR TITLE
builds-1.8: chore: update operator digest from Konflux snapshot

### DIFF
--- a/bundle/manifests/openshift-builds-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/openshift-builds-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -4,7 +4,7 @@ metadata:
   creationTimestamp: null
   labels:
     app.kubernetes.io/part-of: openshift-builds
-    app.kubernetes.io/version: 1.5.0
+    app.kubernetes.io/version: 1.8.0
   name: openshift-builds-metrics-reader
 rules:
 - nonResourceURLs:

--- a/bundle/manifests/openshift-builds-operator-metrics_v1_service.yaml
+++ b/bundle/manifests/openshift-builds-operator-metrics_v1_service.yaml
@@ -4,7 +4,7 @@ metadata:
   creationTimestamp: null
   labels:
     app.kubernetes.io/part-of: openshift-builds
-    app.kubernetes.io/version: 1.5.0
+    app.kubernetes.io/version: 1.8.0
   name: openshift-builds-operator-metrics
 spec:
   ports:

--- a/bundle/manifests/openshift-builds-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/openshift-builds-operator.clusterserviceversion.yaml
@@ -36,7 +36,7 @@ metadata:
     categories: Developer Tools, Integration & Delivery
     certified: "true"
     containerImage: registry.redhat.io/openshift-builds/openshift-builds-rhel9-operator
-    createdAt: "2026-05-11T08:20:29Z"
+    createdAt: "2026-05-11T09:36:41Z"
     description: Builds for Red Hat OpenShift is a framework for building container images on Kubernetes.
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
@@ -810,7 +810,7 @@ spec:
         - label:
             app: openshift-builds-operator
             app.kubernetes.io/part-of: openshift-builds
-            app.kubernetes.io/version: 1.5.0
+            app.kubernetes.io/version: 1.8.0
             control-plane: controller-manager
           name: openshift-builds-operator
           spec:
@@ -873,7 +873,7 @@ spec:
                         value: registry.redhat.io/openshift-builds/openshift-builds-waiters-rhel9@sha256:69e3199adf1ec18114db8a51ce67a6c8e86c6a3f88e2e199dddf3ddf82abce29
                       - name: IMAGE_SHIPWRIGHT_SHIPWRIGHT_BUILD_WEBHOOK
                         value: registry.redhat.io/openshift-builds/openshift-builds-webhook-rhel9@sha256:a10950ebe04c01354991514b9b1e9b9d547290add3a4de593195d1a8d6a0f3af
-                    image: registry.redhat.io/openshift-builds/openshift-builds-rhel9-operator@sha256:1b9909c1a9aa4cb31bacdcfc356de4a383f65034762405bf1714e789a1c658eb
+                    image: registry.redhat.io/openshift-builds/openshift-builds-rhel9-operator@sha256:9c78ab30ba40f25585dce8f4722f1834bc82e63f1c2e37091269a45de0575359
                     imagePullPolicy: Always
                     livenessProbe:
                       httpGet:
@@ -968,7 +968,7 @@ spec:
     name: Red Hat
     url: https://www.redhat.com
   relatedImages:
-    - image: registry.redhat.io/openshift-builds/openshift-builds-rhel9-operator@sha256:1b9909c1a9aa4cb31bacdcfc356de4a383f65034762405bf1714e789a1c658eb
+    - image: registry.redhat.io/openshift-builds/openshift-builds-rhel9-operator@sha256:9c78ab30ba40f25585dce8f4722f1834bc82e63f1c2e37091269a45de0575359
       name: OPENSHIFT_BUILDS_OPERATOR
     - image: registry.redhat.io/openshift-builds/openshift-builds-controller-rhel9@sha256:c53c98ed417c9a431412624ae0cd13dfb81200edea06177e818969f93f9cc36c
       name: OPENSHIFT_BUILDS_CONTROLLER

--- a/bundle/manifests/openshift-builds-shared-resource-node-privileged-binding_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
+++ b/bundle/manifests/openshift-builds-shared-resource-node-privileged-binding_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
@@ -4,7 +4,7 @@ metadata:
   creationTimestamp: null
   labels:
     app.kubernetes.io/part-of: openshift-builds
-    app.kubernetes.io/version: 1.5.0
+    app.kubernetes.io/version: 1.8.0
   name: openshift-builds-shared-resource-node-privileged-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/bundle/manifests/openshift-builds-shared-resource-privileged-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/openshift-builds-shared-resource-privileged-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -4,7 +4,7 @@ metadata:
   creationTimestamp: null
   labels:
     app.kubernetes.io/part-of: openshift-builds
-    app.kubernetes.io/version: 1.5.0
+    app.kubernetes.io/version: 1.8.0
   name: openshift-builds-shared-resource-privileged-role
 rules:
 - apiGroups:

--- a/bundle/manifests/openshift-builds-shared-resource-prometheus_rbac.authorization.k8s.io_v1_role.yaml
+++ b/bundle/manifests/openshift-builds-shared-resource-prometheus_rbac.authorization.k8s.io_v1_role.yaml
@@ -4,7 +4,7 @@ metadata:
   creationTimestamp: null
   labels:
     app.kubernetes.io/part-of: openshift-builds
-    app.kubernetes.io/version: 1.5.0
+    app.kubernetes.io/version: 1.8.0
   name: openshift-builds-shared-resource-prometheus
 rules:
 - apiGroups:

--- a/bundle/manifests/openshift-builds-shared-resource-prometheus_rbac.authorization.k8s.io_v1_rolebinding.yaml
+++ b/bundle/manifests/openshift-builds-shared-resource-prometheus_rbac.authorization.k8s.io_v1_rolebinding.yaml
@@ -4,7 +4,7 @@ metadata:
   creationTimestamp: null
   labels:
     app.kubernetes.io/part-of: openshift-builds
-    app.kubernetes.io/version: 1.5.0
+    app.kubernetes.io/version: 1.8.0
   name: openshift-builds-shared-resource-prometheus
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/bundle/manifests/operator.openshift.io_openshiftbuilds.yaml
+++ b/bundle/manifests/operator.openshift.io_openshiftbuilds.yaml
@@ -6,7 +6,7 @@ metadata:
   creationTimestamp: null
   labels:
     app.kubernetes.io/part-of: openshift-builds
-    app.kubernetes.io/version: 1.5.0
+    app.kubernetes.io/version: 1.8.0
   name: openshiftbuilds.operator.openshift.io
 spec:
   group: operator.openshift.io

--- a/bundle/manifests/operator.shipwright.io_shipwrightbuilds.yaml
+++ b/bundle/manifests/operator.shipwright.io_shipwrightbuilds.yaml
@@ -6,7 +6,7 @@ metadata:
   creationTimestamp: null
   labels:
     app.kubernetes.io/part-of: openshift-builds
-    app.kubernetes.io/version: 1.5.0
+    app.kubernetes.io/version: 1.8.0
   name: shipwrightbuilds.operator.shipwright.io
 spec:
   group: operator.shipwright.io

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -14,7 +14,7 @@ namePrefix: openshift-builds-
 labels:
   - pairs:
       app.kubernetes.io/part-of: openshift-builds
-      app.kubernetes.io/version: 1.5.0
+      app.kubernetes.io/version: 1.8.0
 
 resources:
 - ../crd

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -3,6 +3,6 @@ resources:
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
-- digest: sha256:1b9909c1a9aa4cb31bacdcfc356de4a383f65034762405bf1714e789a1c658eb
+- digest: sha256:9c78ab30ba40f25585dce8f4722f1834bc82e63f1c2e37091269a45de0575359
   name: operator
   newName: registry.redhat.io/openshift-builds/openshift-builds-rhel9-operator

--- a/config/manifests/bases/openshift-builds-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/openshift-builds-operator.clusterserviceversion.yaml
@@ -83,7 +83,7 @@ spec:
     name: Red Hat
     url: https://www.redhat.com
   relatedImages:
-    - image: registry.redhat.io/openshift-builds/openshift-builds-rhel9-operator@sha256:1b9909c1a9aa4cb31bacdcfc356de4a383f65034762405bf1714e789a1c658eb
+    - image: registry.redhat.io/openshift-builds/openshift-builds-rhel9-operator@sha256:9c78ab30ba40f25585dce8f4722f1834bc82e63f1c2e37091269a45de0575359
       name: OPENSHIFT_BUILDS_OPERATOR
     - image: registry.redhat.io/openshift-builds/openshift-builds-controller-rhel9@sha256:c53c98ed417c9a431412624ae0cd13dfb81200edea06177e818969f93f9cc36c
       name: OPENSHIFT_BUILDS_CONTROLLER
@@ -109,4 +109,4 @@ spec:
       name: OPENSHIFT_BUILDS_BUILDAH
     - image: registry.redhat.io/source-to-image/source-to-image-rhel9@sha256:70293cb8a80aa548933ff5f502bac89945a5cd08801c4ca3aac08a10dd01f62f
       name: OPENSHIFT_BUILDS_SOURCE_TO_IMAGE
-  version: 1.7.1
+  version: 1.8.0


### PR DESCRIPTION
## Summary
- Updated operator image digest from Konflux snapshot: openshift-builds-1-8-20260511-091232-000-vl
- Ran make bundle to regenerate manifests
- Verified all component SHAs match snapshot

Assisted-By: Claude Code