### PR TITLE
fix: sync bundled Shipwright manifests to v0.19 to match the controller

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -241,9 +241,9 @@ YQ ?= $(LOCALBIN)/yq
 #ENVTEST_VERSION ?= release-0.20
 
 ## Upstream Sources
-SHIPWRIGHT_OPERATOR_RELEASE ?= v0.18.0
+SHIPWRIGHT_OPERATOR_RELEASE ?= v0.19.0
 SHIPWRIGHT_OPERATOR_SOURCE ?= https://raw.githubusercontent.com/shipwright-io/operator/refs/tags/$(SHIPWRIGHT_OPERATOR_RELEASE)
-SHIPWRIGHT_BUILD_RELEASE ?= v0.18.0
+SHIPWRIGHT_BUILD_RELEASE ?= v0.19.4
 SHIPWRIGHT_BUILD_SOURCE ?= https://github.com/shipwright-io/build/releases/download/$(SHIPWRIGHT_BUILD_RELEASE)
 
 # ClusterBuildStrategy Sources

--- a/bundle/manifests/openshift-builds-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/openshift-builds-operator.clusterserviceversion.yaml
@@ -36,7 +36,7 @@ metadata:
     categories: Developer Tools, Integration & Delivery
     certified: "true"
     containerImage: registry.redhat.io/openshift-builds/openshift-builds-rhel9-operator
-    createdAt: "2026-05-07T09:44:41Z"
+    createdAt: "2026-06-06T21:49:10Z"
     description: Builds for Red Hat OpenShift is a framework for building container images on Kubernetes.
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
@@ -51,7 +51,7 @@ metadata:
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-builds
     operators.openshift.io/valid-subscription: '["OpenShift Container Platform", "OpenShift Platform Plus"]'
-    operators.operatorframework.io/builder: operator-sdk-v1.35.0
+    operators.operatorframework.io/builder: operator-sdk-v1.39.2
     operators.operatorframework.io/internal-objects: '["openshiftbuilds.operator.openshift.io","shipwrightbuilds.operator.shipwright.io"]'
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
     repository: https://github.com/shipwright-io/operator
@@ -67,7 +67,9 @@ spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
-      - description: OpenShiftBuild describes the desired state of Builds for OpenShift, and the status of all deployed components.
+      - description: |-
+          OpenShiftBuild describes the desired state of Builds for OpenShift, and the status of
+          all deployed components.
         displayName: Open Shift Build
         kind: OpenShiftBuild
         name: openshiftbuilds.operator.openshift.io

--- a/bundle/manifests/operator.shipwright.io_shipwrightbuilds.yaml
+++ b/bundle/manifests/operator.shipwright.io_shipwrightbuilds.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.18.0
   creationTimestamp: null
   labels:
     app.kubernetes.io/part-of: openshift-builds
@@ -56,16 +56,8 @@ spec:
                 description: Conditions holds the latest available observations of
                   a resource's current state.
                 items:
-                  description: "Condition contains details for one aspect of the current
-                    state of this API Resource.\n---\nThis struct is intended for
-                    direct use as an array at the field path .status.conditions.  For
-                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
-                    observations of a foo's current state.\n\t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
-                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                    \   // other fields\n\t}"
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
                   properties:
                     lastTransitionTime:
                       description: |-
@@ -106,12 +98,7 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: |-
-                        type of condition in CamelCase or in foo.example.com/CamelCase.
-                        ---
-                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                        useful (see .node.status.conditions), the ability to deconflict is important.
-                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string

--- a/config/crd/bases/operator.shipwright.io_shipwrightbuilds.yaml
+++ b/config/crd/bases/operator.shipwright.io_shipwrightbuilds.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: shipwrightbuilds.operator.shipwright.io
 spec:
   group: operator.shipwright.io
@@ -53,16 +53,8 @@ spec:
                 description: Conditions holds the latest available observations of
                   a resource's current state.
                 items:
-                  description: "Condition contains details for one aspect of the current
-                    state of this API Resource.\n---\nThis struct is intended for
-                    direct use as an array at the field path .status.conditions.  For
-                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
-                    observations of a foo's current state.\n\t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
-                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                    \   // other fields\n\t}"
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
                   properties:
                     lastTransitionTime:
                       description: |-
@@ -103,12 +95,7 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: |-
-                        type of condition in CamelCase or in foo.example.com/CamelCase.
-                        ---
-                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                        useful (see .node.status.conditions), the ability to deconflict is important.
-                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string

--- a/config/manifests/bases/openshift-builds-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/openshift-builds-operator.clusterserviceversion.yaml
@@ -40,7 +40,9 @@ spec:
         kind: ShipwrightBuild
         name: shipwrightbuilds.operator.shipwright.io
         version: v1alpha1
-      - description: OpenShiftBuild describes the desired state of Builds for OpenShift, and the status of all deployed components.
+      - description: |-
+          OpenShiftBuild describes the desired state of Builds for OpenShift, and the status of
+          all deployed components.
         displayName: Open Shift Build
         kind: OpenShiftBuild
         name: openshiftbuilds.operator.openshift.io

--- a/config/shipwright/build/release/release.yaml
+++ b/config/shipwright/build/release/release.yaml
@@ -155,7 +155,7 @@ spec:
       serviceAccountName: shipwright-build-controller
       containers:
         - name: shipwright-build
-          image: ghcr.io/shipwright-io/build/shipwright-build-controller:v0.18.0@sha256:484bc5e57f754d08dd06481cd573adf475c21211e1402d7c7913091a3659f0a4
+          image: ghcr.io/shipwright-io/build/shipwright-build-controller:v0.19.4@sha256:85d8be73936ffff01846865d9e88702175fce6a04ac06044dd10d46268e29ca7
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -172,15 +172,15 @@ spec:
             - name: CONTROLLER_NAME
               value: "shipwright-build"
             - name: GIT_CONTAINER_IMAGE
-              value: ghcr.io/shipwright-io/build/git:v0.18.0@sha256:0b8beff3346f4a16785f76ee3f87fd3e390e869faf7135730f2fb4e8d4a3cc30
+              value: ghcr.io/shipwright-io/build/git:v0.19.4@sha256:f4cceafc64bf11800d2536987085c596964c32d2c6c3ce18b2dc7009726a0d51
             - name: GIT_ENABLE_REWRITE_RULE
               value: "false"
             - name: IMAGE_PROCESSING_CONTAINER_IMAGE
-              value: ghcr.io/shipwright-io/build/image-processing:v0.18.0@sha256:a392d89eb09f952eba88ee084aa75fb993b4b8b21d25993322622119346acfe1
+              value: ghcr.io/shipwright-io/build/image-processing:v0.19.4@sha256:b096d18b370efa94eab1d852ea7a1aa805ec07e35ecc05791b1bb1ca184bde9a
             - name: BUNDLE_CONTAINER_IMAGE
-              value: ghcr.io/shipwright-io/build/bundle:v0.18.0@sha256:999a569a05162bc4c1ff8998e4a55e548db3912175cf04c6fa25e69a88fbbaaa
+              value: ghcr.io/shipwright-io/build/bundle:v0.19.4@sha256:4df73f522e1f9bc736a0f9364b24585a007a9fd84c273e24fa44c266d1e93b5d
             - name: WAITER_CONTAINER_IMAGE
-              value: ghcr.io/shipwright-io/build/waiter:v0.18.0@sha256:5a95e960c87669580eae55ad79e8e0b3d9c076362ab14fd095aee735deb1bd46
+              value: ghcr.io/shipwright-io/build/waiter:v0.19.4@sha256:d9fc7163dadad7b131f03d8780cdabdd335bcd36a95c23da4588ab4d9dba6aa4
           ports:
             - containerPort: 8383
               name: metrics-port
@@ -237,7 +237,7 @@ spec:
       serviceAccountName: shipwright-build-webhook
       containers:
         - name: shipwright-build-webhook
-          image: ghcr.io/shipwright-io/build/shipwright-build-webhook:v0.18.0@sha256:7e127ea8f4ff3d425fee54979d9c7e86a6c2cd7aa33ea95a7b6ed266bb2f5dad
+          image: ghcr.io/shipwright-io/build/shipwright-build-webhook:v0.19.4@sha256:c0ee8b0ab696d79fb3c140a8b0db98b0d7ce6a781206988bdf8586d989d9e2bd
           volumeMounts:
             - name: webhook-certs
               mountPath: /etc/webhook/certs
@@ -308,7 +308,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.18.0
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: buildruns.shipwright.io
 spec:
   conversion:
@@ -456,7 +456,9 @@ spec:
                         description: EnvVar represents an environment variable present in a Container.
                         properties:
                           name:
-                            description: Name of the environment variable. Must be a C_IDENTIFIER.
+                            description: |-
+                              Name of the environment variable.
+                              May consist of any printable ASCII characters except '='.
                             type: string
                           value:
                             description: |-
@@ -508,6 +510,42 @@ spec:
                                     type: string
                                 required:
                                   - fieldPath
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              fileKeyRef:
+                                description: |-
+                                  FileKeyRef selects a key of the env file.
+                                  Requires the EnvFiles feature gate to be enabled.
+                                properties:
+                                  key:
+                                    description: |-
+                                      The key within the env file. An invalid key will prevent the pod from starting.
+                                      The keys defined within a source may consist of any printable ASCII characters except '='.
+                                      During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                    type: string
+                                  optional:
+                                    default: false
+                                    description: |-
+                                      Specify whether the file or its key must be defined. If the file or key
+                                      does not exist, then the env var is not published.
+                                      If optional is set to true and the specified key does not exist,
+                                      the environment variable will not be set in the Pod's containers.
+
+                                      If optional is set to false and the specified key does not exist,
+                                      an error will be returned during Pod creation.
+                                    type: boolean
+                                  path:
+                                    description: |-
+                                      The path within the volume from which to select the file.
+                                      Must be relative and may not contain the '..' path or start with '..'.
+                                    type: string
+                                  volumeName:
+                                    description: The name of the volume mount containing the env file.
+                                    type: string
+                                required:
+                                  - key
+                                  - path
+                                  - volumeName
                                 type: object
                                 x-kubernetes-map-type: atomic
                               resourceFieldRef:
@@ -1548,15 +1586,13 @@ spec:
                                           volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
                                           If specified, the CSI driver will create or update the volume with the attributes defined
                                           in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                                          it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
-                                          will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
-                                          If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
-                                          will be set by the persistentvolume controller if it exists.
+                                          it can be changed after the claim is created. An empty string or nil value indicates that no
+                                          VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
+                                          this field can be reset to its previous value (including nil) to cancel the modification.
                                           If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
                                           set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
                                           exists.
                                           More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
-                                          (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).
                                         type: string
                                       volumeMode:
                                         description: |-
@@ -1730,12 +1766,9 @@ spec:
                             description: |-
                               glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
                               Deprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported.
-                              More info: https://examples.k8s.io/volumes/glusterfs/README.md
                             properties:
                               endpoints:
-                                description: |-
-                                  endpoints is the endpoint name that details Glusterfs topology.
-                                  More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+                                description: endpoints is the endpoint name that details Glusterfs topology.
                                 type: string
                               path:
                                 description: |-
@@ -1814,7 +1847,7 @@ spec:
                             description: |-
                               iscsi represents an ISCSI Disk resource that is attached to a
                               kubelet's host machine and then exposed to the pod.
-                              More info: https://examples.k8s.io/volumes/iscsi/README.md
+                              More info: https://kubernetes.io/docs/concepts/storage/volumes/#iscsi
                             properties:
                               chapAuthDiscovery:
                                 description: chapAuthDiscovery defines whether support iSCSI Discovery CHAP authentication
@@ -2201,6 +2234,110 @@ spec:
                                           type: array
                                           x-kubernetes-list-type: atomic
                                       type: object
