### PR TITLE
[BUILD-1607] feat: add incremental parameter to source-to-image ClusterBuildStrategy

### DIFF
--- a/config/shipwright/build/strategy/source-to-image.yaml
+++ b/config/shipwright/build/strategy/source-to-image.yaml
@@ -22,6 +22,7 @@ spec:
         - $(build.builder.image)
         - $(params.shp-output-image)
         - --as-dockerfile=/s2i/Dockerfile
+        - --incremental=$(params.incremental)
       volumeMounts:
         - name: s2i
           mountPath: /s2i
@@ -156,6 +157,11 @@ spec:
       defaults:
         - registry.redhat.io
         - quay.io
+    - name: incremental
+      description: "Perform an incremental build by reusing artifacts from a previously built image. Set to 'true' to enable. Maps to BuildConfig spec.strategy.sourceStrategy.incremental."
+      type: string
+      default: "false"
+      # For details see the "--incremental" section of https://github.com/openshift/source-to-image/blob/master/docs/cli.md
     - name: storage-driver
       description: "The storage driver to use, such as 'overlay' or 'vfs'."
       type: string


### PR DESCRIPTION
## Summary
- Adds an `incremental` parameter (type string, default `"false"`) to the `source-to-image` ClusterBuildStrategy
- Wires `--incremental=$(params.incremental)` into the build step so callers can enable incremental S2I builds (reusing artifacts from a previously built image)
- Default `"false"` preserves current behavior when the param is absent

## Test plan
- [x] Cluster e2e (2026-07-27): converted Build with `incremental=true` ran via the strategy; BuildRun on `test-incremental-build-1607` Succeeded on OpenShift, incremental artifact reuse verified via cached Dockerfile stage

## Dependencies
- crane-lib PR: https://github.com/migtools/crane-lib/pull/149 — maps BuildConfig `spec.strategy.sourceStrategy.incremental` to this parameter; this operator PR must merge first

## Related
- Jira: https://issues.redhat.com/browse/BUILD-1607

Co-authored-by: Claude Code <noreply@anthropic.com>