### PR TITLE
chore: bump VERSION to 1.7.4 for patch release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,4 +43,4 @@ LABEL \
     summary="Red Hat OpenShift Builds Operator" \
     url="https://github.com/redhat-openshift-builds/operator" \
     vendor="Red Hat, Inc." \
-    version="v1.7.3"
+    version="v1.7.4"

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 1.7.3
+VERSION ?= 1.7.4
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/bundle/manifests/openshift-builds-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/openshift-builds-operator.clusterserviceversion.yaml
@@ -36,7 +36,7 @@ metadata:
     categories: Developer Tools, Integration & Delivery
     certified: "true"
     containerImage: registry.redhat.io/openshift-builds/openshift-builds-operator-rhel9
-    createdAt: "2026-07-03T10:25:25Z"
+    createdAt: "2026-07-03T11:30:42Z"
     description: Builds for Red Hat OpenShift is a framework for building container images on Kubernetes.
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
@@ -61,7 +61,7 @@ metadata:
     operatorframework.io/arch.arm64: supported
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
-  name: openshift-builds-operator.v1.7.3
+  name: openshift-builds-operator.v1.7.4
   namespace: openshift-builds
 spec:
   apiservicedefinitions: {}
@@ -850,4 +850,4 @@ spec:
       name: OPENSHIFT_BUILDS_BUILDAH
     - image: registry.redhat.io/source-to-image/source-to-image-rhel9@sha256:70293cb8a80aa548933ff5f502bac89945a5cd08801c4ca3aac08a10dd01f62f
       name: OPENSHIFT_BUILDS_SOURCE_TO_IMAGE
-  version: 1.7.3
+  version: 1.7.4


### PR DESCRIPTION
bump VERSION to 1.7.4 in Makefile, Dockerfile and CSV for patch release
