### PR TITLE
builds-1.8: chore: bump pipeline max-keep-runs from 3 to 4

### DIFF
--- a/.tekton/openshift-builds-operator-bundle-pull-request.yaml
+++ b/.tekton/openshift-builds-operator-bundle-pull-request.yaml
@@ -6,7 +6,7 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
-    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/max-keep-runs: "4"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "pull_request" &&
       target_branch == "builds-1.8" &&

--- a/.tekton/openshift-builds-operator-bundle-push.yaml
+++ b/.tekton/openshift-builds-operator-bundle-push.yaml
@@ -5,7 +5,7 @@ metadata:
     build.appstudio.openshift.io/repo: https://github.com/redhat-openshift-builds/operator?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
-    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/max-keep-runs: "4"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push" &&
       target_branch == "builds-1.8" &&

--- a/.tekton/openshift-builds-operator-pull-request.yaml
+++ b/.tekton/openshift-builds-operator-pull-request.yaml
@@ -6,7 +6,7 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
-    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/max-keep-runs: "4"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "pull_request" &&
       target_branch == "builds-1.8" &&

--- a/.tekton/openshift-builds-operator-push.yaml
+++ b/.tekton/openshift-builds-operator-push.yaml
@@ -5,7 +5,7 @@ metadata:
     build.appstudio.openshift.io/repo: https://github.com/redhat-openshift-builds/operator?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
-    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/max-keep-runs: "4"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push" &&
       target_branch == "builds-1.8" &&


### PR DESCRIPTION
## Summary
- Bump pipelinesascode max-keep-runs from 3 to 4 across all 4 .tekton pipeline YAMLs

Co-Authored-By: Claude Opus 4.6