### PR TITLE
[BUILD-2062] Update operator image labels to rhel10/el10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,14 +31,14 @@ ENTRYPOINT ["/operator"]
 
 LABEL \
     com.redhat.component="openshift-builds-operator" \
-    cpe="cpe:/a:redhat:openshift_builds:1.8::el9" \
+    cpe="cpe:/a:redhat:openshift_builds:1.8::el10" \
     description="Red Hat OpenShift Builds Operator" \
     distribution-scope="public" \
     io.k8s.description="Red Hat OpenShift Builds Operator" \
     io.k8s.display-name="Red Hat OpenShift Builds Operator" \
     io.openshift.tags="builds,operator" \
     maintainer="openshift-builds@redhat.com" \
-    name="openshift-builds/openshift-builds-rhel9-operator" \
+    name="openshift-builds/openshift-builds-rhel10-operator" \
     release="1" \
     summary="Red Hat OpenShift Builds Operator" \
     url="https://github.com/redhat-openshift-builds/operator" \

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -16,7 +16,7 @@ LABEL operators.operatorframework.io.test.config.v1=tests/scorecard/
 LABEL \
     com.redhat.openshift.versions="v4.16-v4.21" \
     com.redhat.component="openshift-builds-operator-bundle" \
-    cpe="cpe:/a:redhat:openshift_builds:1.8::el9" \
+    cpe="cpe:/a:redhat:openshift_builds:1.8::el10" \
     description="Red Hat OpenShift Builds Operator Bundle" \
     distribution-scope="public" \
     io.k8s.description="Red Hat OpenShift Builds Operator Bundle" \


### PR DESCRIPTION
Update Dockerfile and bundle.Dockerfile CPE and operator image name labels.