### PR TITLE
builds-1.8: chore: update component digests from Konflux snapshot

### DIFF
--- a/bundle/manifests/openshift-builds-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/openshift-builds-operator.clusterserviceversion.yaml
@@ -36,7 +36,7 @@ metadata:
     categories: Developer Tools, Integration & Delivery
     certified: "true"
     containerImage: registry.redhat.io/openshift-builds/openshift-builds-rhel9-operator
-    createdAt: "2026-05-11T09:36:41Z"
+    createdAt: "2026-05-12T14:01:21Z"
     description: Builds for Red Hat OpenShift is a framework for building container images on Kubernetes.
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
@@ -862,18 +862,18 @@ spec:
                       - name: PLATFORM
                         value: openshift
                       - name: IMAGE_SHIPWRIGHT_SHIPWRIGHT_BUILD
-                        value: registry.redhat.io/openshift-builds/openshift-builds-controller-rhel9@sha256:c53c98ed417c9a431412624ae0cd13dfb81200edea06177e818969f93f9cc36c
+                        value: registry.redhat.io/openshift-builds/openshift-builds-controller-rhel9@sha256:f644a5f10be9833aa22c43b430e215717c14666ca61aafebf909f43417932929
                       - name: IMAGE_SHIPWRIGHT_GIT_CONTAINER_IMAGE
-                        value: registry.redhat.io/openshift-builds/openshift-builds-git-cloner-rhel9@sha256:4f7621002e11a0dba633723959c2074d8bd1ede20bdbfc37af946af7906b6a5f
+                        value: registry.redhat.io/openshift-builds/openshift-builds-git-cloner-rhel9@sha256:2d7a450fb2fd7ff9c74ec66906334c9a0e4ef96fb83a4d0d4cd8f5e306638c8b
                       - name: IMAGE_SHIPWRIGHT_IMAGE_PROCESSING_CONTAINER_IMAGE
-                        value: registry.redhat.io/openshift-builds/openshift-builds-image-processing-rhel9@sha256:c8ddff762388aae99221b28e5c51a68aee2945d5f207380bc20a220badd1d2eb
+                        value: registry.redhat.io/openshift-builds/openshift-builds-image-processing-rhel9@sha256:dfcca5a731131eccb297f89a6b232be07f5ee6bd7b07df5b0997853f42ffc8c6
                       - name: IMAGE_SHIPWRIGHT_BUNDLE_CONTAINER_IMAGE
-                        value: registry.redhat.io/openshift-builds/openshift-builds-image-bundler-rhel9@sha256:e7e0d8858283eff61a335712a04551e268b5c0e5dfe456dfcd250f5b4e689f89
+                        value: registry.redhat.io/openshift-builds/openshift-builds-image-bundler-rhel9@sha256:4179ce97f3c2bd4d0d1cc3f1849f17e403d136584dfeaa40a7b0bd58b139cd47
                       - name: IMAGE_SHIPWRIGHT_WAITER_CONTAINER_IMAGE
-                        value: registry.redhat.io/openshift-builds/openshift-builds-waiters-rhel9@sha256:69e3199adf1ec18114db8a51ce67a6c8e86c6a3f88e2e199dddf3ddf82abce29
+                        value: registry.redhat.io/openshift-builds/openshift-builds-waiters-rhel9@sha256:2759712d421dc6e083e36928831eebeb2600c222c239c9c7b9e6c20c0a58db0d
                       - name: IMAGE_SHIPWRIGHT_SHIPWRIGHT_BUILD_WEBHOOK
-                        value: registry.redhat.io/openshift-builds/openshift-builds-webhook-rhel9@sha256:a10950ebe04c01354991514b9b1e9b9d547290add3a4de593195d1a8d6a0f3af
-                    image: registry.redhat.io/openshift-builds/openshift-builds-rhel9-operator@sha256:9c78ab30ba40f25585dce8f4722f1834bc82e63f1c2e37091269a45de0575359
+                        value: registry.redhat.io/openshift-builds/openshift-builds-webhook-rhel9@sha256:23ac759d63b7e1298065556b954de400426afda1ceb43cef924c71842c31e8cf
+                    image: registry.redhat.io/openshift-builds/openshift-builds-rhel9-operator@sha256:a9a03065d7240db05592b4f24624eb4c78884921ce8539355e1e59a343226271
                     imagePullPolicy: Always
                     livenessProbe:
                       httpGet:
