### PR TITLE
[BUILD-1581] feat(strategy): add squash parameter to buildah ClusterBuildStrategy

### DIFF
--- a/config/shipwright/build/strategy/buildah.yaml
+++ b/config/shipwright/build/strategy/buildah.yaml
@@ -28,6 +28,7 @@ spec:
           budArgs=()
           inBuildArgs=false
           noCache="false"
+          squash="false"
           registriesBlock=""
           inRegistriesBlock=false
           registriesInsecure=""
@@ -75,6 +76,13 @@ spec:
               inRegistriesInsecure=false
               inRegistriesSearch=false
               noCache="$1"
+              shift
+            elif [ "${arg}" == "--squash" ]; then
+              inBuildArgs=false
+              inRegistriesBlock=false
+              inRegistriesInsecure=false
+              inRegistriesSearch=false
+              squash="$1"
               shift
             elif [ "${arg}" == "--runtime-stage-from" ]; then
               inBuildArgs=false
@@ -166,6 +174,10 @@ spec:
             budArgs+=("--no-cache")
           fi
 
+          if [ "${squash}" == "true" ]; then
+            budArgs+=("--squash")
+          fi
+
           if [ -n "${runtimeStageFrom}" ]; then
             lastFromImage=$(tac "${dockerfile}" | grep -m1 -i -E '^[ ]*FROM' | \
               sed -n '0,/p/s/^[ ]*from[ ]\+\([^ ]*\)[ ]*\(as.*$\)\{0,1\}$/\1/Ip')
@@ -210,6 +222,8 @@ spec:
         - $(params.target)
         - --no-cache
         - $(params.no-cache)
+        - --squash
+        - $(params.squash)
         - --runtime-stage-from
         - $(params.runtime-stage-from)
       volumeMounts:
@@ -260,6 +274,10 @@ spec:
       default: ""
     - name: no-cache
       description: "Do not use existing cached images for the container build. Build from the start with a new set of cached layers."
+      type: string
+      default: "false"
+    - name: squash
+      description: "Squash all new layers into a single new layer. The value of --squash passed to buildah bud."
       type: string
       default: "false"
   volumes:


### PR DESCRIPTION
## Summary
- Add `squash` parameter to the buildah ClusterBuildStrategy (default: `"false"`)
- When set to `"true"`, passes `--squash` to `buildah bud` to squash all new layers into a single layer
- Enables migration parity for BuildConfigs with `DockerStrategy.ImageOptimizationPolicy: SkipLayers`

## Test plan
- [x] Unit tests: 81/81 PASS (crane-lib)
- [x] Cluster test: Strategy validation on OpenShift 4.20.0-0.nightly — control build vs squash build both completed successfully
- [x] Cluster test: Full e2e crane conversion pipeline verified — BuildConfig with imageOptimizationPolicy:SkipLayers correctly generates Build with squash=true param

## Dependencies
- crane-lib PR: https://github.com/migtools/crane-lib/pull/146

## Related
- Jira: https://issues.redhat.com/browse/BUILD-1581

🤖 Generated with [Claude Code](https://claude.com/claude-code)