### PR TITLE
feat: onboard repository to Codecov for unit test coverage

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,34 @@
+codecov:
+  require_ci_to_pass: yes
+
+coverage:
+  precision: 2
+  round: down
+  range: "50...100"
+
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        target: auto
+        threshold: 1%
+
+ignore:
+  - "vendor/**"
+  - "**/zz_generated*.go"
+  - "test/**"
+  - "hack/**"
+  - "config/**"
+  - "bundle/**"
+  - "docs/**"
+
+flags:
+  unit-tests:
+    carryforward: true
+
+comment:
+  layout: "reach,diff,flags,files"
+  behavior: default

--- a/.tekton/openshift-builds-operator-pull-request.yaml
+++ b/.tekton/openshift-builds-operator-pull-request.yaml
@@ -58,9 +58,15 @@ spec:
   - name: unit-test-command
     value: make test
   - name: unit-test-revision
-    value: "62314daa6fddc49f2b92bbdc06864eaba4b36c69"
+    value: "101e48ca34e5d0d2353735b6261da82236af1e92"
   - name: enable-sealights
     value: "false"
+  - name: upload-codecov
+    value: "true"
+  - name: codecov-token-secret
+    value: codecov-token
+  - name: codecov-flags
+    value: unit-tests
   pipelineRef:
     params:
     - name: url

--- a/.tekton/openshift-builds-operator-push.yaml
+++ b/.tekton/openshift-builds-operator-push.yaml
@@ -42,6 +42,18 @@ spec:
     - linux/s390x
   - name: prefetch-input
     value: '{"packages": [{"type": "gomod"}]}'
+  - name: run-unit-test
+    value: "true"
+  - name: unit-test-command
+    value: make test
+  - name: unit-test-revision
+    value: "101e48ca34e5d0d2353735b6261da82236af1e92"
+  - name: upload-codecov
+    value: "true"
+  - name: codecov-token-secret
+    value: codecov-token
+  - name: codecov-flags
+    value: unit-tests
   pipelineRef:
     params:
     - name: url


### PR DESCRIPTION
Add .codecov.yml with coverage status checks, ignore patterns for generated/vendored files, and unit-tests flag with carryforward. Update Tekton PipelineRun configs to pass Codecov upload params (upload-codecov, codecov-token-secret, codecov-flags). Enable unit tests on push pipeline to establish main branch coverage baseline.

Requires corresponding changes in redhat-openshift-builds/release to add coverage upload step to the unit-test task and pipeline params.

Co-Authored-By: Claude Code