@@ -968,23 +968,23 @@ spec:
     name: Red Hat
     url: https://www.redhat.com
   relatedImages:
-    - image: registry.redhat.io/openshift-builds/openshift-builds-rhel9-operator@sha256:9c78ab30ba40f25585dce8f4722f1834bc82e63f1c2e37091269a45de0575359
+    - image: registry.redhat.io/openshift-builds/openshift-builds-rhel9-operator@sha256:a9a03065d7240db05592b4f24624eb4c78884921ce8539355e1e59a343226271
       name: OPENSHIFT_BUILDS_OPERATOR
-    - image: registry.redhat.io/openshift-builds/openshift-builds-controller-rhel9@sha256:c53c98ed417c9a431412624ae0cd13dfb81200edea06177e818969f93f9cc36c
+    - image: registry.redhat.io/openshift-builds/openshift-builds-controller-rhel9@sha256:f644a5f10be9833aa22c43b430e215717c14666ca61aafebf909f43417932929
       name: OPENSHIFT_BUILDS_CONTROLLER
-    - image: registry.redhat.io/openshift-builds/openshift-builds-git-cloner-rhel9@sha256:4f7621002e11a0dba633723959c2074d8bd1ede20bdbfc37af946af7906b6a5f
+    - image: registry.redhat.io/openshift-builds/openshift-builds-git-cloner-rhel9@sha256:2d7a450fb2fd7ff9c74ec66906334c9a0e4ef96fb83a4d0d4cd8f5e306638c8b
       name: OPENSHIFT_BUILDS_GIT_CLONER
-    - image: registry.redhat.io/openshift-builds/openshift-builds-image-processing-rhel9@sha256:c8ddff762388aae99221b28e5c51a68aee2945d5f207380bc20a220badd1d2eb
+    - image: registry.redhat.io/openshift-builds/openshift-builds-image-processing-rhel9@sha256:dfcca5a731131eccb297f89a6b232be07f5ee6bd7b07df5b0997853f42ffc8c6
       name: OPENSHIFT_BUILDS_IMAGE_PROCESSING
-    - image: registry.redhat.io/openshift-builds/openshift-builds-image-bundler-rhel9@sha256:e7e0d8858283eff61a335712a04551e268b5c0e5dfe456dfcd250f5b4e689f89
+    - image: registry.redhat.io/openshift-builds/openshift-builds-image-bundler-rhel9@sha256:4179ce97f3c2bd4d0d1cc3f1849f17e403d136584dfeaa40a7b0bd58b139cd47
       name: OPENSHIFT_BUILDS_IMAGE_BUNDLER
-    - image: registry.redhat.io/openshift-builds/openshift-builds-waiters-rhel9@sha256:69e3199adf1ec18114db8a51ce67a6c8e86c6a3f88e2e199dddf3ddf82abce29
+    - image: registry.redhat.io/openshift-builds/openshift-builds-waiters-rhel9@sha256:2759712d421dc6e083e36928831eebeb2600c222c239c9c7b9e6c20c0a58db0d
       name: OPENSHIFT_BUILDS_WAITER
-    - image: registry.redhat.io/openshift-builds/openshift-builds-webhook-rhel9@sha256:a10950ebe04c01354991514b9b1e9b9d547290add3a4de593195d1a8d6a0f3af
+    - image: registry.redhat.io/openshift-builds/openshift-builds-webhook-rhel9@sha256:23ac759d63b7e1298065556b954de400426afda1ceb43cef924c71842c31e8cf
       name: OPENSHIFT_BUILDS_WEBHOOK
