### PR TITLE
[BUILD-1606] feat: add pull-policy parameter to S2I ClusterBuildStrategy

### DIFF
--- a/config/shipwright/build/strategy/source-to-image.yaml
+++ b/config/shipwright/build/strategy/source-to-image.yaml
@@ -22,6 +22,7 @@ spec:
         - $(build.builder.image)
         - $(params.shp-output-image)
         - --as-dockerfile=/s2i/Dockerfile
+        - --pull-policy=$(params.pull-policy)
       volumeMounts:
         - name: s2i
           mountPath: /s2i
@@ -156,6 +157,10 @@ spec:
       defaults:
         - registry.redhat.io
         - quay.io
+    - name: pull-policy
+      description: "Pull policy for the builder image. Valid values: always, never, if-not-present."
+      type: string
+      default: "if-not-present"
     - name: storage-driver
       description: "The storage driver to use, such as 'overlay' or 'vfs'."
       type: string


### PR DESCRIPTION
## Summary
- Adds a `pull-policy` parameter (type string, default `"if-not-present"`) to the `source-to-image` ClusterBuildStrategy
- Wires `--pull-policy=$(params.pull-policy)` into the build step so callers can force builder-image pulls
- Valid values: `always`, `never`, `if-not-present`; default preserves current behavior when the param is absent

## Test plan
- [x] Cluster e2e (2026-07-28): converted Build with `pull-policy=always` ran via the strategy; BuildRun `test-conversion-run-1` Succeeded on OpenShift

## Dependencies
- crane-lib PR: https://github.com/migtools/crane-lib/pull/148 — maps BuildConfig `ForcePull` to this parameter; this PR must merge first

## Related
- Jira: https://issues.redhat.com/browse/BUILD-1606

🤖 Generated with [Claude Code](https://claude.com/claude-code)