### PR TITLE
[BUILD-1975, BUILD-1989] fix(deps): bump tektoncd/pipeline to v1.9.3, update go-toolset SHA,  update to v1.7.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/ubi9/go-toolset@sha256:d637b9dfccb16623f19b95c43fe5a65b20b722e62753c4445c5d02f9e40b807d AS builder
+FROM registry.redhat.io/ubi9/go-toolset@sha256:a2ba4645e7c424b08aa83ed7792e279683b0d33acbc5131b18183fd21e336c55 AS builder
 
 USER 1001
 
@@ -39,8 +39,8 @@ LABEL \
     io.openshift.tags="builds,operator" \
     maintainer="openshift-builds@redhat.com" \
     name="openshift-builds/openshift-builds-operator-rhel9" \
-    release="2" \
+    release="3" \
     summary="Red Hat OpenShift Builds Operator" \
     url="https://github.com/redhat-openshift-builds/operator" \
     vendor="Red Hat, Inc." \
-    version="v1.7.2"
+    version="v1.7.3"

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 1.7.2
+VERSION ?= 1.7.3
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -24,11 +24,11 @@ LABEL \
     io.openshift.tags="builds,operator-bundle" \
     maintainer="openshift-builds@redhat.com" \
     name="openshift-builds/openshift-builds-operator-bundle-rhel9" \
-    release="2" \
+    release="3" \
     summary="Red Hat OpenShift Builds Operator Bundle" \
     url="https://github.com/redhat-openshift-builds/operator" \
     vendor="Red Hat, Inc." \
-    version="1.7.2"
+    version="1.7.3"
 
 COPY bundle/ /
 COPY LICENSE /licenses/

--- a/bundle/manifests/openshift-builds-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/openshift-builds-operator.clusterserviceversion.yaml
@@ -61,7 +61,7 @@ metadata:
     operatorframework.io/arch.arm64: supported
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
-  name: openshift-builds-operator.v1.7.2
+  name: openshift-builds-operator.v1.7.3
   namespace: openshift-builds
 spec:
   apiservicedefinitions: {}
@@ -994,4 +994,4 @@ spec:
       name: OPENSHIFT_BUILDS_BUILDAH
     - image: registry.redhat.io/source-to-image/source-to-image-rhel9@sha256:70293cb8a80aa548933ff5f502bac89945a5cd08801c4ca3aac08a10dd01f62f
       name: OPENSHIFT_BUILDS_SOURCE_TO_IMAGE
-  version: 1.7.2
+  version: 1.7.3

--- a/config/olm/kustomization.yaml
+++ b/config/olm/kustomization.yaml
@@ -14,4 +14,4 @@ resources:
 images:
 - name: catalog
   newName: registry.redhat.io/openshift-builds/openshift-builds-operator-catalog
-  newTag: v1.7.2
+  newTag: v1.7.3

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/redhat-openshift-builds/operator
 
-go 1.24.4
+go 1.26.2
 
 require (
 	github.com/go-logr/logr v1.4.3
@@ -94,7 +94,7 @@ require (
 	github.com/spf13/afero v1.15.0 // indirect
 	github.com/spf13/cobra v1.10.1 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
-	github.com/tektoncd/pipeline v1.6.1 // indirect
+	github.com/tektoncd/pipeline v1.6.2 // indirect
 	github.com/tektoncd/triggers v0.33.0 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	github.com/xlab/treeprint v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -711,8 +711,8 @@ github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD
 github.com/stvp/go-udp-testing v0.0.0-20201019212854-469649b16807/go.mod h1:7jxmlfBCDBXRzr0eAQJ48XC1hBu1np4CS5+cHEYfwpc=
 github.com/tektoncd/operator v0.77.0 h1:GaNvJnjMOhvUyAarBK+h31zTHgjSQjhIXP2oY7iPAxk=
 github.com/tektoncd/operator v0.77.0/go.mod h1:dBgVRdA8uQYoCMXda5l11u5yNmQzvMkgRjMJE7EgWpI=
-github.com/tektoncd/pipeline v1.6.1 h1:DLeA6gVQrDHw9hy7eI48rOp2MO+Fwawj1+AcgSpJysk=
-github.com/tektoncd/pipeline v1.6.1/go.mod h1:5SNoYgRYPQopkv7ApVq5GO3JqPk2AjV+VMMjwBsbJOg=
+github.com/tektoncd/pipeline v1.6.2 h1:lcpC4fuoc9Uy6uWjjNmtRJgYd+e6XIcFZKYitbVnORc=
+github.com/tektoncd/pipeline v1.6.2/go.mod h1:lnC/pCLLG37eZE3B5QPCumkWZyY0Lb2LZBpQlJCNaio=
 github.com/tektoncd/triggers v0.33.0 h1:pG2Kz/2FHjysGG4GGhiGp9hHdwA8BLZI3H7m9U9sj4M=
 github.com/tektoncd/triggers v0.33.0/go.mod h1:V2CTUxZB6zwymfeUnsZqFEwtkN6ClT+chtxr03N3L7c=
 github.com/tidwall/gjson v1.18.0 h1:FIDeeyB800efLX89e5a8Y0BNH+LOngJyGrIWxG2FKQY=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -323,8 +323,8 @@ github.com/tektoncd/operator/pkg/client/clientset/versioned/scheme
 github.com/tektoncd/operator/pkg/client/clientset/versioned/typed/operator/v1alpha1
 github.com/tektoncd/operator/pkg/common
 github.com/tektoncd/operator/pkg/reconciler/openshift
-# github.com/tektoncd/pipeline v1.6.1
-## explicit; go 1.24.0
+# github.com/tektoncd/pipeline v1.6.2
+## explicit; go 1.24.13
 github.com/tektoncd/pipeline/pkg/apis/config
 github.com/tektoncd/pipeline/pkg/apis/pipeline/pod
 github.com/tektoncd/pipeline/pkg/spire/config


### PR DESCRIPTION
Fixes CVE-2026-40161, CVE-2026-40938, CVE-2026-32280.

Bumps:
  - github.com/tektoncd/pipeline from v1.6.1 to v1.6.2 (fixes CVE-2026-40161, CVE-2026-40938)
  - Updated go-toolset SHA to go1.26.2 (fixes CVE-2026-32280)
  - Updated version to v1.7.3, release to 3

Resolves: BUILD-1975, BUILD-1989