-    - image: registry.redhat.io/openshift-builds/openshift-builds-shared-resource-webhook-rhel9@sha256:fcfb69b77df93969a958df0f6187a3bdc6aeadce7bacfae4dee74094c1acfd05
+    - image: registry.redhat.io/openshift-builds/openshift-builds-shared-resource-webhook-rhel9@sha256:01628aa30162a08ab7197df17cc21c2373d296ff456ffdfd75781d289b4da186
       name: OPENSHIFT_BUILDS_SHARED_RESOURCE_WEBHOOK
-    - image: registry.redhat.io/openshift-builds/openshift-builds-shared-resource-rhel9@sha256:25991360eba4789527d0427a132ba8f1e09ec88b32c6b64349cb17f5a30405ea
+    - image: registry.redhat.io/openshift-builds/openshift-builds-shared-resource-rhel9@sha256:80dbec7b6f6958eeaf9226c77d3325007e0f2cfbdc3f4f079d2a525eea4f5418
       name: OPENSHIFT_BUILDS_SHARED_RESOURCE
     - image: registry.redhat.io/openshift4/ose-csi-node-driver-registrar-rhel9@sha256:ce7050192d9850ed4c35cb3295ccdeec1aa593e27e3a3da6d6aca97cde782abe
       name: OPENSHIFT_BUILDS_SHARED_RESOURCE_NODE_REGISTRAR

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -3,6 +3,6 @@ resources:
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
-- digest: sha256:9c78ab30ba40f25585dce8f4722f1834bc82e63f1c2e37091269a45de0575359
+- digest: sha256:a9a03065d7240db05592b4f24624eb4c78884921ce8539355e1e59a343226271
   name: operator
   newName: registry.redhat.io/openshift-builds/openshift-builds-rhel9-operator

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -71,17 +71,17 @@ spec:
           - name: PLATFORM
             value: "openshift"
           - name: IMAGE_SHIPWRIGHT_SHIPWRIGHT_BUILD
-            value: registry.redhat.io/openshift-builds/openshift-builds-controller-rhel9@sha256:c53c98ed417c9a431412624ae0cd13dfb81200edea06177e818969f93f9cc36c
+            value: registry.redhat.io/openshift-builds/openshift-builds-controller-rhel9@sha256:f644a5f10be9833aa22c43b430e215717c14666ca61aafebf909f43417932929
           - name: IMAGE_SHIPWRIGHT_GIT_CONTAINER_IMAGE
-            value: registry.redhat.io/openshift-builds/openshift-builds-git-cloner-rhel9@sha256:4f7621002e11a0dba633723959c2074d8bd1ede20bdbfc37af946af7906b6a5f
+            value: registry.redhat.io/openshift-builds/openshift-builds-git-cloner-rhel9@sha256:2d7a450fb2fd7ff9c74ec66906334c9a0e4ef96fb83a4d0d4cd8f5e306638c8b
           - name: IMAGE_SHIPWRIGHT_IMAGE_PROCESSING_CONTAINER_IMAGE
-            value: registry.redhat.io/openshift-builds/openshift-builds-image-processing-rhel9@sha256:c8ddff762388aae99221b28e5c51a68aee2945d5f207380bc20a220badd1d2eb
+            value: registry.redhat.io/openshift-builds/openshift-builds-image-processing-rhel9@sha256:dfcca5a731131eccb297f89a6b232be07f5ee6bd7b07df5b0997853f42ffc8c6
           - name: IMAGE_SHIPWRIGHT_BUNDLE_CONTAINER_IMAGE
-            value: registry.redhat.io/openshift-builds/openshift-builds-image-bundler-rhel9@sha256:e7e0d8858283eff61a335712a04551e268b5c0e5dfe456dfcd250f5b4e689f89
+            value: registry.redhat.io/openshift-builds/openshift-builds-image-bundler-rhel9@sha256:4179ce97f3c2bd4d0d1cc3f1849f17e403d136584dfeaa40a7b0bd58b139cd47
           - name: IMAGE_SHIPWRIGHT_WAITER_CONTAINER_IMAGE
