### PR TITLE
[BUILD-1746] feat: add runtime-stage-from parameter to buildah ClusterBuildStrategy

### DIFF
--- a/config/shipwright/build/strategy/buildah.yaml
+++ b/config/shipwright/build/strategy/buildah.yaml
@@ -24,6 +24,7 @@ spec:
           context=
           dockerfile=
           image=
+          runtimeStageFrom=
           budArgs=()
           inBuildArgs=false
           noCache="false"
@@ -74,6 +75,13 @@ spec:
               inRegistriesInsecure=false
               inRegistriesSearch=false
               noCache="$1"
+              shift
+            elif [ "${arg}" == "--runtime-stage-from" ]; then
+              inBuildArgs=false
+              inRegistriesBlock=false
+              inRegistriesInsecure=false
+              inRegistriesSearch=false
+              runtimeStageFrom="$1"
               shift
             elif [ "${arg}" == "--build-args" ]; then
               inBuildArgs=true
@@ -158,6 +166,14 @@ spec:
             budArgs+=("--no-cache")
           fi
 
+          if [ -n "${runtimeStageFrom}" ]; then
+            lastFromImage=$(tac "${dockerfile}" | grep -m1 -i -E '^[ ]*FROM' | \
+              sed -n '0,/p/s/^[ ]*from[ ]\+\([^ ]*\)[ ]*\(as.*$\)\{0,1\}$/\1/Ip')
+            if [ -n "${lastFromImage}" ]; then
+              budArgs+=("--build-context" "${lastFromImage}=docker-image://${runtimeStageFrom}")
+            fi
+          fi
+
           # Building the image
           echo "[INFO] Building image ${image}"
           buildah --storage-driver=$(params.storage-driver) \
@@ -194,6 +210,8 @@ spec:
         - $(params.target)
         - --no-cache
         - $(params.no-cache)
+        - --runtime-stage-from
+        - $(params.runtime-stage-from)
       volumeMounts:
         - mountPath: /etc/pki/entitlement
           name: etc-pki-entitlement
@@ -223,6 +241,10 @@ spec:
       defaults:
         - registry.redhat.io
         - quay.io
+    - name: runtime-stage-from
+      description: "Image name used to replace the value in the last FROM instruction in the Dockerfile."
+      type: string
+      default: ""
     - name: dockerfile
       description: The path to the Dockerfile to be used for building the image.
       type: string


### PR DESCRIPTION
## Summary
- Adds `runtime-stage-from` string parameter to the downstream buildah ClusterBuildStrategy
- Enables replacing the last FROM instruction in multi-stage Dockerfiles with a user-specified image
- Uses buildah's `--build-context` mechanism to override the runtime stage base image
- Supports BuildConfig migration parity for `Spec.Strategy.DockerStrategy.From` field

## Implementation
- New parameter `runtime-stage-from` (string, default: "")
- Shell parsing added to the strategy script: extracts the last FROM image via `tac | grep | sed`, then injects `--build-context <original>=docker-image://<replacement>`
- Pattern copied from upstream multiarch-native-buildah strategy

## Test plan
- [x] Deploy as `buildah-custom` strategy on OpenShift 4.20.0 nightly
- [x] Control build (no param) — PASS, 38.8MB image
- [x] Override build (`runtime-stage-from: ubi-micro`) — PASS, 6.9MB image
- [x] True multi-stage build (different bases) — PASS, only last FROM replaced
- [x] Full e2e: BuildConfig → crane convert → Shipwright Build → BuildRun — PASS

## Related
- crane-lib PR: (pending, maps `DockerStrategy.From` to this param)
- Jira: https://issues.redhat.com/browse/BUILD-1746

🤖 Generated with [Claude Code](https://claude.com/claude-code)