### PR TITLE
[BUILD-1578] feat: add no-cache parameter to buildah ClusterBuildStrategy

### DIFF
--- a/config/shipwright/build/strategy/buildah.yaml
+++ b/config/shipwright/build/strategy/buildah.yaml
@@ -24,8 +24,10 @@ spec:
           context=
           dockerfile=
           image=
+          runtimeStageFrom=
           budArgs=()
           inBuildArgs=false
+          noCache=false
           registriesBlock=""
           inRegistriesBlock=false
           registriesInsecure=""
@@ -66,6 +68,20 @@ spec:
               if [ "$1" != "" ]; then
                 budArgs+=(--target "$1")
               fi
+              shift
+            elif [ "${arg}" == "--runtime-stage-from" ]; then
+              inBuildArgs=false
+              inRegistriesBlock=false
+              inRegistriesInsecure=false
+              inRegistriesSearch=false
+              runtimeStageFrom="$1"
+              shift
+            elif [ "${arg}" == "--no-cache" ]; then
+              inBuildArgs=false
+              inRegistriesBlock=false
+              inRegistriesInsecure=false
+              inRegistriesSearch=false
+              noCache="$1"
               shift
             elif [ "${arg}" == "--build-args" ]; then
               inBuildArgs=true
@@ -146,6 +162,18 @@ spec:
           EOF
           fi
 
+          if [ -n "${runtimeStageFrom}" ]; then
+            lastFromImage=$(tac "${dockerfile}" | grep -m1 -i -E '^[ ]*FROM' | \
+              sed -n '0,/p/s/^[ ]*from[ ]\+\([^ ]*\)[ ]*\(as.*$\)\{0,1\}$/\1/Ip')
+            if [ -n "${lastFromImage}" ]; then
+              budArgs+=("--build-context" "${lastFromImage}=docker-image://${runtimeStageFrom}")
+            fi
+          fi
+
+          if [ "${noCache}" == "true" ]; then
+            budArgs+=("--no-cache")
+          fi
+
           # Building the image
           echo "[INFO] Building image ${image}"
           buildah --storage-driver=$(params.storage-driver) \
@@ -180,6 +208,10 @@ spec:
         - $(params.registries-search[*])
         - --target
         - $(params.target)
+        - --runtime-stage-from
+        - $(params.runtime-stage-from)
+        - --no-cache
+        - $(params.no-cache)
       volumeMounts:
         - mountPath: /etc/pki/entitlement
           name: etc-pki-entitlement
@@ -222,6 +254,14 @@ spec:
       description: "Sets the target stage to be built."
       type: string
       default: ""
+    - name: runtime-stage-from
+      description: "Image name used to replace the value in the last FROM instruction in the Dockerfile."
+      type: string
+      default: ""
+    - name: no-cache
+      description: "Do not use existing cached images for the container build. Build from the start with a new set of cached layers."
+      type: string
+      default: "false"
   volumes:
     - name: etc-pki-entitlement
       emptyDir: {}

--- a/config/shipwright/build/strategy/buildah.yaml
+++ b/config/shipwright/build/strategy/buildah.yaml
@@ -27,7 +27,7 @@ spec:
           runtimeStageFrom=
           budArgs=()
           inBuildArgs=false
-          noCache=false
+          noCache="false"
           registriesBlock=""
           inRegistriesBlock=false
           registriesInsecure=""

--- a/config/shipwright/build/strategy/buildah.yaml
+++ b/config/shipwright/build/strategy/buildah.yaml
@@ -24,7 +24,6 @@ spec:
           context=
           dockerfile=
           image=
-          runtimeStageFrom=
           budArgs=()
           inBuildArgs=false
           noCache="false"
@@ -68,13 +67,6 @@ spec:
               if [ "$1" != "" ]; then
                 budArgs+=(--target "$1")
               fi
-              shift
-            elif [ "${arg}" == "--runtime-stage-from" ]; then
-              inBuildArgs=false
-              inRegistriesBlock=false
-              inRegistriesInsecure=false
-              inRegistriesSearch=false
-              runtimeStageFrom="$1"
               shift
             elif [ "${arg}" == "--no-cache" ]; then
               inBuildArgs=false
@@ -162,14 +154,6 @@ spec:
           EOF
           fi
 
-          if [ -n "${runtimeStageFrom}" ]; then
-            lastFromImage=$(tac "${dockerfile}" | grep -m1 -i -E '^[ ]*FROM' | \
-              sed -n '0,/p/s/^[ ]*from[ ]\+\([^ ]*\)[ ]*\(as.*$\)\{0,1\}$/\1/Ip')
-            if [ -n "${lastFromImage}" ]; then
-              budArgs+=("--build-context" "${lastFromImage}=docker-image://${runtimeStageFrom}")
-            fi
-          fi
-
           if [ "${noCache}" == "true" ]; then
             budArgs+=("--no-cache")
           fi
@@ -208,8 +192,6 @@ spec:
         - $(params.registries-search[*])
         - --target
         - $(params.target)
-        - --runtime-stage-from
-        - $(params.runtime-stage-from)
         - --no-cache
         - $(params.no-cache)
       volumeMounts:
@@ -252,10 +234,6 @@ spec:
       # For details see the "--storage-driver" section of https://github.com/containers/buildah/blob/main/docs/buildah.1.md#options
     - name: target
       description: "Sets the target stage to be built."
-      type: string
-      default: ""
-    - name: runtime-stage-from
-      description: "Image name used to replace the value in the last FROM instruction in the Dockerfile."
       type: string
       default: ""
     - name: no-cache


### PR DESCRIPTION
## Summary
- Add `no-cache` strategy parameter to the downstream Buildah
  ClusterBuildStrategy
- When set to `"true"`, passes `--no-cache` to `buildah bud` to disable
  intermediate layer caching

## Context
Resolves [BUILD-1578](https://issues.redhat.com/browse/BUILD-1578). The
`no-cache` parameter enables migration parity for OpenShift BuildConfigs
that use `DockerStrategy.NoCache: true`. The crane migration tool maps
this BuildConfig field to the new strategy parameter.

## Changes
- `config/shipwright/build/strategy/buildah.yaml`: Add `no-cache` parameter
  (string, default `"false"`) and shell script logic to pass `--no-cache`
  to `buildah bud` when value is `"true"`

## Test plan
- [x] Cluster test on OpenShift 4.20.0-nightly: parameter accepted by
  strategy without errors, BuildRun completed successfully
- [x] Verified no regression on builds without the parameter set

## Companion PR
- crane-lib repo: `NoCache` field mapping in conversion logic
  (https://github.com/migtools/crane-lib/pull/142)

Co-authored-by: Claude Code