-            value: registry.redhat.io/openshift-builds/openshift-builds-waiters-rhel9@sha256:69e3199adf1ec18114db8a51ce67a6c8e86c6a3f88e2e199dddf3ddf82abce29
+            value: registry.redhat.io/openshift-builds/openshift-builds-waiters-rhel9@sha256:2759712d421dc6e083e36928831eebeb2600c222c239c9c7b9e6c20c0a58db0d
           - name: IMAGE_SHIPWRIGHT_SHIPWRIGHT_BUILD_WEBHOOK
-            value: registry.redhat.io/openshift-builds/openshift-builds-webhook-rhel9@sha256:a10950ebe04c01354991514b9b1e9b9d547290add3a4de593195d1a8d6a0f3af
+            value: registry.redhat.io/openshift-builds/openshift-builds-webhook-rhel9@sha256:23ac759d63b7e1298065556b954de400426afda1ceb43cef924c71842c31e8cf
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true

--- a/config/manifests/bases/openshift-builds-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/openshift-builds-operator.clusterserviceversion.yaml
@@ -83,23 +83,23 @@ spec:
     name: Red Hat
     url: https://www.redhat.com
   relatedImages:
-    - image: registry.redhat.io/openshift-builds/openshift-builds-rhel9-operator@sha256:9c78ab30ba40f25585dce8f4722f1834bc82e63f1c2e37091269a45de0575359
+    - image: registry.redhat.io/openshift-builds/openshift-builds-rhel9-operator@sha256:a9a03065d7240db05592b4f24624eb4c78884921ce8539355e1e59a343226271
       name: OPENSHIFT_BUILDS_OPERATOR
-    - image: registry.redhat.io/openshift-builds/openshift-builds-controller-rhel9@sha256:c53c98ed417c9a431412624ae0cd13dfb81200edea06177e818969f93f9cc36c
+    - image: registry.redhat.io/openshift-builds/openshift-builds-controller-rhel9@sha256:f644a5f10be9833aa22c43b430e215717c14666ca61aafebf909f43417932929
       name: OPENSHIFT_BUILDS_CONTROLLER
-    - image: registry.redhat.io/openshift-builds/openshift-builds-git-cloner-rhel9@sha256:4f7621002e11a0dba633723959c2074d8bd1ede20bdbfc37af946af7906b6a5f
+    - image: registry.redhat.io/openshift-builds/openshift-builds-git-cloner-rhel9@sha256:2d7a450fb2fd7ff9c74ec66906334c9a0e4ef96fb83a4d0d4cd8f5e306638c8b
       name: OPENSHIFT_BUILDS_GIT_CLONER
-    - image: registry.redhat.io/openshift-builds/openshift-builds-image-processing-rhel9@sha256:c8ddff762388aae99221b28e5c51a68aee2945d5f207380bc20a220badd1d2eb
+    - image: registry.redhat.io/openshift-builds/openshift-builds-image-processing-rhel9@sha256:dfcca5a731131eccb297f89a6b232be07f5ee6bd7b07df5b0997853f42ffc8c6
       name: OPENSHIFT_BUILDS_IMAGE_PROCESSING
-    - image: registry.redhat.io/openshift-builds/openshift-builds-image-bundler-rhel9@sha256:e7e0d8858283eff61a335712a04551e268b5c0e5dfe456dfcd250f5b4e689f89
+    - image: registry.redhat.io/openshift-builds/openshift-builds-image-bundler-rhel9@sha256:4179ce97f3c2bd4d0d1cc3f1849f17e403d136584dfeaa40a7b0bd58b139cd47
       name: OPENSHIFT_BUILDS_IMAGE_BUNDLER
