### PR TITLE
[BUILD-1641] feat: add scripts-url param to source-to-image strategy

### DIFF
--- a/config/shipwright/build/strategy/source-to-image.yaml
+++ b/config/shipwright/build/strategy/source-to-image.yaml
@@ -22,6 +22,7 @@ spec:
         - $(build.builder.image)
         - $(params.shp-output-image)
         - --as-dockerfile=/s2i/Dockerfile
+        - --scripts-url=$(params.scripts-url)
       volumeMounts:
         - name: s2i
           mountPath: /s2i
@@ -156,6 +157,11 @@ spec:
       defaults:
         - registry.redhat.io
         - quay.io
+    - name: scripts-url
+      description: "URL of custom S2I scripts, overriding the builder image's default scripts. Empty means use the builder image defaults. Maps to BuildConfig spec.strategy.sourceStrategy.scripts."
+      type: string
+      default: ""
+      # For details see the "--scripts-url" section of https://github.com/openshift/source-to-image/blob/master/docs/cli.md
     - name: storage-driver
       description: "The storage driver to use, such as 'overlay' or 'vfs'."
       type: string


### PR DESCRIPTION
## Summary
- Adds a `scripts-url` string parameter (default `""`) to the `source-to-image` ClusterBuildStrategy
- Passes `--scripts-url=$(params.scripts-url)` to the `s2i-generate` step, mirroring the BUILD-1607 `incremental` param pattern
- Empty default is a verified no-op: s2i's CLI default for `ScriptsURL` is already `""` and behavior is gated on `len(config.ScriptsURL) > 0`, so an unset param is byte-identical to omitting the flag

## Test plan
- [x] Unit tests (crane-lib convert suite consuming this param): 87/87 PASS
- [x] Static verification against `openshift/source-to-image` master: empty `--scripts-url=` accepted by CLI, no validation rejects it, scripts fall back to `--image-scripts-url` default `image:///usr/libexec/s2i`
- [x] Full results: designs/test-results/BUILD-1641-results.md

## Dependencies
This PR must merge first. crane-lib PR: https://github.com/migtools/crane-lib/pull/150

## Related
- Jira: https://issues.redhat.com/browse/BUILD-1641

🤖 Generated with [Claude Code](https://claude.com/claude-code)