+                                    podCertificate:
+                                      description: |-
+                                        Projects an auto-rotating credential bundle (private key and certificate
+                                        chain) that the pod can use either as a TLS client or server.
+
+                                        Kubelet generates a private key and uses it to send a
+                                        PodCertificateRequest to the named signer.  Once the signer approves the
+                                        request and issues a certificate chain, Kubelet writes the key and
+                                        certificate chain to the pod filesystem.  The pod does not start until
+                                        certificates have been issued for each podCertificate projected volume
+                                        source in its spec.
+
+                                        Kubelet will begin trying to rotate the certificate at the time indicated
+                                        by the signer using the PodCertificateRequest.Status.BeginRefreshAt
+                                        timestamp.
+
+                                        Kubelet can write a single file, indicated by the credentialBundlePath
+                                        field, or separate files, indicated by the keyPath and
+                                        certificateChainPath fields.
+
+                                        The credential bundle is a single file in PEM format.  The first PEM
+                                        entry is the private key (in PKCS#8 format), and the remaining PEM
+                                        entries are the certificate chain issued by the signer (typically,
+                                        signers will return their certificate chain in leaf-to-root order).
+
+                                        Prefer using the credential bundle format, since your application code
+                                        can read it atomically.  If you use keyPath and certificateChainPath,
+                                        your application must make two separate file reads. If these coincide
+                                        with a certificate rotation, it is possible that the private key and leaf
+                                        certificate you read may not correspond to each other.  Your application
+                                        will need to check for this condition, and re-read until they are
+                                        consistent.
+
+                                        The named signer controls chooses the format of the certificate it
+                                        issues; consult the signer implementation's documentation to learn how to
+                                        use the certificates it issues.
+                                      properties:
+                                        certificateChainPath:
+                                          description: |-
+                                            Write the certificate chain at this path in the projected volume.
+
+                                            Most applications should use credentialBundlePath.  When using keyPath
+                                            and certificateChainPath, your application needs to check that the key
+                                            and leaf certificate are consistent, because it is possible to read the
+                                            files mid-rotation.
+                                          type: string
+                                        credentialBundlePath:
+                                          description: |-
+                                            Write the credential bundle at this path in the projected volume.
+
+                                            The credential bundle is a single file that contains multiple PEM blocks.
+                                            The first PEM block is a PRIVATE KEY block, containing a PKCS#8 private
+                                            key.
+
+                                            The remaining blocks are CERTIFICATE blocks, containing the issued
+                                            certificate chain from the signer (leaf and any intermediates).
+
+                                            Using credentialBundlePath lets your Pod's application code make a single
+                                            atomic read that retrieves a consistent key and certificate chain.  If you
+                                            project them to separate files, your application code will need to
+                                            additionally check that the leaf certificate was issued to the key.
+                                          type: string
+                                        keyPath:
+                                          description: |-
+                                            Write the key at this path in the projected volume.
+
+                                            Most applications should use credentialBundlePath.  When using keyPath
+                                            and certificateChainPath, your application needs to check that the key
+                                            and leaf certificate are consistent, because it is possible to read the
+                                            files mid-rotation.
+                                          type: string
+                                        keyType:
+                                          description: |-
+                                            The type of keypair Kubelet will generate for the pod.
+
+                                            Valid values are "RSA3072", "RSA4096", "ECDSAP256", "ECDSAP384",
+                                            "ECDSAP521", and "ED25519".
+                                          type: string
+                                        maxExpirationSeconds:
+                                          description: |-
+                                            maxExpirationSeconds is the maximum lifetime permitted for the
+                                            certificate.
+
+                                            Kubelet copies this value verbatim into the PodCertificateRequests it
+                                            generates for this projection.
+
+                                            If omitted, kube-apiserver will set it to 86400(24 hours). kube-apiserver
+                                            will reject values shorter than 3600 (1 hour).  The maximum allowable
+                                            value is 7862400 (91 days).
+
+                                            The signer implementation is then free to issue a certificate with any
+                                            lifetime *shorter* than MaxExpirationSeconds, but no shorter than 3600
+                                            seconds (1 hour).  This constraint is enforced by kube-apiserver.
+                                            `kubernetes.io` signers will never issue certificates with a lifetime
+                                            longer than 24 hours.
+                                          format: int32
+                                          type: integer
+                                        signerName:
+                                          description: Kubelet's generated CSRs will be addressed to this signer.
+                                          type: string
+                                      required:
+                                        - keyType
+                                        - signerName
+                                      type: object
                                     secret:
                                       description: secret information about the secret data to project
                                       properties:
@@ -2330,7 +2467,6 @@ spec:
                             description: |-
                               rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
                               Deprecated: RBD is deprecated and the in-tree rbd type is no longer supported.
-                              More info: https://examples.k8s.io/volumes/rbd/README.md
                             properties:
                               fsType:
                                 description: |-
@@ -2615,7 +2751,9 @@ spec:
                     description: EnvVar represents an environment variable present in a Container.
                     properties:
                       name:
-                        description: Name of the environment variable. Must be a C_IDENTIFIER.
+                        description: |-
+                          Name of the environment variable.
+                          May consist of any printable ASCII characters except '='.
                         type: string
                       value:
                         description: |-
@@ -2667,6 +2805,42 @@ spec:
                                 type: string
                             required:
                               - fieldPath
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          fileKeyRef:
+                            description: |-
+                              FileKeyRef selects a key of the env file.
+                              Requires the EnvFiles feature gate to be enabled.
+                            properties:
+                              key:
+                                description: |-
+                                  The key within the env file. An invalid key will prevent the pod from starting.
+                                  The keys defined within a source may consist of any printable ASCII characters except '='.
+                                  During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                type: string
+                              optional:
+                                default: false
+                                description: |-
+                                  Specify whether the file or its key must be defined. If the file or key
+                                  does not exist, then the env var is not published.
+                                  If optional is set to true and the specified key does not exist,
+                                  the environment variable will not be set in the Pod's containers.
+
+                                  If optional is set to false and the specified key does not exist,
+                                  an error will be returned during Pod creation.
+                                type: boolean
+                              path:
+                                description: |-
+                                  The path within the volume from which to select the file.
+                                  Must be relative and may not contain the '..' path or start with '..'.
+                                type: string
+                              volumeName:
+                                description: The name of the volume mount containing the env file.
+                                type: string
+                            required:
+                              - key
+                              - path
+                              - volumeName
                             type: object
                             x-kubernetes-map-type: atomic
                           resourceFieldRef:
@@ -3571,15 +3745,13 @@ spec:
                                       volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
                                       If specified, the CSI driver will create or update the volume with the attributes defined
                                       in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                                      it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
-                                      will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
-                                      If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
-                                      will be set by the persistentvolume controller if it exists.
+                                      it can be changed after the claim is created. An empty string or nil value indicates that no
+                                      VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
+                                      this field can be reset to its previous value (including nil) to cancel the modification.
                                       If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
                                       set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
                                       exists.
                                       More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
-                                      (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).
                                     type: string
                                   volumeMode:
                                     description: |-
@@ -3753,12 +3925,9 @@ spec:
                         description: |-
                           glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
                           Deprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported.
-                          More info: https://examples.k8s.io/volumes/glusterfs/README.md
                         properties:
                           endpoints:
-                            description: |-
-                              endpoints is the endpoint name that details Glusterfs topology.
-                              More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+                            description: endpoints is the endpoint name that details Glusterfs topology.
                             type: string
                           path:
                             description: |-
@@ -3837,7 +4006,7 @@ spec:
                         description: |-
                           iscsi represents an ISCSI Disk resource that is attached to a
                           kubelet's host machine and then exposed to the pod.
-                          More info: https://examples.k8s.io/volumes/iscsi/README.md
+                          More info: https://kubernetes.io/docs/concepts/storage/volumes/#iscsi
                         properties:
                           chapAuthDiscovery:
                             description: chapAuthDiscovery defines whether support iSCSI Discovery CHAP authentication
@@ -4224,6 +4393,110 @@ spec:
                                       type: array
                                       x-kubernetes-list-type: atomic
                                   type: object
+                                podCertificate:
+                                  description: |-
+                                    Projects an auto-rotating credential bundle (private key and certificate
+                                    chain) that the pod can use either as a TLS client or server.
+
+                                    Kubelet generates a private key and uses it to send a
+                                    PodCertificateRequest to the named signer.  Once the signer approves the
+                                    request and issues a certificate chain, Kubelet writes the key and
+                                    certificate chain to the pod filesystem.  The pod does not start until
+                                    certificates have been issued for each podCertificate projected volume
+                                    source in its spec.
+
+                                    Kubelet will begin trying to rotate the certificate at the time indicated
+                                    by the signer using the PodCertificateRequest.Status.BeginRefreshAt
+                                    timestamp.
+
+                                    Kubelet can write a single file, indicated by the credentialBundlePath
+                                    field, or separate files, indicated by the keyPath and
+                                    certificateChainPath fields.
+
+                                    The credential bundle is a single file in PEM format.  The first PEM
+                                    entry is the private key (in PKCS#8 format), and the remaining PEM
+                                    entries are the certificate chain issued by the signer (typically,
+                                    signers will return their certificate chain in leaf-to-root order).
+
+                                    Prefer using the credential bundle format, since your application code
+                                    can read it atomically.  If you use keyPath and certificateChainPath,
+                                    your application must make two separate file reads. If these coincide
+                                    with a certificate rotation, it is possible that the private key and leaf
+                                    certificate you read may not correspond to each other.  Your application
+                                    will need to check for this condition, and re-read until they are
+                                    consistent.
+
+                                    The named signer controls chooses the format of the certificate it
+                                    issues; consult the signer implementation's documentation to learn how to
+                                    use the certificates it issues.
+                                  properties:
+                                    certificateChainPath:
+                                      description: |-
+                                        Write the certificate chain at this path in the projected volume.
+
+                                        Most applications should use credentialBundlePath.  When using keyPath
+                                        and certificateChainPath, your application needs to check that the key
+                                        and leaf certificate are consistent, because it is possible to read the
+                                        files mid-rotation.
+                                      type: string
+                                    credentialBundlePath:
+                                      description: |-
+                                        Write the credential bundle at this path in the projected volume.
+
+                                        The credential bundle is a single file that contains multiple PEM blocks.
+                                        The first PEM block is a PRIVATE KEY block, containing a PKCS#8 private
+                                        key.
+
+                                        The remaining blocks are CERTIFICATE blocks, containing the issued
+                                        certificate chain from the signer (leaf and any intermediates).
+
+                                        Using credentialBundlePath lets your Pod's application code make a single
+                                        atomic read that retrieves a consistent key and certificate chain.  If you
+                                        project them to separate files, your application code will need to
+                                        additionally check that the leaf certificate was issued to the key.
+                                      type: string
+                                    keyPath:
+                                      description: |-
+                                        Write the key at this path in the projected volume.
+
+                                        Most applications should use credentialBundlePath.  When using keyPath
+                                        and certificateChainPath, your application needs to check that the key
+                                        and leaf certificate are consistent, because it is possible to read the
+                                        files mid-rotation.
+                                      type: string
+                                    keyType:
+                                      description: |-
+                                        The type of keypair Kubelet will generate for the pod.
+
+                                        Valid values are "RSA3072", "RSA4096", "ECDSAP256", "ECDSAP384",
+                                        "ECDSAP521", and "ED25519".
+                                      type: string
+                                    maxExpirationSeconds:
+                                      description: |-
+                                        maxExpirationSeconds is the maximum lifetime permitted for the
+                                        certificate.
+
+                                        Kubelet copies this value verbatim into the PodCertificateRequests it
+                                        generates for this projection.
+
+                                        If omitted, kube-apiserver will set it to 86400(24 hours). kube-apiserver
+                                        will reject values shorter than 3600 (1 hour).  The maximum allowable
+                                        value is 7862400 (91 days).
+
+                                        The signer implementation is then free to issue a certificate with any
+                                        lifetime *shorter* than MaxExpirationSeconds, but no shorter than 3600
+                                        seconds (1 hour).  This constraint is enforced by kube-apiserver.
+                                        `kubernetes.io` signers will never issue certificates with a lifetime
+                                        longer than 24 hours.
+                                      format: int32
+                                      type: integer
+                                    signerName:
+                                      description: Kubelet's generated CSRs will be addressed to this signer.
+                                      type: string
+                                  required:
+                                    - keyType
+                                    - signerName
+                                  type: object
                                 secret:
                                   description: secret information about the secret data to project
                                   properties:
@@ -4353,7 +4626,6 @@ spec:
                         description: |-
                           rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
                           Deprecated: RBD is deprecated and the in-tree rbd type is no longer supported.
-                          More info: https://examples.k8s.io/volumes/rbd/README.md
                         properties:
                           fsType:
                             description: |-
@@ -4701,7 +4973,9 @@ spec:
                         description: EnvVar represents an environment variable present in a Container.
                         properties:
                           name:
-                            description: Name of the environment variable. Must be a C_IDENTIFIER.
+                            description: |-
+                              Name of the environment variable.
+                              May consist of any printable ASCII characters except '='.
                             type: string
                           value:
                             description: |-
@@ -4753,6 +5027,42 @@ spec:
                                     type: string
                                 required:
                                   - fieldPath
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              fileKeyRef:
+                                description: |-
+                                  FileKeyRef selects a key of the env file.
+                                  Requires the EnvFiles feature gate to be enabled.
+                                properties:
+                                  key:
+                                    description: |-
+                                      The key within the env file. An invalid key will prevent the pod from starting.
+                                      The keys defined within a source may consist of any printable ASCII characters except '='.
+                                      During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                    type: string
+                                  optional:
+                                    default: false
+                                    description: |-
+                                      Specify whether the file or its key must be defined. If the file or key
+                                      does not exist, then the env var is not published.
+                                      If optional is set to true and the specified key does not exist,
+                                      the environment variable will not be set in the Pod's containers.
+
+                                      If optional is set to false and the specified key does not exist,
+                                      an error will be returned during Pod creation.
+                                    type: boolean
+                                  path:
+                                    description: |-
+                                      The path within the volume from which to select the file.
+                                      Must be relative and may not contain the '..' path or start with '..'.
+                                    type: string
+                                  volumeName:
+                                    description: The name of the volume mount containing the env file.
+                                    type: string
+                                required:
+                                  - key
+                                  - path
+                                  - volumeName
                                 type: object
                                 x-kubernetes-map-type: atomic
                               resourceFieldRef:
@@ -5793,15 +6103,13 @@ spec:
                                           volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
                                           If specified, the CSI driver will create or update the volume with the attributes defined
                                           in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                                          it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
-                                          will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
-                                          If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
-                                          will be set by the persistentvolume controller if it exists.
+                                          it can be changed after the claim is created. An empty string or nil value indicates that no
+                                          VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
+                                          this field can be reset to its previous value (including nil) to cancel the modification.
                                           If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
                                           set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
                                           exists.
                                           More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
-                                          (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).
                                         type: string
                                       volumeMode:
                                         description: |-
@@ -5975,12 +6283,9 @@ spec:
                             description: |-
                               glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
                               Deprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported.
-                              More info: https://examples.k8s.io/volumes/glusterfs/README.md
                             properties:
                               endpoints:
-                                description: |-
-                                  endpoints is the endpoint name that details Glusterfs topology.
-                                  More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+                                description: endpoints is the endpoint name that details Glusterfs topology.
                                 type: string
                               path:
                                 description: |-
@@ -6059,7 +6364,7 @@ spec:
                             description: |-
                               iscsi represents an ISCSI Disk resource that is attached to a
                               kubelet's host machine and then exposed to the pod.
-                              More info: https://examples.k8s.io/volumes/iscsi/README.md
+                              More info: https://kubernetes.io/docs/concepts/storage/volumes/#iscsi
                             properties:
                               chapAuthDiscovery:
                                 description: chapAuthDiscovery defines whether support iSCSI Discovery CHAP authentication
@@ -6446,6 +6751,110 @@ spec:
                                           type: array
                                           x-kubernetes-list-type: atomic
                                       type: object
+                                    podCertificate:
+                                      description: |-
+                                        Projects an auto-rotating credential bundle (private key and certificate
+                                        chain) that the pod can use either as a TLS client or server.
+
+                                        Kubelet generates a private key and uses it to send a
+                                        PodCertificateRequest to the named signer.  Once the signer approves the
+                                        request and issues a certificate chain, Kubelet writes the key and
+                                        certificate chain to the pod filesystem.  The pod does not start until
+                                        certificates have been issued for each podCertificate projected volume
+                                        source in its spec.
+
+                                        Kubelet will begin trying to rotate the certificate at the time indicated
+                                        by the signer using the PodCertificateRequest.Status.BeginRefreshAt
+                                        timestamp.
+
+                                        Kubelet can write a single file, indicated by the credentialBundlePath
+                                        field, or separate files, indicated by the keyPath and
+                                        certificateChainPath fields.
+
+                                        The credential bundle is a single file in PEM format.  The first PEM
+                                        entry is the private key (in PKCS#8 format), and the remaining PEM
+                                        entries are the certificate chain issued by the signer (typically,
+                                        signers will return their certificate chain in leaf-to-root order).
+
+                                        Prefer using the credential bundle format, since your application code
+                                        can read it atomically.  If you use keyPath and certificateChainPath,
+                                        your application must make two separate file reads. If these coincide
+                                        with a certificate rotation, it is possible that the private key and leaf
+                                        certificate you read may not correspond to each other.  Your application
+                                        will need to check for this condition, and re-read until they are
+                                        consistent.
+
+                                        The named signer controls chooses the format of the certificate it
+                                        issues; consult the signer implementation's documentation to learn how to
+                                        use the certificates it issues.
+                                      properties:
+                                        certificateChainPath:
+                                          description: |-
+                                            Write the certificate chain at this path in the projected volume.
+
+                                            Most applications should use credentialBundlePath.  When using keyPath
+                                            and certificateChainPath, your application needs to check that the key
+                                            and leaf certificate are consistent, because it is possible to read the
+                                            files mid-rotation.
+                                          type: string
+                                        credentialBundlePath:
+                                          description: |-
+                                            Write the credential bundle at this path in the projected volume.
+
+                                            The credential bundle is a single file that contains multiple PEM blocks.
+                                            The first PEM block is a PRIVATE KEY block, containing a PKCS#8 private
+                                            key.
+
+                                            The remaining blocks are CERTIFICATE blocks, containing the issued
+                                            certificate chain from the signer (leaf and any intermediates).
+
+                                            Using credentialBundlePath lets your Pod's application code make a single
+                                            atomic read that retrieves a consistent key and certificate chain.  If you
+                                            project them to separate files, your application code will need to
+                                            additionally check that the leaf certificate was issued to the key.
+                                          type: string
+                                        keyPath:
+                                          description: |-
+                                            Write the key at this path in the projected volume.
+
+                                            Most applications should use credentialBundlePath.  When using keyPath
+                                            and certificateChainPath, your application needs to check that the key
+                                            and leaf certificate are consistent, because it is possible to read the
+                                            files mid-rotation.
+                                          type: string
+                                        keyType:
+                                          description: |-
+                                            The type of keypair Kubelet will generate for the pod.
+
+                                            Valid values are "RSA3072", "RSA4096", "ECDSAP256", "ECDSAP384",
+                                            "ECDSAP521", and "ED25519".
+                                          type: string
+                                        maxExpirationSeconds:
+                                          description: |-
+                                            maxExpirationSeconds is the maximum lifetime permitted for the
+                                            certificate.
+
+                                            Kubelet copies this value verbatim into the PodCertificateRequests it
+                                            generates for this projection.
+
+                                            If omitted, kube-apiserver will set it to 86400(24 hours). kube-apiserver
+                                            will reject values shorter than 3600 (1 hour).  The maximum allowable
+                                            value is 7862400 (91 days).
+
+                                            The signer implementation is then free to issue a certificate with any
+                                            lifetime *shorter* than MaxExpirationSeconds, but no shorter than 3600
+                                            seconds (1 hour).  This constraint is enforced by kube-apiserver.
+                                            `kubernetes.io` signers will never issue certificates with a lifetime
+                                            longer than 24 hours.
+                                          format: int32
+                                          type: integer
+                                        signerName:
+                                          description: Kubelet's generated CSRs will be addressed to this signer.
+                                          type: string
+                                      required:
+                                        - keyType
+                                        - signerName
+                                      type: object
                                     secret:
                                       description: secret information about the secret data to project
                                       properties:
@@ -6575,7 +6984,6 @@ spec:
                             description: |-
                               rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
                               Deprecated: RBD is deprecated and the in-tree rbd type is no longer supported.
-                              More info: https://examples.k8s.io/volumes/rbd/README.md
                             properties:
                               fsType:
                                 description: |-
@@ -7047,7 +7455,9 @@ spec:
                             description: EnvVar represents an environment variable present in a Container.
                             properties:
                               name:
-                                description: Name of the environment variable. Must be a C_IDENTIFIER.
+                                description: |-
+                                  Name of the environment variable.
+                                  May consist of any printable ASCII characters except '='.
                                 type: string
                               value:
                                 description: |-
@@ -7099,6 +7509,42 @@ spec:
                                         type: string
                                     required:
                                       - fieldPath
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  fileKeyRef:
+                                    description: |-
+                                      FileKeyRef selects a key of the env file.
+                                      Requires the EnvFiles feature gate to be enabled.
+                                    properties:
+                                      key:
+                                        description: |-
+                                          The key within the env file. An invalid key will prevent the pod from starting.
+                                          The keys defined within a source may consist of any printable ASCII characters except '='.
+                                          During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                        type: string
+                                      optional:
+                                        default: false
+                                        description: |-
+                                          Specify whether the file or its key must be defined. If the file or key
+                                          does not exist, then the env var is not published.
+                                          If optional is set to true and the specified key does not exist,
+                                          the environment variable will not be set in the Pod's containers.
+
+                                          If optional is set to false and the specified key does not exist,
+                                          an error will be returned during Pod creation.
+                                        type: boolean
+                                      path:
+                                        description: |-
+                                          The path within the volume from which to select the file.
+                                          Must be relative and may not contain the '..' path or start with '..'.
+                                        type: string
+                                      volumeName:
+                                        description: The name of the volume mount containing the env file.
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                      - volumeName
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   resourceFieldRef:
@@ -7345,6 +7791,9 @@ spec:
                               format: duration
                               type: string
                           type: object
+                        runtimeClassName:
+                          description: RuntimeClassName specifies the RuntimeClass to be used to run the Pod
+                          type: string
                         schedulerName:
                           description: SchedulerName specifies the scheduler to be used to dispatch the Pod
                           type: string
@@ -7446,6 +7895,86 @@ spec:
                             name:
                               description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
                               type: string
+                            stepResources:
+                              description: |-
+                                StepResources allows overriding the resource requirements for specific steps
+                                defined in the referenced BuildStrategy or ClusterBuildStrategy. Each entry
+                                specifies the step name and the resources to use instead of those defined in
+                                the referenced strategy.
+                              items:
+                                description: |-
+                                  StepResourceOverride allows overriding resource requirements for a specific
+                                  step defined in the referenced BuildStrategy or ClusterBuildStrategy.
+                                properties:
+                                  name:
+                                    description: |-
+                                      Name of the step to override resources for. Must match a step name
+                                      defined in the referenced BuildStrategy or ClusterBuildStrategy.
+                                    type: string
+                                  resources:
+                                    description: Resources defines the compute resource requirements for this step.
+                                    properties:
+                                      claims:
+                                        description: |-
+                                          Claims lists the names of resources, defined in spec.resourceClaims,
+                                          that are used by this container.
+
+                                          This field depends on the
+                                          DynamicResourceAllocation feature gate.
+
+                                          This field is immutable. It can only be set for containers.
+                                        items:
+                                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                                          properties:
+                                            name:
+                                              description: |-
+                                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                                the Pod where this field is used. It makes that resource available
+                                                inside a container.
+                                              type: string
+                                            request:
+                                              description: |-
+                                                Request is the name chosen for a request in the referenced claim.
+                                                If empty, everything from the claim is made available, otherwise
+                                                only the result of this request.
+                                              type: string
+                                          required:
+                                            - name
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-map-keys:
+                                          - name
+                                        x-kubernetes-list-type: map
+                                      limits:
+                                        additionalProperties:
+                                          anyOf:
+                                            - type: integer
+                                            - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        description: |-
+                                          Limits describes the maximum amount of compute resources allowed.
+                                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                        type: object
+                                      requests:
+                                        additionalProperties:
+                                          anyOf:
+                                            - type: integer
+                                            - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        description: |-
+                                          Requests describes the minimum amount of compute resources required.
+                                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                        type: object
+                                    type: object
+                                required:
+                                  - name
+                                  - resources
+                                type: object
+                              type: array
                           required:
                             - name
                           type: object
@@ -8202,15 +8731,13 @@ spec:
                                               volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
                                               If specified, the CSI driver will create or update the volume with the attributes defined
                                               in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                                              it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
-                                              will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
-                                              If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
-                                              will be set by the persistentvolume controller if it exists.
+                                              it can be changed after the claim is created. An empty string or nil value indicates that no
+                                              VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
+                                              this field can be reset to its previous value (including nil) to cancel the modification.
                                               If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
                                               set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
                                               exists.
                                               More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
-                                              (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).
                                             type: string
                                           volumeMode:
                                             description: |-
@@ -8384,12 +8911,9 @@ spec:
                                 description: |-
                                   glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
                                   Deprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported.
-                                  More info: https://examples.k8s.io/volumes/glusterfs/README.md
                                 properties:
                                   endpoints:
-                                    description: |-
-                                      endpoints is the endpoint name that details Glusterfs topology.
-                                      More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+                                    description: endpoints is the endpoint name that details Glusterfs topology.
                                     type: string
                                   path:
                                     description: |-
@@ -8468,7 +8992,7 @@ spec:
                                 description: |-
                                   iscsi represents an ISCSI Disk resource that is attached to a
                                   kubelet's host machine and then exposed to the pod.
-                                  More info: https://examples.k8s.io/volumes/iscsi/README.md
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes/#iscsi
                                 properties:
                                   chapAuthDiscovery:
                                     description: chapAuthDiscovery defines whether support iSCSI Discovery CHAP authentication
@@ -8855,6 +9379,110 @@ spec:
                                               type: array
                                               x-kubernetes-list-type: atomic
                                           type: object
+                                        podCertificate:
+                                          description: |-
+                                            Projects an auto-rotating credential bundle (private key and certificate
+                                            chain) that the pod can use either as a TLS client or server.
+
+                                            Kubelet generates a private key and uses it to send a
+                                            PodCertificateRequest to the named signer.  Once the signer approves the
+                                            request and issues a certificate chain, Kubelet writes the key and
+                                            certificate chain to the pod filesystem.  The pod does not start until
+                                            certificates have been issued for each podCertificate projected volume
+                                            source in its spec.
+
+                                            Kubelet will begin trying to rotate the certificate at the time indicated
+                                            by the signer using the PodCertificateRequest.Status.BeginRefreshAt
+                                            timestamp.
+
+                                            Kubelet can write a single file, indicated by the credentialBundlePath
+                                            field, or separate files, indicated by the keyPath and
+                                            certificateChainPath fields.
+
+                                            The credential bundle is a single file in PEM format.  The first PEM
+                                            entry is the private key (in PKCS#8 format), and the remaining PEM
+                                            entries are the certificate chain issued by the signer (typically,
+                                            signers will return their certificate chain in leaf-to-root order).
+
+                                            Prefer using the credential bundle format, since your application code
+                                            can read it atomically.  If you use keyPath and certificateChainPath,
+                                            your application must make two separate file reads. If these coincide
+                                            with a certificate rotation, it is possible that the private key and leaf
+                                            certificate you read may not correspond to each other.  Your application
+                                            will need to check for this condition, and re-read until they are
+                                            consistent.
+
+                                            The named signer controls chooses the format of the certificate it
+                                            issues; consult the signer implementation's documentation to learn how to
+                                            use the certificates it issues.
+                                          properties:
+                                            certificateChainPath:
+                                              description: |-
+                                                Write the certificate chain at this path in the projected volume.
+
+                                                Most applications should use credentialBundlePath.  When using keyPath
+                                                and certificateChainPath, your application needs to check that the key
+                                                and leaf certificate are consistent, because it is possible to read the
+                                                files mid-rotation.
+                                              type: string
+                                            credentialBundlePath:
+                                              description: |-
+                                                Write the credential bundle at this path in the projected volume.
+
+                                                The credential bundle is a single file that contains multiple PEM blocks.
+                                                The first PEM block is a PRIVATE KEY block, containing a PKCS#8 private
+                                                key.
+
+                                                The remaining blocks are CERTIFICATE blocks, containing the issued
+                                                certificate chain from the signer (leaf and any intermediates).
+
+                                                Using credentialBundlePath lets your Pod's application code make a single
+                                                atomic read that retrieves a consistent key and certificate chain.  If you
+                                                project them to separate files, your application code will need to
+                                                additionally check that the leaf certificate was issued to the key.
+                                              type: string
+                                            keyPath:
+                                              description: |-
+                                                Write the key at this path in the projected volume.
+
+                                                Most applications should use credentialBundlePath.  When using keyPath
+                                                and certificateChainPath, your application needs to check that the key
+                                                and leaf certificate are consistent, because it is possible to read the
+                                                files mid-rotation.
+                                              type: string
+                                            keyType:
+                                              description: |-
+                                                The type of keypair Kubelet will generate for the pod.
+
+                                                Valid values are "RSA3072", "RSA4096", "ECDSAP256", "ECDSAP384",
+                                                "ECDSAP521", and "ED25519".
+                                              type: string
+                                            maxExpirationSeconds:
+                                              description: |-
+                                                maxExpirationSeconds is the maximum lifetime permitted for the
+                                                certificate.
+
+                                                Kubelet copies this value verbatim into the PodCertificateRequests it
+                                                generates for this projection.
+
+                                                If omitted, kube-apiserver will set it to 86400(24 hours). kube-apiserver
+                                                will reject values shorter than 3600 (1 hour).  The maximum allowable
+                                                value is 7862400 (91 days).
+
+                                                The signer implementation is then free to issue a certificate with any
+                                                lifetime *shorter* than MaxExpirationSeconds, but no shorter than 3600
+                                                seconds (1 hour).  This constraint is enforced by kube-apiserver.
+                                                `kubernetes.io` signers will never issue certificates with a lifetime
+                                                longer than 24 hours.
+                                              format: int32
+                                              type: integer
+                                            signerName:
+                                              description: Kubelet's generated CSRs will be addressed to this signer.
+                                              type: string
+                                          required:
+                                            - keyType
+                                            - signerName
+                                          type: object
                                         secret:
                                           description: secret information about the secret data to project
                                           properties:
@@ -8984,7 +9612,6 @@ spec:
                                 description: |-
                                   rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
                                   Deprecated: RBD is deprecated and the in-tree rbd type is no longer supported.
-                                  More info: https://examples.k8s.io/volumes/rbd/README.md
                                 properties:
                                   fsType:
                                     description: |-
@@ -9269,7 +9896,9 @@ spec:
                     description: EnvVar represents an environment variable present in a Container.
                     properties:
                       name:
-                        description: Name of the environment variable. Must be a C_IDENTIFIER.
+                        description: |-
+                          Name of the environment variable.
+                          May consist of any printable ASCII characters except '='.
                         type: string
                       value:
                         description: |-
@@ -9321,6 +9950,42 @@ spec:
                                 type: string
                             required:
                               - fieldPath
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          fileKeyRef:
+                            description: |-
+                              FileKeyRef selects a key of the env file.
+                              Requires the EnvFiles feature gate to be enabled.
+                            properties:
+                              key:
+                                description: |-
+                                  The key within the env file. An invalid key will prevent the pod from starting.
+                                  The keys defined within a source may consist of any printable ASCII characters except '='.
+                                  During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                type: string
+                              optional:
+                                default: false
+                                description: |-
+                                  Specify whether the file or its key must be defined. If the file or key
+                                  does not exist, then the env var is not published.
+                                  If optional is set to true and the specified key does not exist,
+                                  the environment variable will not be set in the Pod's containers.
+
+                                  If optional is set to false and the specified key does not exist,
+                                  an error will be returned during Pod creation.
+                                type: boolean
+                              path:
+                                description: |-
+                                  The path within the volume from which to select the file.
+                                  Must be relative and may not contain the '..' path or start with '..'.
+                                type: string
+                              volumeName:
+                                description: The name of the volume mount containing the env file.
+                                type: string
+                            required:
+                              - key
+                              - path
+                              - volumeName
                             type: object
                             x-kubernetes-map-type: atomic
                           resourceFieldRef:
@@ -9556,6 +10221,9 @@ spec:
                       format: duration
                       type: string
                   type: object
+                runtimeClassName:
+                  description: RuntimeClassName specifies the RuntimeClass to be used to run the Pod
+                  type: string
                 schedulerName:
                   description: SchedulerName specifies the scheduler to be used to dispatch the Pod
                   type: string
@@ -9594,6 +10262,87 @@ spec:
                 state:
                   description: State is used for canceling a buildrun (and maybe more later on).
                   type: string
+                stepResources:
+                  description: |-
+                    StepResources allows overriding the resource requirements for specific steps
+                    defined in the referenced BuildStrategy or ClusterBuildStrategy. Each entry
+                    specifies the step name and the resources to use instead of those defined in
+                    the referenced strategy.
+                    BuildRun stepResources take precedence over Build stepResources.
+                  items:
+                    description: |-
+                      StepResourceOverride allows overriding resource requirements for a specific
+                      step defined in the referenced BuildStrategy or ClusterBuildStrategy.
+                    properties:
+                      name:
+                        description: |-
+                          Name of the step to override resources for. Must match a step name
+                          defined in the referenced BuildStrategy or ClusterBuildStrategy.
+                        type: string
+                      resources:
+                        description: Resources defines the compute resource requirements for this step.
+                        properties:
+                          claims:
+                            description: |-
+                              Claims lists the names of resources, defined in spec.resourceClaims,
+                              that are used by this container.
+
+                              This field depends on the
+                              DynamicResourceAllocation feature gate.
+
+                              This field is immutable. It can only be set for containers.
+                            items:
+                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                              properties:
+                                name:
+                                  description: |-
+                                    Name must match the name of one entry in pod.spec.resourceClaims of
+                                    the Pod where this field is used. It makes that resource available
+                                    inside a container.
+                                  type: string
+                                request:
+                                  description: |-
+                                    Request is the name chosen for a request in the referenced claim.
+                                    If empty, everything from the claim is made available, otherwise
+                                    only the result of this request.
+                                  type: string
+                              required:
+                                - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                              - name
+                            x-kubernetes-list-type: map
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: |-
+                              Limits describes the maximum amount of compute resources allowed.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: |-
+                              Requests describes the minimum amount of compute resources required.
+                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                            type: object
+                        type: object
+                    required:
+                      - name
+                      - resources
+                    type: object
+                  type: array
                 timeout:
                   description: Timeout defines the maximum run time of this BuildRun.
                   format: duration
@@ -10280,15 +11029,13 @@ spec:
                                       volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
                                       If specified, the CSI driver will create or update the volume with the attributes defined
                                       in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                                      it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
-                                      will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
-                                      If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
-                                      will be set by the persistentvolume controller if it exists.
+                                      it can be changed after the claim is created. An empty string or nil value indicates that no
+                                      VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
+                                      this field can be reset to its previous value (including nil) to cancel the modification.
                                       If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
                                       set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
                                       exists.
                                       More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
-                                      (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).
                                     type: string
                                   volumeMode:
                                     description: |-
@@ -10462,12 +11209,9 @@ spec:
                         description: |-
                           glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
                           Deprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported.
-                          More info: https://examples.k8s.io/volumes/glusterfs/README.md
                         properties:
                           endpoints:
-                            description: |-
-                              endpoints is the endpoint name that details Glusterfs topology.
-                              More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+                            description: endpoints is the endpoint name that details Glusterfs topology.
                             type: string
                           path:
                             description: |-
@@ -10546,7 +11290,7 @@ spec:
                         description: |-
                           iscsi represents an ISCSI Disk resource that is attached to a
                           kubelet's host machine and then exposed to the pod.
-                          More info: https://examples.k8s.io/volumes/iscsi/README.md
+                          More info: https://kubernetes.io/docs/concepts/storage/volumes/#iscsi
                         properties:
                           chapAuthDiscovery:
                             description: chapAuthDiscovery defines whether support iSCSI Discovery CHAP authentication
@@ -10933,6 +11677,110 @@ spec:
                                       type: array
                                       x-kubernetes-list-type: atomic
                                   type: object
+                                podCertificate:
+                                  description: |-
+                                    Projects an auto-rotating credential bundle (private key and certificate
+                                    chain) that the pod can use either as a TLS client or server.
+
+                                    Kubelet generates a private key and uses it to send a
+                                    PodCertificateRequest to the named signer.  Once the signer approves the
+                                    request and issues a certificate chain, Kubelet writes the key and
+                                    certificate chain to the pod filesystem.  The pod does not start until
+                                    certificates have been issued for each podCertificate projected volume
+                                    source in its spec.
+
+                                    Kubelet will begin trying to rotate the certificate at the time indicated
+                                    by the signer using the PodCertificateRequest.Status.BeginRefreshAt
+                                    timestamp.
+
+                                    Kubelet can write a single file, indicated by the credentialBundlePath
+                                    field, or separate files, indicated by the keyPath and
+                                    certificateChainPath fields.
+
+                                    The credential bundle is a single file in PEM format.  The first PEM
+                                    entry is the private key (in PKCS#8 format), and the remaining PEM
+                                    entries are the certificate chain issued by the signer (typically,
+                                    signers will return their certificate chain in leaf-to-root order).
+
+                                    Prefer using the credential bundle format, since your application code
+                                    can read it atomically.  If you use keyPath and certificateChainPath,
+                                    your application must make two separate file reads. If these coincide
+                                    with a certificate rotation, it is possible that the private key and leaf
+                                    certificate you read may not correspond to each other.  Your application
+                                    will need to check for this condition, and re-read until they are
+                                    consistent.
+
+                                    The named signer controls chooses the format of the certificate it
+                                    issues; consult the signer implementation's documentation to learn how to
+                                    use the certificates it issues.
+                                  properties:
+                                    certificateChainPath:
+                                      description: |-
+                                        Write the certificate chain at this path in the projected volume.
+
+                                        Most applications should use credentialBundlePath.  When using keyPath
+                                        and certificateChainPath, your application needs to check that the key
+                                        and leaf certificate are consistent, because it is possible to read the
+                                        files mid-rotation.
+                                      type: string
+                                    credentialBundlePath:
+                                      description: |-
+                                        Write the credential bundle at this path in the projected volume.
+
+                                        The credential bundle is a single file that contains multiple PEM blocks.
+                                        The first PEM block is a PRIVATE KEY block, containing a PKCS#8 private
+                                        key.
+
+                                        The remaining blocks are CERTIFICATE blocks, containing the issued
+                                        certificate chain from the signer (leaf and any intermediates).
+
+                                        Using credentialBundlePath lets your Pod's application code make a single
+                                        atomic read that retrieves a consistent key and certificate chain.  If you
+                                        project them to separate files, your application code will need to
+                                        additionally check that the leaf certificate was issued to the key.
+                                      type: string
+                                    keyPath:
+                                      description: |-
+                                        Write the key at this path in the projected volume.
+
+                                        Most applications should use credentialBundlePath.  When using keyPath
+                                        and certificateChainPath, your application needs to check that the key
+                                        and leaf certificate are consistent, because it is possible to read the
+                                        files mid-rotation.
+                                      type: string
+                                    keyType:
+                                      description: |-
+                                        The type of keypair Kubelet will generate for the pod.
+
+                                        Valid values are "RSA3072", "RSA4096", "ECDSAP256", "ECDSAP384",
+                                        "ECDSAP521", and "ED25519".
+                                      type: string
+                                    maxExpirationSeconds:
+                                      description: |-
+                                        maxExpirationSeconds is the maximum lifetime permitted for the
+                                        certificate.
+
+                                        Kubelet copies this value verbatim into the PodCertificateRequests it
+                                        generates for this projection.
+
+                                        If omitted, kube-apiserver will set it to 86400(24 hours). kube-apiserver
+                                        will reject values shorter than 3600 (1 hour).  The maximum allowable
+                                        value is 7862400 (91 days).
+
+                                        The signer implementation is then free to issue a certificate with any
+                                        lifetime *shorter* than MaxExpirationSeconds, but no shorter than 3600
+                                        seconds (1 hour).  This constraint is enforced by kube-apiserver.
+                                        `kubernetes.io` signers will never issue certificates with a lifetime
+                                        longer than 24 hours.
+                                      format: int32
+                                      type: integer
+                                    signerName:
+                                      description: Kubelet's generated CSRs will be addressed to this signer.
+                                      type: string
+                                  required:
+                                    - keyType
+                                    - signerName
+                                  type: object
                                 secret:
                                   description: secret information about the secret data to project
                                   properties:
@@ -11062,7 +11910,6 @@ spec:
                         description: |-
                           rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
                           Deprecated: RBD is deprecated and the in-tree rbd type is no longer supported.
-                          More info: https://examples.k8s.io/volumes/rbd/README.md
                         properties:
                           fsType:
                             description: |-
@@ -11351,7 +12198,9 @@ spec:
                         description: EnvVar represents an environment variable present in a Container.
                         properties:
                           name:
-                            description: Name of the environment variable. Must be a C_IDENTIFIER.
+                            description: |-
+                              Name of the environment variable.
+                              May consist of any printable ASCII characters except '='.
                             type: string
                           value:
                             description: |-
@@ -11403,6 +12252,42 @@ spec:
                                     type: string
                                 required:
                                   - fieldPath
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              fileKeyRef:
+                                description: |-
+                                  FileKeyRef selects a key of the env file.
+                                  Requires the EnvFiles feature gate to be enabled.
+                                properties:
+                                  key:
+                                    description: |-
+                                      The key within the env file. An invalid key will prevent the pod from starting.
+                                      The keys defined within a source may consist of any printable ASCII characters except '='.
+                                      During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                    type: string
+                                  optional:
+                                    default: false
+                                    description: |-
+                                      Specify whether the file or its key must be defined. If the file or key
+                                      does not exist, then the env var is not published.
+                                      If optional is set to true and the specified key does not exist,
+                                      the environment variable will not be set in the Pod's containers.
+
+                                      If optional is set to false and the specified key does not exist,
+                                      an error will be returned during Pod creation.
+                                    type: boolean
+                                  path:
+                                    description: |-
+                                      The path within the volume from which to select the file.
+                                      Must be relative and may not contain the '..' path or start with '..'.
+                                    type: string
+                                  volumeName:
+                                    description: The name of the volume mount containing the env file.
+                                    type: string
+                                required:
+                                  - key
+                                  - path
+                                  - volumeName
                                 type: object
                                 x-kubernetes-map-type: atomic
                               resourceFieldRef:
@@ -11649,6 +12534,9 @@ spec:
                           format: duration
                           type: string
                       type: object
+                    runtimeClassName:
+                      description: RuntimeClassName specifies the RuntimeClass to be used to run the Pod
+                      type: string
                     schedulerName:
                       description: SchedulerName specifies the scheduler to be used to dispatch the Pod
                       type: string
@@ -11750,6 +12638,86 @@ spec:
                         name:
                           description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
                           type: string
+                        stepResources:
+                          description: |-
+                            StepResources allows overriding the resource requirements for specific steps
+                            defined in the referenced BuildStrategy or ClusterBuildStrategy. Each entry
+                            specifies the step name and the resources to use instead of those defined in
+                            the referenced strategy.
+                          items:
+                            description: |-
+                              StepResourceOverride allows overriding resource requirements for a specific
+                              step defined in the referenced BuildStrategy or ClusterBuildStrategy.
+                            properties:
+                              name:
+                                description: |-
+                                  Name of the step to override resources for. Must match a step name
+                                  defined in the referenced BuildStrategy or ClusterBuildStrategy.
+                                type: string
+                              resources:
+                                description: Resources defines the compute resource requirements for this step.
+                                properties:
+                                  claims:
+                                    description: |-
+                                      Claims lists the names of resources, defined in spec.resourceClaims,
+                                      that are used by this container.
+
+                                      This field depends on the
+                                      DynamicResourceAllocation feature gate.
+
+                                      This field is immutable. It can only be set for containers.
+                                    items:
+                                      description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                                      properties:
+                                        name:
+                                          description: |-
+                                            Name must match the name of one entry in pod.spec.resourceClaims of
+                                            the Pod where this field is used. It makes that resource available
+                                            inside a container.
+                                          type: string
+                                        request:
+                                          description: |-
+                                            Request is the name chosen for a request in the referenced claim.
+                                            If empty, everything from the claim is made available, otherwise
+                                            only the result of this request.
+                                          type: string
+                                      required:
+                                        - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                      - name
+                                    x-kubernetes-list-type: map
+                                  limits:
+                                    additionalProperties:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    description: |-
+                                      Limits describes the maximum amount of compute resources allowed.
+                                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                    type: object
+                                  requests:
+                                    additionalProperties:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    description: |-
+                                      Requests describes the minimum amount of compute resources required.
+                                      If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                      otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                    type: object
+                                type: object
+                            required:
+                              - name
+                              - resources
+                            type: object
+                          type: array
                       required:
                         - name
                       type: object
@@ -12506,15 +13474,13 @@ spec:
                                           volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
                                           If specified, the CSI driver will create or update the volume with the attributes defined
                                           in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                                          it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
-                                          will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
-                                          If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
-                                          will be set by the persistentvolume controller if it exists.
+                                          it can be changed after the claim is created. An empty string or nil value indicates that no
+                                          VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
+                                          this field can be reset to its previous value (including nil) to cancel the modification.
                                           If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
                                           set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
                                           exists.
                                           More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
-                                          (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).
                                         type: string
                                       volumeMode:
                                         description: |-
@@ -12688,12 +13654,9 @@ spec:
                             description: |-
                               glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
                               Deprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported.
-                              More info: https://examples.k8s.io/volumes/glusterfs/README.md
                             properties:
                               endpoints:
-                                description: |-
-                                  endpoints is the endpoint name that details Glusterfs topology.
-                                  More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+                                description: endpoints is the endpoint name that details Glusterfs topology.
                                 type: string
                               path:
                                 description: |-
@@ -12772,7 +13735,7 @@ spec:
                             description: |-
                               iscsi represents an ISCSI Disk resource that is attached to a
                               kubelet's host machine and then exposed to the pod.
-                              More info: https://examples.k8s.io/volumes/iscsi/README.md
+                              More info: https://kubernetes.io/docs/concepts/storage/volumes/#iscsi
                             properties:
                               chapAuthDiscovery:
                                 description: chapAuthDiscovery defines whether support iSCSI Discovery CHAP authentication
@@ -13159,6 +14122,110 @@ spec:
                                           type: array
                                           x-kubernetes-list-type: atomic
                                       type: object
+                                    podCertificate:
+                                      description: |-
+                                        Projects an auto-rotating credential bundle (private key and certificate
+                                        chain) that the pod can use either as a TLS client or server.
+
+                                        Kubelet generates a private key and uses it to send a
+                                        PodCertificateRequest to the named signer.  Once the signer approves the
+                                        request and issues a certificate chain, Kubelet writes the key and
+                                        certificate chain to the pod filesystem.  The pod does not start until
+                                        certificates have been issued for each podCertificate projected volume
+                                        source in its spec.
+
+                                        Kubelet will begin trying to rotate the certificate at the time indicated
+                                        by the signer using the PodCertificateRequest.Status.BeginRefreshAt
+                                        timestamp.
+
+                                        Kubelet can write a single file, indicated by the credentialBundlePath
+                                        field, or separate files, indicated by the keyPath and
+                                        certificateChainPath fields.
+
+                                        The credential bundle is a single file in PEM format.  The first PEM
+                                        entry is the private key (in PKCS#8 format), and the remaining PEM
+                                        entries are the certificate chain issued by the signer (typically,
+                                        signers will return their certificate chain in leaf-to-root order).
+
+                                        Prefer using the credential bundle format, since your application code
+                                        can read it atomically.  If you use keyPath and certificateChainPath,
+                                        your application must make two separate file reads. If these coincide
+                                        with a certificate rotation, it is possible that the private key and leaf
+                                        certificate you read may not correspond to each other.  Your application
+                                        will need to check for this condition, and re-read until they are
+                                        consistent.
+
+                                        The named signer controls chooses the format of the certificate it
+                                        issues; consult the signer implementation's documentation to learn how to
+                                        use the certificates it issues.
+                                      properties:
+                                        certificateChainPath:
+                                          description: |-
+                                            Write the certificate chain at this path in the projected volume.
+
+                                            Most applications should use credentialBundlePath.  When using keyPath
+                                            and certificateChainPath, your application needs to check that the key
+                                            and leaf certificate are consistent, because it is possible to read the
+                                            files mid-rotation.
+                                          type: string
+                                        credentialBundlePath:
+                                          description: |-
+                                            Write the credential bundle at this path in the projected volume.
+
+                                            The credential bundle is a single file that contains multiple PEM blocks.
+                                            The first PEM block is a PRIVATE KEY block, containing a PKCS#8 private
+                                            key.
+
+                                            The remaining blocks are CERTIFICATE blocks, containing the issued
+                                            certificate chain from the signer (leaf and any intermediates).
+
+                                            Using credentialBundlePath lets your Pod's application code make a single
+                                            atomic read that retrieves a consistent key and certificate chain.  If you
+                                            project them to separate files, your application code will need to
+                                            additionally check that the leaf certificate was issued to the key.
+                                          type: string
+                                        keyPath:
+                                          description: |-
+                                            Write the key at this path in the projected volume.
+
+                                            Most applications should use credentialBundlePath.  When using keyPath
+                                            and certificateChainPath, your application needs to check that the key
+                                            and leaf certificate are consistent, because it is possible to read the
+                                            files mid-rotation.
+                                          type: string
+                                        keyType:
+                                          description: |-
+                                            The type of keypair Kubelet will generate for the pod.
+
+                                            Valid values are "RSA3072", "RSA4096", "ECDSAP256", "ECDSAP384",
+                                            "ECDSAP521", and "ED25519".
+                                          type: string
+                                        maxExpirationSeconds:
+                                          description: |-
+                                            maxExpirationSeconds is the maximum lifetime permitted for the
+                                            certificate.
+
+                                            Kubelet copies this value verbatim into the PodCertificateRequests it
+                                            generates for this projection.
+
+                                            If omitted, kube-apiserver will set it to 86400(24 hours). kube-apiserver
+                                            will reject values shorter than 3600 (1 hour).  The maximum allowable
+                                            value is 7862400 (91 days).
+
+                                            The signer implementation is then free to issue a certificate with any
+                                            lifetime *shorter* than MaxExpirationSeconds, but no shorter than 3600
+                                            seconds (1 hour).  This constraint is enforced by kube-apiserver.
+                                            `kubernetes.io` signers will never issue certificates with a lifetime
+                                            longer than 24 hours.
+                                          format: int32
+                                          type: integer
+                                        signerName:
+                                          description: Kubelet's generated CSRs will be addressed to this signer.
+                                          type: string
+                                      required:
+                                        - keyType
+                                        - signerName
+                                      type: object
                                     secret:
                                       description: secret information about the secret data to project
                                       properties:
@@ -13288,7 +14355,6 @@ spec:
                             description: |-
                               rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
                               Deprecated: RBD is deprecated and the in-tree rbd type is no longer supported.
-                              More info: https://examples.k8s.io/volumes/rbd/README.md
                             properties:
                               fsType:
                                 description: |-
@@ -13715,7 +14781,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.18.0
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: builds.shipwright.io
 spec:
   conversion:
@@ -13849,7 +14915,9 @@ spec:
                     description: EnvVar represents an environment variable present in a Container.
                     properties:
                       name:
-                        description: Name of the environment variable. Must be a C_IDENTIFIER.
+                        description: |-
+                          Name of the environment variable.
+                          May consist of any printable ASCII characters except '='.
                         type: string
                       value:
                         description: |-
@@ -13901,6 +14969,42 @@ spec:
                                 type: string
                             required:
                               - fieldPath
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          fileKeyRef:
+                            description: |-
+                              FileKeyRef selects a key of the env file.
+                              Requires the EnvFiles feature gate to be enabled.
+                            properties:
+                              key:
+                                description: |-
+                                  The key within the env file. An invalid key will prevent the pod from starting.
+                                  The keys defined within a source may consist of any printable ASCII characters except '='.
+                                  During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                type: string
+                              optional:
+                                default: false
+                                description: |-
+                                  Specify whether the file or its key must be defined. If the file or key
+                                  does not exist, then the env var is not published.
+                                  If optional is set to true and the specified key does not exist,
+                                  the environment variable will not be set in the Pod's containers.
+
+                                  If optional is set to false and the specified key does not exist,
+                                  an error will be returned during Pod creation.
+                                type: boolean
+                              path:
+                                description: |-
+                                  The path within the volume from which to select the file.
+                                  Must be relative and may not contain the '..' path or start with '..'.
+                                type: string
+                              volumeName:
+                                description: The name of the volume mount containing the env file.
+                                type: string
+                            required:
+                              - key
+                              - path
+                              - volumeName
                             type: object
                             x-kubernetes-map-type: atomic
                           resourceFieldRef:
@@ -14941,15 +16045,13 @@ spec:
                                       volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
                                       If specified, the CSI driver will create or update the volume with the attributes defined
                                       in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                                      it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
-                                      will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
-                                      If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
-                                      will be set by the persistentvolume controller if it exists.
+                                      it can be changed after the claim is created. An empty string or nil value indicates that no
+                                      VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
+                                      this field can be reset to its previous value (including nil) to cancel the modification.
                                       If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
                                       set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
                                       exists.
                                       More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
-                                      (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).
                                     type: string
                                   volumeMode:
                                     description: |-
@@ -15123,12 +16225,9 @@ spec:
                         description: |-
                           glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
                           Deprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported.
-                          More info: https://examples.k8s.io/volumes/glusterfs/README.md
                         properties:
                           endpoints:
-                            description: |-
-                              endpoints is the endpoint name that details Glusterfs topology.
-                              More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+                            description: endpoints is the endpoint name that details Glusterfs topology.
                             type: string
                           path:
                             description: |-
@@ -15207,7 +16306,7 @@ spec:
                         description: |-
                           iscsi represents an ISCSI Disk resource that is attached to a
                           kubelet's host machine and then exposed to the pod.
-                          More info: https://examples.k8s.io/volumes/iscsi/README.md
+                          More info: https://kubernetes.io/docs/concepts/storage/volumes/#iscsi
                         properties:
                           chapAuthDiscovery:
                             description: chapAuthDiscovery defines whether support iSCSI Discovery CHAP authentication
@@ -15594,6 +16693,110 @@ spec:
                                       type: array
                                       x-kubernetes-list-type: atomic
                                   type: object
+                                podCertificate:
+                                  description: |-
+                                    Projects an auto-rotating credential bundle (private key and certificate
+                                    chain) that the pod can use either as a TLS client or server.
+
+                                    Kubelet generates a private key and uses it to send a
+                                    PodCertificateRequest to the named signer.  Once the signer approves the
+                                    request and issues a certificate chain, Kubelet writes the key and
+                                    certificate chain to the pod filesystem.  The pod does not start until
+                                    certificates have been issued for each podCertificate projected volume
+                                    source in its spec.
+
+                                    Kubelet will begin trying to rotate the certificate at the time indicated
+                                    by the signer using the PodCertificateRequest.Status.BeginRefreshAt
+                                    timestamp.
+
+                                    Kubelet can write a single file, indicated by the credentialBundlePath
+                                    field, or separate files, indicated by the keyPath and
+                                    certificateChainPath fields.
+
+                                    The credential bundle is a single file in PEM format.  The first PEM
+                                    entry is the private key (in PKCS#8 format), and the remaining PEM
+                                    entries are the certificate chain issued by the signer (typically,
+                                    signers will return their certificate chain in leaf-to-root order).
+
+                                    Prefer using the credential bundle format, since your application code
+                                    can read it atomically.  If you use keyPath and certificateChainPath,
+                                    your application must make two separate file reads. If these coincide
+                                    with a certificate rotation, it is possible that the private key and leaf
+                                    certificate you read may not correspond to each other.  Your application
+                                    will need to check for this condition, and re-read until they are
+                                    consistent.
+
+                                    The named signer controls chooses the format of the certificate it
+                                    issues; consult the signer implementation's documentation to learn how to
+                                    use the certificates it issues.
+                                  properties:
+                                    certificateChainPath:
+                                      description: |-
+                                        Write the certificate chain at this path in the projected volume.
+
+                                        Most applications should use credentialBundlePath.  When using keyPath
+                                        and certificateChainPath, your application needs to check that the key
+                                        and leaf certificate are consistent, because it is possible to read the
+                                        files mid-rotation.
+                                      type: string
+                                    credentialBundlePath:
+                                      description: |-
+                                        Write the credential bundle at this path in the projected volume.
+
+                                        The credential bundle is a single file that contains multiple PEM blocks.
+                                        The first PEM block is a PRIVATE KEY block, containing a PKCS#8 private
+                                        key.
+
+                                        The remaining blocks are CERTIFICATE blocks, containing the issued
+                                        certificate chain from the signer (leaf and any intermediates).
+
+                                        Using credentialBundlePath lets your Pod's application code make a single
+                                        atomic read that retrieves a consistent key and certificate chain.  If you
+                                        project them to separate files, your application code will need to
+                                        additionally check that the leaf certificate was issued to the key.
+                                      type: string
+                                    keyPath:
+                                      description: |-
+                                        Write the key at this path in the projected volume.
+
+                                        Most applications should use credentialBundlePath.  When using keyPath
+                                        and certificateChainPath, your application needs to check that the key
+                                        and leaf certificate are consistent, because it is possible to read the
+                                        files mid-rotation.
+                                      type: string
+                                    keyType:
+                                      description: |-
+                                        The type of keypair Kubelet will generate for the pod.
+
+                                        Valid values are "RSA3072", "RSA4096", "ECDSAP256", "ECDSAP384",
+                                        "ECDSAP521", and "ED25519".
+                                      type: string
+                                    maxExpirationSeconds:
+                                      description: |-
+                                        maxExpirationSeconds is the maximum lifetime permitted for the
+                                        certificate.
+
+                                        Kubelet copies this value verbatim into the PodCertificateRequests it
+                                        generates for this projection.
+
+                                        If omitted, kube-apiserver will set it to 86400(24 hours). kube-apiserver
+                                        will reject values shorter than 3600 (1 hour).  The maximum allowable
+                                        value is 7862400 (91 days).
+
+                                        The signer implementation is then free to issue a certificate with any
+                                        lifetime *shorter* than MaxExpirationSeconds, but no shorter than 3600
+                                        seconds (1 hour).  This constraint is enforced by kube-apiserver.
+                                        `kubernetes.io` signers will never issue certificates with a lifetime
+                                        longer than 24 hours.
+                                      format: int32
+                                      type: integer
+                                    signerName:
+                                      description: Kubelet's generated CSRs will be addressed to this signer.
+                                      type: string
+                                  required:
+                                    - keyType
+                                    - signerName
+                                  type: object
                                 secret:
                                   description: secret information about the secret data to project
                                   properties:
@@ -15723,7 +16926,6 @@ spec:
                         description: |-
                           rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
                           Deprecated: RBD is deprecated and the in-tree rbd type is no longer supported.
-                          More info: https://examples.k8s.io/volumes/rbd/README.md
                         properties:
                           fsType:
                             description: |-
@@ -16077,7 +17279,9 @@ spec:
                     description: EnvVar represents an environment variable present in a Container.
                     properties:
                       name:
-                        description: Name of the environment variable. Must be a C_IDENTIFIER.
+                        description: |-
+                          Name of the environment variable.
+                          May consist of any printable ASCII characters except '='.
                         type: string
                       value:
                         description: |-
@@ -16129,6 +17333,42 @@ spec:
                                 type: string
                             required:
                               - fieldPath
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          fileKeyRef:
+                            description: |-
+                              FileKeyRef selects a key of the env file.
+                              Requires the EnvFiles feature gate to be enabled.
+                            properties:
+                              key:
+                                description: |-
+                                  The key within the env file. An invalid key will prevent the pod from starting.
+                                  The keys defined within a source may consist of any printable ASCII characters except '='.
+                                  During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                type: string
+                              optional:
+                                default: false
+                                description: |-
+                                  Specify whether the file or its key must be defined. If the file or key
+                                  does not exist, then the env var is not published.
+                                  If optional is set to true and the specified key does not exist,
+                                  the environment variable will not be set in the Pod's containers.
+
+                                  If optional is set to false and the specified key does not exist,
+                                  an error will be returned during Pod creation.
+                                type: boolean
+                              path:
+                                description: |-
+                                  The path within the volume from which to select the file.
+                                  Must be relative and may not contain the '..' path or start with '..'.
+                                type: string
+                              volumeName:
+                                description: The name of the volume mount containing the env file.
+                                type: string
+                            required:
+                              - key
+                              - path
+                              - volumeName
                             type: object
                             x-kubernetes-map-type: atomic
                           resourceFieldRef:
@@ -16375,6 +17615,9 @@ spec:
                       format: duration
                       type: string
                   type: object
+                runtimeClassName:
+                  description: RuntimeClassName specifies the RuntimeClass to be used to run the Pod
+                  type: string
                 schedulerName:
                   description: SchedulerName specifies the scheduler to be used to dispatch the Pod
                   type: string
@@ -16476,6 +17719,86 @@ spec:
                     name:
                       description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
                       type: string
+                    stepResources:
+                      description: |-
+                        StepResources allows overriding the resource requirements for specific steps
+                        defined in the referenced BuildStrategy or ClusterBuildStrategy. Each entry
+                        specifies the step name and the resources to use instead of those defined in
+                        the referenced strategy.
+                      items:
+                        description: |-
+                          StepResourceOverride allows overriding resource requirements for a specific
+                          step defined in the referenced BuildStrategy or ClusterBuildStrategy.
+                        properties:
+                          name:
+                            description: |-
+                              Name of the step to override resources for. Must match a step name
+                              defined in the referenced BuildStrategy or ClusterBuildStrategy.
+                            type: string
+                          resources:
+                            description: Resources defines the compute resource requirements for this step.
+                            properties:
+                              claims:
+                                description: |-
+                                  Claims lists the names of resources, defined in spec.resourceClaims,
+                                  that are used by this container.
+
+                                  This field depends on the
+                                  DynamicResourceAllocation feature gate.
+
+                                  This field is immutable. It can only be set for containers.
+                                items:
+                                  description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                                  properties:
+                                    name:
+                                      description: |-
+                                        Name must match the name of one entry in pod.spec.resourceClaims of
+                                        the Pod where this field is used. It makes that resource available
+                                        inside a container.
+                                      type: string
+                                    request:
+                                      description: |-
+                                        Request is the name chosen for a request in the referenced claim.
+                                        If empty, everything from the claim is made available, otherwise
+                                        only the result of this request.
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                  - name
+                                x-kubernetes-list-type: map
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: |-
+                                  Limits describes the maximum amount of compute resources allowed.
+                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: |-
+                                  Requests describes the minimum amount of compute resources required.
+                                  If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                  otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                type: object
+                            type: object
+                        required:
+                          - name
+                          - resources
+                        type: object
+                      type: array
                   required:
                     - name
                   type: object
@@ -17232,15 +18555,13 @@ spec:
                                       volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
                                       If specified, the CSI driver will create or update the volume with the attributes defined
                                       in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                                      it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
-                                      will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
-                                      If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
-                                      will be set by the persistentvolume controller if it exists.
+                                      it can be changed after the claim is created. An empty string or nil value indicates that no
+                                      VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
+                                      this field can be reset to its previous value (including nil) to cancel the modification.
                                       If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
                                       set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
                                       exists.
                                       More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
-                                      (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).
                                     type: string
                                   volumeMode:
                                     description: |-
@@ -17414,12 +18735,9 @@ spec:
                         description: |-
                           glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
                           Deprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported.
-                          More info: https://examples.k8s.io/volumes/glusterfs/README.md
                         properties:
                           endpoints:
-                            description: |-
-                              endpoints is the endpoint name that details Glusterfs topology.
-                              More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+                            description: endpoints is the endpoint name that details Glusterfs topology.
                             type: string
                           path:
                             description: |-
@@ -17498,7 +18816,7 @@ spec:
                         description: |-
                           iscsi represents an ISCSI Disk resource that is attached to a
                           kubelet's host machine and then exposed to the pod.
-                          More info: https://examples.k8s.io/volumes/iscsi/README.md
+                          More info: https://kubernetes.io/docs/concepts/storage/volumes/#iscsi
                         properties:
                           chapAuthDiscovery:
                             description: chapAuthDiscovery defines whether support iSCSI Discovery CHAP authentication
@@ -17885,6 +19203,110 @@ spec:
                                       type: array
                                       x-kubernetes-list-type: atomic
                                   type: object
+                                podCertificate:
+                                  description: |-
+                                    Projects an auto-rotating credential bundle (private key and certificate
+                                    chain) that the pod can use either as a TLS client or server.
+
+                                    Kubelet generates a private key and uses it to send a
+                                    PodCertificateRequest to the named signer.  Once the signer approves the
+                                    request and issues a certificate chain, Kubelet writes the key and
+                                    certificate chain to the pod filesystem.  The pod does not start until
+                                    certificates have been issued for each podCertificate projected volume
+                                    source in its spec.
+
+                                    Kubelet will begin trying to rotate the certificate at the time indicated
+                                    by the signer using the PodCertificateRequest.Status.BeginRefreshAt
+                                    timestamp.
+
+                                    Kubelet can write a single file, indicated by the credentialBundlePath
+                                    field, or separate files, indicated by the keyPath and
+                                    certificateChainPath fields.
+
+                                    The credential bundle is a single file in PEM format.  The first PEM
+                                    entry is the private key (in PKCS#8 format), and the remaining PEM
+                                    entries are the certificate chain issued by the signer (typically,
+                                    signers will return their certificate chain in leaf-to-root order).
+
+                                    Prefer using the credential bundle format, since your application code
+                                    can read it atomically.  If you use keyPath and certificateChainPath,
+                                    your application must make two separate file reads. If these coincide
+                                    with a certificate rotation, it is possible that the private key and leaf
+                                    certificate you read may not correspond to each other.  Your application
+                                    will need to check for this condition, and re-read until they are
+                                    consistent.
+
+                                    The named signer controls chooses the format of the certificate it
+                                    issues; consult the signer implementation's documentation to learn how to
+                                    use the certificates it issues.
+                                  properties:
+                                    certificateChainPath:
+                                      description: |-
+                                        Write the certificate chain at this path in the projected volume.
+
+                                        Most applications should use credentialBundlePath.  When using keyPath
+                                        and certificateChainPath, your application needs to check that the key
+                                        and leaf certificate are consistent, because it is possible to read the
+                                        files mid-rotation.
+                                      type: string
+                                    credentialBundlePath:
+                                      description: |-
+                                        Write the credential bundle at this path in the projected volume.
+
+                                        The credential bundle is a single file that contains multiple PEM blocks.
+                                        The first PEM block is a PRIVATE KEY block, containing a PKCS#8 private
+                                        key.
+
+                                        The remaining blocks are CERTIFICATE blocks, containing the issued
+                                        certificate chain from the signer (leaf and any intermediates).
+
+                                        Using credentialBundlePath lets your Pod's application code make a single
+                                        atomic read that retrieves a consistent key and certificate chain.  If you
+                                        project them to separate files, your application code will need to
+                                        additionally check that the leaf certificate was issued to the key.
+                                      type: string
+                                    keyPath:
+                                      description: |-
+                                        Write the key at this path in the projected volume.
+
+                                        Most applications should use credentialBundlePath.  When using keyPath
+                                        and certificateChainPath, your application needs to check that the key
+                                        and leaf certificate are consistent, because it is possible to read the
+                                        files mid-rotation.
+                                      type: string
+                                    keyType:
+                                      description: |-
+                                        The type of keypair Kubelet will generate for the pod.
+
+                                        Valid values are "RSA3072", "RSA4096", "ECDSAP256", "ECDSAP384",
+                                        "ECDSAP521", and "ED25519".
+                                      type: string
+                                    maxExpirationSeconds:
+                                      description: |-
+                                        maxExpirationSeconds is the maximum lifetime permitted for the
+                                        certificate.
+
+                                        Kubelet copies this value verbatim into the PodCertificateRequests it
+                                        generates for this projection.
+
+                                        If omitted, kube-apiserver will set it to 86400(24 hours). kube-apiserver
+                                        will reject values shorter than 3600 (1 hour).  The maximum allowable
+                                        value is 7862400 (91 days).
+
+                                        The signer implementation is then free to issue a certificate with any
+                                        lifetime *shorter* than MaxExpirationSeconds, but no shorter than 3600
+                                        seconds (1 hour).  This constraint is enforced by kube-apiserver.
+                                        `kubernetes.io` signers will never issue certificates with a lifetime
+                                        longer than 24 hours.
+                                      format: int32
+                                      type: integer
+                                    signerName:
+                                      description: Kubelet's generated CSRs will be addressed to this signer.
+                                      type: string
+                                  required:
+                                    - keyType
+                                    - signerName
+                                  type: object
                                 secret:
                                   description: secret information about the secret data to project
                                   properties:
@@ -18014,7 +19436,6 @@ spec:
                         description: |-
                           rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
                           Deprecated: RBD is deprecated and the in-tree rbd type is no longer supported.
-                          More info: https://examples.k8s.io/volumes/rbd/README.md
                         properties:
                           fsType:
                             description: |-
@@ -18321,7 +19742,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.18.0
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: buildstrategies.shipwright.io
 spec:
   conversion:
@@ -18416,7 +19837,9 @@ spec:
                           description: EnvVar represents an environment variable present in a Container.
                           properties:
                             name:
-                              description: Name of the environment variable. Must be a C_IDENTIFIER.
+                              description: |-
+                                Name of the environment variable.
+                                May consist of any printable ASCII characters except '='.
                               type: string
                             value:
                               description: |-
@@ -18468,6 +19891,42 @@ spec:
                                       type: string
                                   required:
                                     - fieldPath
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                fileKeyRef:
+                                  description: |-
+                                    FileKeyRef selects a key of the env file.
+                                    Requires the EnvFiles feature gate to be enabled.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        The key within the env file. An invalid key will prevent the pod from starting.
+                                        The keys defined within a source may consist of any printable ASCII characters except '='.
+                                        During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                      type: string
+                                    optional:
+                                      default: false
+                                      description: |-
+                                        Specify whether the file or its key must be defined. If the file or key
+                                        does not exist, then the env var is not published.
+                                        If optional is set to true and the specified key does not exist,
+                                        the environment variable will not be set in the Pod's containers.
+
+                                        If optional is set to false and the specified key does not exist,
+                                        an error will be returned during Pod creation.
+                                      type: boolean
+                                    path:
+                                      description: |-
+                                        The path within the volume from which to select the file.
+                                        Must be relative and may not contain the '..' path or start with '..'.
+                                      type: string
+                                    volumeName:
+                                      description: The name of the volume mount containing the env file.
+                                      type: string
+                                  required:
+                                    - key
+                                    - path
+                                    - volumeName
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 resourceFieldRef:
@@ -18525,8 +19984,8 @@ spec:
                       envFrom:
                         description: |-
                           List of sources to populate environment variables in the container.
-                          The keys defined within a source must be a C_IDENTIFIER. All invalid keys
-                          will be reported as an event when the container is starting. When a key exists in multiple
+                          The keys defined within a source may consist of any printable ASCII characters except '='.
+                          When a key exists in multiple
                           sources, the value associated with the last source will take precedence.
                           Values defined by an Env with a duplicate key will take precedence.
                           Cannot be updated.
@@ -18551,7 +20010,9 @@ spec:
                               type: object
                               x-kubernetes-map-type: atomic
                             prefix:
-                              description: Optional text to prepend to the name of each environment variable. Must be a C_IDENTIFIER.
+                              description: |-
+                                Optional text to prepend to the name of each environment variable.
+                                May consist of any printable ASCII characters except '='.
                               type: string
                             secretRef:
                               description: The Secret to select from
@@ -19196,7 +20657,7 @@ spec:
                               Claims lists the names of resources, defined in spec.resourceClaims,
                               that are used by this container.
 
-                              This is an alpha field and requires enabling the
+                              This field depends on the
                               DynamicResourceAllocation feature gate.
 
                               This field is immutable. It can only be set for containers.
@@ -19250,10 +20711,10 @@ spec:
                       restartPolicy:
                         description: |-
                           RestartPolicy defines the restart behavior of individual containers in a pod.
-                          This field may only be set for init containers, and the only allowed value is "Always".
-                          For non-init containers or when this field is not specified,
+                          This overrides the pod-level restart policy. When this field is not specified,
                           the restart behavior is defined by the Pod's restart policy and the container type.
-                          Setting the RestartPolicy as "Always" for the init container will have the following effect:
+                          Additionally, setting the RestartPolicy as "Always" for the init container will
+                          have the following effect:
                           this init container will be continually restarted on
                           exit until all regular containers have terminated. Once all regular
                           containers have completed, all init containers with restartPolicy "Always"
@@ -19265,6 +20726,57 @@ spec:
                           init container is started, or after any startupProbe has successfully
                           completed.
                         type: string
+                      restartPolicyRules:
+                        description: |-
+                          Represents a list of rules to be checked to determine if the
+                          container should be restarted on exit. The rules are evaluated in
+                          order. Once a rule matches a container exit condition, the remaining
+                          rules are ignored. If no rule matches the container exit condition,
+                          the Container-level restart policy determines the whether the container
+                          is restarted or not. Constraints on the rules:
+                          - At most 20 rules are allowed.
+                          - Rules can have the same action.
+                          - Identical rules are not forbidden in validations.
+                          When rules are specified, container MUST set RestartPolicy explicitly
+                          even it if matches the Pod's RestartPolicy.
+                        items:
+                          description: ContainerRestartRule describes how a container exit is handled.
+                          properties:
+                            action:
+                              description: |-
+                                Specifies the action taken on a container exit if the requirements
+                                are satisfied. The only possible value is "Restart" to restart the
+                                container.
+                              type: string
+                            exitCodes:
+                              description: Represents the exit codes to check on container exits.
+                              properties:
+                                operator:
+                                  description: |-
+                                    Represents the relationship between the container exit code(s) and the
+                                    specified values. Possible values are:
+                                    - In: the requirement is satisfied if the container exit code is in the
+                                      set of specified values.
+                                    - NotIn: the requirement is satisfied if the container exit code is
+                                      not in the set of specified values.
+                                  type: string
+                                values:
+                                  description: |-
+                                    Specifies the set of values to check for container exit codes.
+                                    At most 255 elements are allowed.
+                                  items:
+                                    format: int32
+                                    type: integer
+                                  type: array
+                                  x-kubernetes-list-type: set
+                              required:
+                                - operator
+                              type: object
+                          required:
+                            - action
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
                       securityContext:
                         description: |-
                           SecurityContext defines the security options the container should be run with.
@@ -20446,15 +21958,13 @@ spec:
                                       volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
                                       If specified, the CSI driver will create or update the volume with the attributes defined
                                       in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                                      it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
-                                      will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
-                                      If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
-                                      will be set by the persistentvolume controller if it exists.
+                                      it can be changed after the claim is created. An empty string or nil value indicates that no
+                                      VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
+                                      this field can be reset to its previous value (including nil) to cancel the modification.
                                       If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
                                       set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
                                       exists.
                                       More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
-                                      (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).
                                     type: string
                                   volumeMode:
                                     description: |-
@@ -20628,12 +22138,9 @@ spec:
                         description: |-
                           glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
                           Deprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported.
-                          More info: https://examples.k8s.io/volumes/glusterfs/README.md
                         properties:
                           endpoints:
-                            description: |-
-                              endpoints is the endpoint name that details Glusterfs topology.
-                              More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+                            description: endpoints is the endpoint name that details Glusterfs topology.
                             type: string
                           path:
                             description: |-
@@ -20712,7 +22219,7 @@ spec:
                         description: |-
                           iscsi represents an ISCSI Disk resource that is attached to a
                           kubelet's host machine and then exposed to the pod.
-                          More info: https://examples.k8s.io/volumes/iscsi/README.md
+                          More info: https://kubernetes.io/docs/concepts/storage/volumes/#iscsi
                         properties:
                           chapAuthDiscovery:
                             description: chapAuthDiscovery defines whether support iSCSI Discovery CHAP authentication
@@ -21104,6 +22611,110 @@ spec:
                                       type: array
                                       x-kubernetes-list-type: atomic
                                   type: object
+                                podCertificate:
+                                  description: |-
+                                    Projects an auto-rotating credential bundle (private key and certificate
+                                    chain) that the pod can use either as a TLS client or server.
+
+                                    Kubelet generates a private key and uses it to send a
+                                    PodCertificateRequest to the named signer.  Once the signer approves the
+                                    request and issues a certificate chain, Kubelet writes the key and
+                                    certificate chain to the pod filesystem.  The pod does not start until
+                                    certificates have been issued for each podCertificate projected volume
+                                    source in its spec.
+
+                                    Kubelet will begin trying to rotate the certificate at the time indicated
+                                    by the signer using the PodCertificateRequest.Status.BeginRefreshAt
+                                    timestamp.
+
+                                    Kubelet can write a single file, indicated by the credentialBundlePath
+                                    field, or separate files, indicated by the keyPath and
+                                    certificateChainPath fields.
+
+                                    The credential bundle is a single file in PEM format.  The first PEM
+                                    entry is the private key (in PKCS#8 format), and the remaining PEM
+                                    entries are the certificate chain issued by the signer (typically,
+                                    signers will return their certificate chain in leaf-to-root order).
+
+                                    Prefer using the credential bundle format, since your application code
+                                    can read it atomically.  If you use keyPath and certificateChainPath,
+                                    your application must make two separate file reads. If these coincide
+                                    with a certificate rotation, it is possible that the private key and leaf
+                                    certificate you read may not correspond to each other.  Your application
+                                    will need to check for this condition, and re-read until they are
+                                    consistent.
+
+                                    The named signer controls chooses the format of the certificate it
+                                    issues; consult the signer implementation's documentation to learn how to
+                                    use the certificates it issues.
+                                  properties:
+                                    certificateChainPath:
+                                      description: |-
+                                        Write the certificate chain at this path in the projected volume.
+
+                                        Most applications should use credentialBundlePath.  When using keyPath
+                                        and certificateChainPath, your application needs to check that the key
+                                        and leaf certificate are consistent, because it is possible to read the
+                                        files mid-rotation.
+                                      type: string
+                                    credentialBundlePath:
+                                      description: |-
+                                        Write the credential bundle at this path in the projected volume.
+
+                                        The credential bundle is a single file that contains multiple PEM blocks.
+                                        The first PEM block is a PRIVATE KEY block, containing a PKCS#8 private
+                                        key.
+
+                                        The remaining blocks are CERTIFICATE blocks, containing the issued
+                                        certificate chain from the signer (leaf and any intermediates).
+
+                                        Using credentialBundlePath lets your Pod's application code make a single
+                                        atomic read that retrieves a consistent key and certificate chain.  If you
+                                        project them to separate files, your application code will need to
+                                        additionally check that the leaf certificate was issued to the key.
+                                      type: string
+                                    keyPath:
+                                      description: |-
+                                        Write the key at this path in the projected volume.
+
+                                        Most applications should use credentialBundlePath.  When using keyPath
+                                        and certificateChainPath, your application needs to check that the key
+                                        and leaf certificate are consistent, because it is possible to read the
+                                        files mid-rotation.
+                                      type: string
+                                    keyType:
+                                      description: |-
+                                        The type of keypair Kubelet will generate for the pod.
+
+                                        Valid values are "RSA3072", "RSA4096", "ECDSAP256", "ECDSAP384",
+                                        "ECDSAP521", and "ED25519".
+                                      type: string
+                                    maxExpirationSeconds:
+                                      description: |-
+                                        maxExpirationSeconds is the maximum lifetime permitted for the
+                                        certificate.
+
+                                        Kubelet copies this value verbatim into the PodCertificateRequests it
+                                        generates for this projection.
+
+                                        If omitted, kube-apiserver will set it to 86400(24 hours). kube-apiserver
+                                        will reject values shorter than 3600 (1 hour).  The maximum allowable
+                                        value is 7862400 (91 days).
+
+                                        The signer implementation is then free to issue a certificate with any
+                                        lifetime *shorter* than MaxExpirationSeconds, but no shorter than 3600
+                                        seconds (1 hour).  This constraint is enforced by kube-apiserver.
+                                        `kubernetes.io` signers will never issue certificates with a lifetime
+                                        longer than 24 hours.
+                                      format: int32
+                                      type: integer
+                                    signerName:
+                                      description: Kubelet's generated CSRs will be addressed to this signer.
+                                      type: string
+                                  required:
+                                    - keyType
+                                    - signerName
+                                  type: object
                                 secret:
                                   description: secret information about the secret data to project
                                   properties:
@@ -21233,7 +22844,6 @@ spec:
                         description: |-
                           rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
                           Deprecated: RBD is deprecated and the in-tree rbd type is no longer supported.
-                          More info: https://examples.k8s.io/volumes/rbd/README.md
                         properties:
                           fsType:
                             description: |-
@@ -21641,7 +23251,9 @@ spec:
                           description: EnvVar represents an environment variable present in a Container.
                           properties:
                             name:
-                              description: Name of the environment variable. Must be a C_IDENTIFIER.
+                              description: |-
+                                Name of the environment variable.
+                                May consist of any printable ASCII characters except '='.
                               type: string
                             value:
                               description: |-
@@ -21693,6 +23305,42 @@ spec:
                                       type: string
                                   required:
                                     - fieldPath
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                fileKeyRef:
+                                  description: |-
+                                    FileKeyRef selects a key of the env file.
+                                    Requires the EnvFiles feature gate to be enabled.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        The key within the env file. An invalid key will prevent the pod from starting.
+                                        The keys defined within a source may consist of any printable ASCII characters except '='.
+                                        During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                      type: string
+                                    optional:
+                                      default: false
+                                      description: |-
+                                        Specify whether the file or its key must be defined. If the file or key
+                                        does not exist, then the env var is not published.
+                                        If optional is set to true and the specified key does not exist,
+                                        the environment variable will not be set in the Pod's containers.
+
+                                        If optional is set to false and the specified key does not exist,
+                                        an error will be returned during Pod creation.
+                                      type: boolean
+                                    path:
+                                      description: |-
+                                        The path within the volume from which to select the file.
+                                        Must be relative and may not contain the '..' path or start with '..'.
+                                      type: string
+                                    volumeName:
+                                      description: The name of the volume mount containing the env file.
+                                      type: string
+                                  required:
+                                    - key
+                                    - path
+                                    - volumeName
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 resourceFieldRef:
@@ -21776,7 +23424,7 @@ spec:
                               Claims lists the names of resources, defined in spec.resourceClaims,
                               that are used by this container.
 
-                              This is an alpha field and requires enabling the
+                              This field depends on the
                               DynamicResourceAllocation feature gate.
 
                               This field is immutable. It can only be set for containers.
@@ -22737,15 +24385,13 @@ spec:
                                       volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
                                       If specified, the CSI driver will create or update the volume with the attributes defined
                                       in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                                      it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
-                                      will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
-                                      If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
-                                      will be set by the persistentvolume controller if it exists.
+                                      it can be changed after the claim is created. An empty string or nil value indicates that no
+                                      VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
+                                      this field can be reset to its previous value (including nil) to cancel the modification.
                                       If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
                                       set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
                                       exists.
                                       More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
-                                      (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).
                                     type: string
                                   volumeMode:
                                     description: |-
@@ -22919,12 +24565,9 @@ spec:
                         description: |-
                           glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
                           Deprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported.
-                          More info: https://examples.k8s.io/volumes/glusterfs/README.md
                         properties:
                           endpoints:
-                            description: |-
-                              endpoints is the endpoint name that details Glusterfs topology.
-                              More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+                            description: endpoints is the endpoint name that details Glusterfs topology.
                             type: string
                           path:
                             description: |-
@@ -23003,7 +24646,7 @@ spec:
                         description: |-
                           iscsi represents an ISCSI Disk resource that is attached to a
                           kubelet's host machine and then exposed to the pod.
-                          More info: https://examples.k8s.io/volumes/iscsi/README.md
+                          More info: https://kubernetes.io/docs/concepts/storage/volumes/#iscsi
                         properties:
                           chapAuthDiscovery:
                             description: chapAuthDiscovery defines whether support iSCSI Discovery CHAP authentication
@@ -23395,6 +25038,110 @@ spec:
                                       type: array
                                       x-kubernetes-list-type: atomic
                                   type: object
+                                podCertificate:
+                                  description: |-
+                                    Projects an auto-rotating credential bundle (private key and certificate
+                                    chain) that the pod can use either as a TLS client or server.
+
+                                    Kubelet generates a private key and uses it to send a
+                                    PodCertificateRequest to the named signer.  Once the signer approves the
+                                    request and issues a certificate chain, Kubelet writes the key and
+                                    certificate chain to the pod filesystem.  The pod does not start until
+                                    certificates have been issued for each podCertificate projected volume
+                                    source in its spec.
+
+                                    Kubelet will begin trying to rotate the certificate at the time indicated
+                                    by the signer using the PodCertificateRequest.Status.BeginRefreshAt
+                                    timestamp.
+
+                                    Kubelet can write a single file, indicated by the credentialBundlePath
+                                    field, or separate files, indicated by the keyPath and
+                                    certificateChainPath fields.
+
+                                    The credential bundle is a single file in PEM format.  The first PEM
+                                    entry is the private key (in PKCS#8 format), and the remaining PEM
+                                    entries are the certificate chain issued by the signer (typically,
+                                    signers will return their certificate chain in leaf-to-root order).
+
+                                    Prefer using the credential bundle format, since your application code
+                                    can read it atomically.  If you use keyPath and certificateChainPath,
+                                    your application must make two separate file reads. If these coincide
+                                    with a certificate rotation, it is possible that the private key and leaf
+                                    certificate you read may not correspond to each other.  Your application
+                                    will need to check for this condition, and re-read until they are
+                                    consistent.
+
+                                    The named signer controls chooses the format of the certificate it
+                                    issues; consult the signer implementation's documentation to learn how to
+                                    use the certificates it issues.
+                                  properties:
+                                    certificateChainPath:
+                                      description: |-
+                                        Write the certificate chain at this path in the projected volume.
+
+                                        Most applications should use credentialBundlePath.  When using keyPath
+                                        and certificateChainPath, your application needs to check that the key
+                                        and leaf certificate are consistent, because it is possible to read the
+                                        files mid-rotation.
+                                      type: string
+                                    credentialBundlePath:
+                                      description: |-
+                                        Write the credential bundle at this path in the projected volume.
+
+                                        The credential bundle is a single file that contains multiple PEM blocks.
+                                        The first PEM block is a PRIVATE KEY block, containing a PKCS#8 private
+                                        key.
+
+                                        The remaining blocks are CERTIFICATE blocks, containing the issued
+                                        certificate chain from the signer (leaf and any intermediates).
+
+                                        Using credentialBundlePath lets your Pod's application code make a single
+                                        atomic read that retrieves a consistent key and certificate chain.  If you
+                                        project them to separate files, your application code will need to
+                                        additionally check that the leaf certificate was issued to the key.
+                                      type: string
+                                    keyPath:
+                                      description: |-
+                                        Write the key at this path in the projected volume.
+
+                                        Most applications should use credentialBundlePath.  When using keyPath
+                                        and certificateChainPath, your application needs to check that the key
+                                        and leaf certificate are consistent, because it is possible to read the
+                                        files mid-rotation.
+                                      type: string
+                                    keyType:
+                                      description: |-
+                                        The type of keypair Kubelet will generate for the pod.
+
+                                        Valid values are "RSA3072", "RSA4096", "ECDSAP256", "ECDSAP384",
+                                        "ECDSAP521", and "ED25519".
+                                      type: string
+                                    maxExpirationSeconds:
+                                      description: |-
+                                        maxExpirationSeconds is the maximum lifetime permitted for the
+                                        certificate.
+
+                                        Kubelet copies this value verbatim into the PodCertificateRequests it
+                                        generates for this projection.
+
+                                        If omitted, kube-apiserver will set it to 86400(24 hours). kube-apiserver
+                                        will reject values shorter than 3600 (1 hour).  The maximum allowable
+                                        value is 7862400 (91 days).
+
+                                        The signer implementation is then free to issue a certificate with any
+                                        lifetime *shorter* than MaxExpirationSeconds, but no shorter than 3600
+                                        seconds (1 hour).  This constraint is enforced by kube-apiserver.
+                                        `kubernetes.io` signers will never issue certificates with a lifetime
+                                        longer than 24 hours.
+                                      format: int32
+                                      type: integer
+                                    signerName:
+                                      description: Kubelet's generated CSRs will be addressed to this signer.
+                                      type: string
+                                  required:
+                                    - keyType
+                                    - signerName
+                                  type: object
                                 secret:
                                   description: secret information about the secret data to project
                                   properties:
@@ -23524,7 +25271,6 @@ spec:
                         description: |-
                           rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
                           Deprecated: RBD is deprecated and the in-tree rbd type is no longer supported.
-                          More info: https://examples.k8s.io/volumes/rbd/README.md
                         properties:
                           fsType:
                             description: |-
@@ -23815,7 +25561,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.18.0
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: clusterbuildstrategies.shipwright.io
 spec:
   conversion:
@@ -23910,7 +25656,9 @@ spec:
                           description: EnvVar represents an environment variable present in a Container.
                           properties:
                             name:
-                              description: Name of the environment variable. Must be a C_IDENTIFIER.
+                              description: |-
+                                Name of the environment variable.
+                                May consist of any printable ASCII characters except '='.
                               type: string
                             value:
                               description: |-
@@ -23962,6 +25710,42 @@ spec:
                                       type: string
                                   required:
                                     - fieldPath
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                fileKeyRef:
+                                  description: |-
+                                    FileKeyRef selects a key of the env file.
+                                    Requires the EnvFiles feature gate to be enabled.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        The key within the env file. An invalid key will prevent the pod from starting.
+                                        The keys defined within a source may consist of any printable ASCII characters except '='.
+                                        During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                      type: string
+                                    optional:
+                                      default: false
+                                      description: |-
+                                        Specify whether the file or its key must be defined. If the file or key
+                                        does not exist, then the env var is not published.
+                                        If optional is set to true and the specified key does not exist,
+                                        the environment variable will not be set in the Pod's containers.
+
+                                        If optional is set to false and the specified key does not exist,
+                                        an error will be returned during Pod creation.
+                                      type: boolean
+                                    path:
+                                      description: |-
+                                        The path within the volume from which to select the file.
+                                        Must be relative and may not contain the '..' path or start with '..'.
+                                      type: string
+                                    volumeName:
+                                      description: The name of the volume mount containing the env file.
+                                      type: string
+                                  required:
+                                    - key
+                                    - path
+                                    - volumeName
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 resourceFieldRef:
@@ -24019,8 +25803,8 @@ spec:
                       envFrom:
                         description: |-
                           List of sources to populate environment variables in the container.
-                          The keys defined within a source must be a C_IDENTIFIER. All invalid keys
-                          will be reported as an event when the container is starting. When a key exists in multiple
+                          The keys defined within a source may consist of any printable ASCII characters except '='.
+                          When a key exists in multiple
                           sources, the value associated with the last source will take precedence.
                           Values defined by an Env with a duplicate key will take precedence.
                           Cannot be updated.
@@ -24045,7 +25829,9 @@ spec:
                               type: object
                               x-kubernetes-map-type: atomic
                             prefix:
-                              description: Optional text to prepend to the name of each environment variable. Must be a C_IDENTIFIER.
+                              description: |-
+                                Optional text to prepend to the name of each environment variable.
+                                May consist of any printable ASCII characters except '='.
                               type: string
                             secretRef:
                               description: The Secret to select from
@@ -24690,7 +26476,7 @@ spec:
                               Claims lists the names of resources, defined in spec.resourceClaims,
                               that are used by this container.
 
-                              This is an alpha field and requires enabling the
+                              This field depends on the
                               DynamicResourceAllocation feature gate.
 
                               This field is immutable. It can only be set for containers.
@@ -24744,10 +26530,10 @@ spec:
                       restartPolicy:
                         description: |-
                           RestartPolicy defines the restart behavior of individual containers in a pod.
-                          This field may only be set for init containers, and the only allowed value is "Always".
-                          For non-init containers or when this field is not specified,
+                          This overrides the pod-level restart policy. When this field is not specified,
                           the restart behavior is defined by the Pod's restart policy and the container type.
-                          Setting the RestartPolicy as "Always" for the init container will have the following effect:
+                          Additionally, setting the RestartPolicy as "Always" for the init container will
+                          have the following effect:
                           this init container will be continually restarted on
                           exit until all regular containers have terminated. Once all regular
                           containers have completed, all init containers with restartPolicy "Always"
@@ -24759,6 +26545,57 @@ spec:
                           init container is started, or after any startupProbe has successfully
                           completed.
                         type: string
+                      restartPolicyRules:
+                        description: |-
+                          Represents a list of rules to be checked to determine if the
+                          container should be restarted on exit. The rules are evaluated in
+                          order. Once a rule matches a container exit condition, the remaining
+                          rules are ignored. If no rule matches the container exit condition,
+                          the Container-level restart policy determines the whether the container
+                          is restarted or not. Constraints on the rules:
+                          - At most 20 rules are allowed.
+                          - Rules can have the same action.
+                          - Identical rules are not forbidden in validations.
+                          When rules are specified, container MUST set RestartPolicy explicitly
+                          even it if matches the Pod's RestartPolicy.
+                        items:
+                          description: ContainerRestartRule describes how a container exit is handled.
+                          properties:
+                            action:
+                              description: |-
+                                Specifies the action taken on a container exit if the requirements
+                                are satisfied. The only possible value is "Restart" to restart the
+                                container.
+                              type: string
+                            exitCodes:
+                              description: Represents the exit codes to check on container exits.
+                              properties:
+                                operator:
+                                  description: |-
+                                    Represents the relationship between the container exit code(s) and the
+                                    specified values. Possible values are:
+                                    - In: the requirement is satisfied if the container exit code is in the
+                                      set of specified values.
+                                    - NotIn: the requirement is satisfied if the container exit code is
+                                      not in the set of specified values.
+                                  type: string
+                                values:
+                                  description: |-
+                                    Specifies the set of values to check for container exit codes.
+                                    At most 255 elements are allowed.
+                                  items:
+                                    format: int32
+                                    type: integer
+                                  type: array
+                                  x-kubernetes-list-type: set
+                              required:
+                                - operator
+                              type: object
+                          required:
+                            - action
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
                       securityContext:
                         description: |-
                           SecurityContext defines the security options the container should be run with.
@@ -25940,15 +27777,13 @@ spec:
                                       volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
                                       If specified, the CSI driver will create or update the volume with the attributes defined
                                       in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                                      it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
-                                      will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
-                                      If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
-                                      will be set by the persistentvolume controller if it exists.
+                                      it can be changed after the claim is created. An empty string or nil value indicates that no
+                                      VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
+                                      this field can be reset to its previous value (including nil) to cancel the modification.
                                       If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
                                       set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
                                       exists.
                                       More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
-                                      (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).
                                     type: string
                                   volumeMode:
                                     description: |-
@@ -26122,12 +27957,9 @@ spec:
                         description: |-
                           glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
                           Deprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported.
-                          More info: https://examples.k8s.io/volumes/glusterfs/README.md
                         properties:
                           endpoints:
-                            description: |-
-                              endpoints is the endpoint name that details Glusterfs topology.
-                              More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+                            description: endpoints is the endpoint name that details Glusterfs topology.
                             type: string
                           path:
                             description: |-
@@ -26206,7 +28038,7 @@ spec:
                         description: |-
                           iscsi represents an ISCSI Disk resource that is attached to a
                           kubelet's host machine and then exposed to the pod.
-                          More info: https://examples.k8s.io/volumes/iscsi/README.md
+                          More info: https://kubernetes.io/docs/concepts/storage/volumes/#iscsi
                         properties:
                           chapAuthDiscovery:
                             description: chapAuthDiscovery defines whether support iSCSI Discovery CHAP authentication
@@ -26598,6 +28430,110 @@ spec:
                                       type: array
                                       x-kubernetes-list-type: atomic
                                   type: object
+                                podCertificate:
+                                  description: |-
+                                    Projects an auto-rotating credential bundle (private key and certificate
+                                    chain) that the pod can use either as a TLS client or server.
+
+                                    Kubelet generates a private key and uses it to send a
+                                    PodCertificateRequest to the named signer.  Once the signer approves the
+                                    request and issues a certificate chain, Kubelet writes the key and
+                                    certificate chain to the pod filesystem.  The pod does not start until
+                                    certificates have been issued for each podCertificate projected volume
+                                    source in its spec.
+
+                                    Kubelet will begin trying to rotate the certificate at the time indicated
+                                    by the signer using the PodCertificateRequest.Status.BeginRefreshAt
+                                    timestamp.
+
+                                    Kubelet can write a single file, indicated by the credentialBundlePath
+                                    field, or separate files, indicated by the keyPath and
+                                    certificateChainPath fields.
+
+                                    The credential bundle is a single file in PEM format.  The first PEM
+                                    entry is the private key (in PKCS#8 format), and the remaining PEM
+                                    entries are the certificate chain issued by the signer (typically,
+                                    signers will return their certificate chain in leaf-to-root order).
+
+                                    Prefer using the credential bundle format, since your application code
+                                    can read it atomically.  If you use keyPath and certificateChainPath,
+                                    your application must make two separate file reads. If these coincide
+                                    with a certificate rotation, it is possible that the private key and leaf
+                                    certificate you read may not correspond to each other.  Your application
+                                    will need to check for this condition, and re-read until they are
+                                    consistent.
+
+                                    The named signer controls chooses the format of the certificate it
+                                    issues; consult the signer implementation's documentation to learn how to
+                                    use the certificates it issues.
+                                  properties:
+                                    certificateChainPath:
+                                      description: |-
+                                        Write the certificate chain at this path in the projected volume.
+
+                                        Most applications should use credentialBundlePath.  When using keyPath
+                                        and certificateChainPath, your application needs to check that the key
+                                        and leaf certificate are consistent, because it is possible to read the
+                                        files mid-rotation.
+                                      type: string
+                                    credentialBundlePath:
+                                      description: |-
+                                        Write the credential bundle at this path in the projected volume.
+
+                                        The credential bundle is a single file that contains multiple PEM blocks.
+                                        The first PEM block is a PRIVATE KEY block, containing a PKCS#8 private
+                                        key.
+
+                                        The remaining blocks are CERTIFICATE blocks, containing the issued
+                                        certificate chain from the signer (leaf and any intermediates).
+
+                                        Using credentialBundlePath lets your Pod's application code make a single
+                                        atomic read that retrieves a consistent key and certificate chain.  If you
+                                        project them to separate files, your application code will need to
+                                        additionally check that the leaf certificate was issued to the key.
+                                      type: string
+                                    keyPath:
+                                      description: |-
+                                        Write the key at this path in the projected volume.
+
+                                        Most applications should use credentialBundlePath.  When using keyPath
+                                        and certificateChainPath, your application needs to check that the key
+                                        and leaf certificate are consistent, because it is possible to read the
+                                        files mid-rotation.
+                                      type: string
+                                    keyType:
+                                      description: |-
+                                        The type of keypair Kubelet will generate for the pod.
+
+                                        Valid values are "RSA3072", "RSA4096", "ECDSAP256", "ECDSAP384",
+                                        "ECDSAP521", and "ED25519".
+                                      type: string
+                                    maxExpirationSeconds:
+                                      description: |-
+                                        maxExpirationSeconds is the maximum lifetime permitted for the
+                                        certificate.
+
+                                        Kubelet copies this value verbatim into the PodCertificateRequests it
+                                        generates for this projection.
+
+                                        If omitted, kube-apiserver will set it to 86400(24 hours). kube-apiserver
+                                        will reject values shorter than 3600 (1 hour).  The maximum allowable
+                                        value is 7862400 (91 days).
+
+                                        The signer implementation is then free to issue a certificate with any
+                                        lifetime *shorter* than MaxExpirationSeconds, but no shorter than 3600
+                                        seconds (1 hour).  This constraint is enforced by kube-apiserver.
+                                        `kubernetes.io` signers will never issue certificates with a lifetime
+                                        longer than 24 hours.
+                                      format: int32
+                                      type: integer
+                                    signerName:
+                                      description: Kubelet's generated CSRs will be addressed to this signer.
+                                      type: string
+                                  required:
+                                    - keyType
+                                    - signerName
+                                  type: object
                                 secret:
                                   description: secret information about the secret data to project
                                   properties:
@@ -26727,7 +28663,6 @@ spec:
                         description: |-
                           rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
                           Deprecated: RBD is deprecated and the in-tree rbd type is no longer supported.
-                          More info: https://examples.k8s.io/volumes/rbd/README.md
                         properties:
                           fsType:
                             description: |-
@@ -27135,7 +29070,9 @@ spec:
                           description: EnvVar represents an environment variable present in a Container.
                           properties:
                             name:
-                              description: Name of the environment variable. Must be a C_IDENTIFIER.
+                              description: |-
+                                Name of the environment variable.
+                                May consist of any printable ASCII characters except '='.
                               type: string
                             value:
                               description: |-
@@ -27187,6 +29124,42 @@ spec:
                                       type: string
                                   required:
                                     - fieldPath
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                fileKeyRef:
+                                  description: |-
+                                    FileKeyRef selects a key of the env file.
+                                    Requires the EnvFiles feature gate to be enabled.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        The key within the env file. An invalid key will prevent the pod from starting.
+                                        The keys defined within a source may consist of any printable ASCII characters except '='.
+                                        During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                      type: string
+                                    optional:
+                                      default: false
+                                      description: |-
+                                        Specify whether the file or its key must be defined. If the file or key
+                                        does not exist, then the env var is not published.
+                                        If optional is set to true and the specified key does not exist,
+                                        the environment variable will not be set in the Pod's containers.
+
+                                        If optional is set to false and the specified key does not exist,
+                                        an error will be returned during Pod creation.
+                                      type: boolean
+                                    path:
+                                      description: |-
+                                        The path within the volume from which to select the file.
+                                        Must be relative and may not contain the '..' path or start with '..'.
+                                      type: string
+                                    volumeName:
+                                      description: The name of the volume mount containing the env file.
+                                      type: string
+                                  required:
+                                    - key
+                                    - path
+                                    - volumeName
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 resourceFieldRef:
@@ -27270,7 +29243,7 @@ spec:
                               Claims lists the names of resources, defined in spec.resourceClaims,
                               that are used by this container.
 
-                              This is an alpha field and requires enabling the
+                              This field depends on the
                               DynamicResourceAllocation feature gate.
 
                               This field is immutable. It can only be set for containers.
@@ -28231,15 +30204,13 @@ spec:
                                       volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
                                       If specified, the CSI driver will create or update the volume with the attributes defined
                                       in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                                      it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
-                                      will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
-                                      If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
-                                      will be set by the persistentvolume controller if it exists.
+                                      it can be changed after the claim is created. An empty string or nil value indicates that no
+                                      VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
+                                      this field can be reset to its previous value (including nil) to cancel the modification.
                                       If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
                                       set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
                                       exists.
                                       More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
-                                      (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).
                                     type: string
                                   volumeMode:
                                     description: |-
@@ -28413,12 +30384,9 @@ spec:
                         description: |-
                           glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
                           Deprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported.
-                          More info: https://examples.k8s.io/volumes/glusterfs/README.md
                         properties:
                           endpoints:
-                            description: |-
-                              endpoints is the endpoint name that details Glusterfs topology.
-                              More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+                            description: endpoints is the endpoint name that details Glusterfs topology.
                             type: string
                           path:
                             description: |-
@@ -28497,7 +30465,7 @@ spec:
                         description: |-
                           iscsi represents an ISCSI Disk resource that is attached to a
                           kubelet's host machine and then exposed to the pod.
-                          More info: https://examples.k8s.io/volumes/iscsi/README.md
+                          More info: https://kubernetes.io/docs/concepts/storage/volumes/#iscsi
                         properties:
                           chapAuthDiscovery:
                             description: chapAuthDiscovery defines whether support iSCSI Discovery CHAP authentication
@@ -28889,6 +30857,110 @@ spec:
                                       type: array
                                       x-kubernetes-list-type: atomic
                                   type: object
+                                podCertificate:
+                                  description: |-
+                                    Projects an auto-rotating credential bundle (private key and certificate
+                                    chain) that the pod can use either as a TLS client or server.
+
+                                    Kubelet generates a private key and uses it to send a
+                                    PodCertificateRequest to the named signer.  Once the signer approves the
+                                    request and issues a certificate chain, Kubelet writes the key and
+                                    certificate chain to the pod filesystem.  The pod does not start until
+                                    certificates have been issued for each podCertificate projected volume
+                                    source in its spec.
+
+                                    Kubelet will begin trying to rotate the certificate at the time indicated
+                                    by the signer using the PodCertificateRequest.Status.BeginRefreshAt
+                                    timestamp.
+
+                                    Kubelet can write a single file, indicated by the credentialBundlePath
+                                    field, or separate files, indicated by the keyPath and
+                                    certificateChainPath fields.
+
+                                    The credential bundle is a single file in PEM format.  The first PEM
+                                    entry is the private key (in PKCS#8 format), and the remaining PEM
+                                    entries are the certificate chain issued by the signer (typically,
+                                    signers will return their certificate chain in leaf-to-root order).
+
+                                    Prefer using the credential bundle format, since your application code
+                                    can read it atomically.  If you use keyPath and certificateChainPath,
+                                    your application must make two separate file reads. If these coincide
+                                    with a certificate rotation, it is possible that the private key and leaf
+                                    certificate you read may not correspond to each other.  Your application
+                                    will need to check for this condition, and re-read until they are
+                                    consistent.
+
+                                    The named signer controls chooses the format of the certificate it
+                                    issues; consult the signer implementation's documentation to learn how to
+                                    use the certificates it issues.
+                                  properties:
+                                    certificateChainPath:
+                                      description: |-
+                                        Write the certificate chain at this path in the projected volume.
+
+                                        Most applications should use credentialBundlePath.  When using keyPath
+                                        and certificateChainPath, your application needs to check that the key
+                                        and leaf certificate are consistent, because it is possible to read the
+                                        files mid-rotation.
+                                      type: string
+                                    credentialBundlePath:
+                                      description: |-
+                                        Write the credential bundle at this path in the projected volume.
+
+                                        The credential bundle is a single file that contains multiple PEM blocks.
+                                        The first PEM block is a PRIVATE KEY block, containing a PKCS#8 private
+                                        key.
+
+                                        The remaining blocks are CERTIFICATE blocks, containing the issued
+                                        certificate chain from the signer (leaf and any intermediates).
+
+                                        Using credentialBundlePath lets your Pod's application code make a single
+                                        atomic read that retrieves a consistent key and certificate chain.  If you
+                                        project them to separate files, your application code will need to
+                                        additionally check that the leaf certificate was issued to the key.
+                                      type: string
+                                    keyPath:
+                                      description: |-
+                                        Write the key at this path in the projected volume.
+
+                                        Most applications should use credentialBundlePath.  When using keyPath
+                                        and certificateChainPath, your application needs to check that the key
+                                        and leaf certificate are consistent, because it is possible to read the
+                                        files mid-rotation.
+                                      type: string
+                                    keyType:
+                                      description: |-
+                                        The type of keypair Kubelet will generate for the pod.
+
+                                        Valid values are "RSA3072", "RSA4096", "ECDSAP256", "ECDSAP384",
+                                        "ECDSAP521", and "ED25519".
+                                      type: string
+                                    maxExpirationSeconds:
+                                      description: |-
+                                        maxExpirationSeconds is the maximum lifetime permitted for the
+                                        certificate.
+
+                                        Kubelet copies this value verbatim into the PodCertificateRequests it
+                                        generates for this projection.
+
+                                        If omitted, kube-apiserver will set it to 86400(24 hours). kube-apiserver
+                                        will reject values shorter than 3600 (1 hour).  The maximum allowable
+                                        value is 7862400 (91 days).
+
+                                        The signer implementation is then free to issue a certificate with any
+                                        lifetime *shorter* than MaxExpirationSeconds, but no shorter than 3600
+                                        seconds (1 hour).  This constraint is enforced by kube-apiserver.
+                                        `kubernetes.io` signers will never issue certificates with a lifetime
+                                        longer than 24 hours.
+                                      format: int32
+                                      type: integer
+                                    signerName:
+                                      description: Kubelet's generated CSRs will be addressed to this signer.
+                                      type: string
+                                  required:
+                                    - keyType
+                                    - signerName
+                                  type: object
                                 secret:
                                   description: secret information about the secret data to project
                                   properties:
@@ -29018,7 +31090,6 @@ spec:
                         description: |-
                           rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
                           Deprecated: RBD is deprecated and the in-tree rbd type is no longer supported.
-                          More info: https://examples.k8s.io/volumes/rbd/README.md
                         properties:
                           fsType:
                             description: |-


### PR DESCRIPTION
The operator is compiled against shipwright-io/build v0.19.4 and shipwright-io/operator v0.19.0 (go.mod), but the bundled CRD and the deployed build manifests were still pinned to v0.18.0: the Makefile's SHIPWRIGHT_*_RELEASE variables were never bumped and `make upstream` was never re-run after the dependency upgrade.

Shipwright v0.19 is supposed to be in builds-1.8 according to https://redhat.atlassian.net/browse/BUILD-1710, but seems like the CRDs did not land in the 1.8.0 release.

Changed the upstream sources in the Makefile and ran `make upstream` and `make bundle`.

Also unsure about your cherry-picking practices, but we probably need to cherry-pick this back to `builds-1.8`