-    - image: registry.redhat.io/openshift-builds/openshift-builds-waiters-rhel9@sha256:69e3199adf1ec18114db8a51ce67a6c8e86c6a3f88e2e199dddf3ddf82abce29
+    - image: registry.redhat.io/openshift-builds/openshift-builds-waiters-rhel9@sha256:2759712d421dc6e083e36928831eebeb2600c222c239c9c7b9e6c20c0a58db0d
       name: OPENSHIFT_BUILDS_WAITER
-    - image: registry.redhat.io/openshift-builds/openshift-builds-webhook-rhel9@sha256:a10950ebe04c01354991514b9b1e9b9d547290add3a4de593195d1a8d6a0f3af
+    - image: registry.redhat.io/openshift-builds/openshift-builds-webhook-rhel9@sha256:23ac759d63b7e1298065556b954de400426afda1ceb43cef924c71842c31e8cf
       name: OPENSHIFT_BUILDS_WEBHOOK
-    - image: registry.redhat.io/openshift-builds/openshift-builds-shared-resource-webhook-rhel9@sha256:fcfb69b77df93969a958df0f6187a3bdc6aeadce7bacfae4dee74094c1acfd05
+    - image: registry.redhat.io/openshift-builds/openshift-builds-shared-resource-webhook-rhel9@sha256:01628aa30162a08ab7197df17cc21c2373d296ff456ffdfd75781d289b4da186
       name: OPENSHIFT_BUILDS_SHARED_RESOURCE_WEBHOOK
-    - image: registry.redhat.io/openshift-builds/openshift-builds-shared-resource-rhel9@sha256:25991360eba4789527d0427a132ba8f1e09ec88b32c6b64349cb17f5a30405ea
+    - image: registry.redhat.io/openshift-builds/openshift-builds-shared-resource-rhel9@sha256:80dbec7b6f6958eeaf9226c77d3325007e0f2cfbdc3f4f079d2a525eea4f5418
       name: OPENSHIFT_BUILDS_SHARED_RESOURCE
     - image: registry.redhat.io/openshift4/ose-csi-node-driver-registrar-rhel9@sha256:ce7050192d9850ed4c35cb3295ccdeec1aa593e27e3a3da6d6aca97cde782abe
       name: OPENSHIFT_BUILDS_SHARED_RESOURCE_NODE_REGISTRAR

--- a/config/sharedresource/node_daemonset.yaml
+++ b/config/sharedresource/node_daemonset.yaml
@@ -53,7 +53,7 @@ spec:
               memory: 20Mi
           terminationMessagePolicy: FallbackToLogsOnError
         - name: hostpath
-          image: registry.redhat.io/openshift-builds/openshift-builds-shared-resource-rhel9@sha256:25991360eba4789527d0427a132ba8f1e09ec88b32c6b64349cb17f5a30405ea
+          image: registry.redhat.io/openshift-builds/openshift-builds-shared-resource-rhel9@sha256:80dbec7b6f6958eeaf9226c77d3325007e0f2cfbdc3f4f079d2a525eea4f5418
           # for development purposes; eventually switch to IfNotPresent
           imagePullPolicy: IfNotPresent
           workingDir: /run/csi-data-dir 

--- a/config/sharedresource/webhook_deployment.yaml
+++ b/config/sharedresource/webhook_deployment.yaml
@@ -21,7 +21,7 @@ spec:
         name: shared-resource-csi-driver-webhook
     spec:
       containers:
-      - image: registry.redhat.io/openshift-builds/openshift-builds-shared-resource-webhook-rhel9@sha256:fcfb69b77df93969a958df0f6187a3bdc6aeadce7bacfae4dee74094c1acfd05
+      - image: registry.redhat.io/openshift-builds/openshift-builds-shared-resource-webhook-rhel9@sha256:01628aa30162a08ab7197df17cc21c2373d296ff456ffdfd75781d289b4da186
         imagePullPolicy: IfNotPresent
         name: shared-resource-csi-driver-webhook
         args:


### PR DESCRIPTION
## Summary
- Updated all component image digests from Konflux snapshot: openshift-builds-1-8-20260512-133157-367
- Files updated: manifest/config files

Assisted-By: Claude Code